### PR TITLE
refactor(cli): use PathBuf instead of String for config path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ name = "basilica-validator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum 0.7.9",
  "base64 0.21.7",

--- a/crates/basilica-executor/src/cli/args.rs
+++ b/crates/basilica-executor/src/cli/args.rs
@@ -9,6 +9,7 @@ use super::Commands;
 use anyhow::Result;
 use clap::Parser;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 /// Main application arguments
 #[derive(Parser, Debug)]
@@ -16,7 +17,7 @@ use std::net::SocketAddr;
 pub struct ExecutorArgs {
     /// Configuration file path
     #[arg(short, long, default_value = "executor.toml")]
-    pub config: String,
+    pub config: PathBuf,
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(short, long, default_value = "info")]
@@ -105,7 +106,7 @@ pub enum ApplicationMode {
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub log_level: String,
-    pub config_path: String,
+    pub config_path: PathBuf,
     pub metrics_enabled: bool,
     pub metrics_addr: SocketAddr,
 }
@@ -113,14 +114,14 @@ pub struct ServerConfig {
 /// CLI mode configuration
 #[derive(Debug, Clone)]
 pub struct CliConfig {
-    pub config_path: String,
+    pub config_path: PathBuf,
     pub command: Option<Commands>,
 }
 
 /// Configuration generation settings
 #[derive(Debug, Clone)]
 pub struct ConfigGenConfig {
-    pub output_path: String,
+    pub output_path: PathBuf,
 }
 
 /// Application configuration resolver
@@ -186,7 +187,7 @@ impl AppConfig {
     }
 
     /// Get config file path if applicable
-    pub fn config_path(&self) -> Option<&str> {
+    pub fn config_path(&self) -> Option<&PathBuf> {
         match self {
             AppConfig::Server(config) => Some(&config.config_path),
             AppConfig::Cli(config) => Some(&config.config_path),
@@ -203,7 +204,7 @@ mod tests {
     #[test]
     fn test_application_mode_detection() {
         let args = ExecutorArgs {
-            config: "test.toml".to_string(),
+            config: "test.toml".into(),
             log_level: "debug".to_string(),
             metrics: false,
             metrics_addr: "127.0.0.1:9090".parse().unwrap(),
@@ -227,7 +228,7 @@ mod tests {
     #[test]
     fn test_config_resolution() {
         let args = ExecutorArgs {
-            config: "test.toml".to_string(),
+            config: "test.toml".into(),
             log_level: "debug".to_string(),
             metrics: true,
             metrics_addr: "127.0.0.1:9090".parse().unwrap(),

--- a/crates/basilica-executor/src/main.rs
+++ b/crates/basilica-executor/src/main.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use tokio::signal;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -37,13 +38,19 @@ async fn run_app(config: AppConfig) -> Result<()> {
 async fn run_config_generation(
     config: basilica_executor::cli::args::ConfigGenConfig,
 ) -> Result<()> {
-    info!("Generating configuration file: {}", config.output_path);
+    info!(
+        "Generating configuration file: {}",
+        config.output_path.display()
+    );
 
     let executor_config = ExecutorConfig::default();
     let toml_content = toml::to_string_pretty(&executor_config)?;
     std::fs::write(&config.output_path, toml_content)?;
 
-    println!("Generated configuration file: {}", config.output_path);
+    println!(
+        "Generated configuration file: {}",
+        config.output_path.display()
+    );
     Ok(())
 }
 
@@ -51,7 +58,10 @@ async fn run_server_mode(config: basilica_executor::cli::args::ServerConfig) -> 
     init_logging(&config.log_level)?;
 
     let executor_config = load_config(&config.config_path)?;
-    info!("Loaded configuration from: {}", config.config_path);
+    info!(
+        "Loaded configuration from: {}",
+        config.config_path.display()
+    );
 
     if config.metrics_enabled {
         init_metrics(config.metrics_addr).await?;
@@ -141,7 +151,7 @@ async fn run_cli_mode(config: basilica_executor::cli::args::CliConfig) -> Result
     init_logging("info")?;
 
     if let Some(command) = config.command {
-        let context = CliContext::new(config.config_path);
+        let context = CliContext::new(config.config_path.to_string_lossy().to_string());
         execute_command(command, &context).await
     } else {
         eprintln!("No command provided. Use --help for available commands or --server to start server mode.");
@@ -172,12 +182,9 @@ fn init_logging(level: &str) -> Result<()> {
     Ok(())
 }
 
-fn load_config(config_path: &str) -> Result<ExecutorConfig> {
-    use std::path::PathBuf;
-
-    let path = PathBuf::from(config_path);
+fn load_config(path: &PathBuf) -> Result<ExecutorConfig> {
     let config = if path.exists() {
-        ExecutorConfig::load_from_file(&path)?
+        ExecutorConfig::load_from_file(path)?
     } else {
         ExecutorConfig::load()?
     };

--- a/crates/basilica-miner/src/cli/args.rs
+++ b/crates/basilica-miner/src/cli/args.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use super::Commands;
 use clap::Parser;
@@ -8,7 +9,7 @@ use clap::Parser;
 pub struct Args {
     /// Configuration file path
     #[arg(short, long, default_value = "miner.toml")]
-    pub config: String,
+    pub config: PathBuf,
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(short, long, default_value = "info")]

--- a/crates/basilica-miner/src/main.rs
+++ b/crates/basilica-miner/src/main.rs
@@ -6,9 +6,8 @@
 use anyhow::{Context, Result};
 use basilica_common::identity::MinerUid;
 use clap::Parser;
-use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
+use std::{path::PathBuf, sync::Arc};
 use tokio::signal;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
@@ -384,7 +383,7 @@ async fn main() -> Result<()> {
         let config = MinerConfig::default();
         let toml_content = toml::to_string_pretty(&config)?;
         std::fs::write(&args.config, toml_content)?;
-        println!("Generated configuration file: {}", args.config);
+        println!("Generated configuration file: {}", args.config.display());
         return Ok(());
     }
 
@@ -393,7 +392,7 @@ async fn main() -> Result<()> {
 
     // Load configuration
     let config = load_config(&args.config)?;
-    info!("Loaded configuration from: {}", args.config);
+    info!("Loaded configuration from: {}", args.config.display());
 
     // Handle CLI commands if provided
     if let Some(command) = args.command {
@@ -561,12 +560,12 @@ fn init_logging(level: &str) -> Result<()> {
 }
 
 /// Load configuration from file and environment
-fn load_config(config_path: &str) -> Result<MinerConfig> {
+fn load_config(config_path: &PathBuf) -> Result<MinerConfig> {
     use basilica_common::config::ConfigValidation;
 
-    let path = PathBuf::from(config_path);
+    let path = config_path;
     let config = if path.exists() {
-        MinerConfig::load_from_file(&path)?
+        MinerConfig::load_from_file(path)?
     } else {
         MinerConfig::load()?
     };

--- a/crates/basilica-validator/src/cli/args.rs
+++ b/crates/basilica-validator/src/cli/args.rs
@@ -13,8 +13,8 @@ pub struct Args {
     #[command(subcommand)]
     pub command: Command,
 
-    #[arg(short, long, global = true)]
-    pub config: Option<PathBuf>,
+    #[arg(short, long, global = true, default_value = "validator.toml")]
+    pub config: PathBuf,
 
     #[arg(short, long, global = true)]
     pub verbose: bool,
@@ -29,11 +29,9 @@ pub struct Args {
 impl Args {
     pub async fn run(self) -> anyhow::Result<()> {
         match self.command {
-            Command::Start { config } => {
-                service::handle_start(self.config.or(config), self.local_test).await
-            }
+            Command::Start => service::handle_start(self.config, self.local_test).await,
             Command::Stop => service::handle_stop().await,
-            Command::Status => service::handle_status().await,
+            Command::Status => service::handle_status(self.config).await,
             Command::GenConfig { output } => service::handle_gen_config(output).await,
 
             // Validation commands removed with HardwareValidator
@@ -54,11 +52,8 @@ impl Args {
             Command::Database { action } => database::handle_database(action).await,
 
             Command::Rental { action } => {
-                let config = if let Some(config_path) = self.config {
-                    crate::config::ValidatorConfig::load_from_file(&config_path)?
-                } else {
-                    return Err(anyhow::anyhow!("Configuration required for rental commands"));
-                };
+                // TODO: for now can we use HandlerUtils::load_config to be consistent with other commands
+                let config = crate::config::ValidatorConfig::load_from_file(&self.config)?;
 
                 let bittensor_service = bittensor::Service::new(config.bittensor.common.clone()).await?;
                 let account_id = bittensor_service.get_account_id();

--- a/crates/basilica-validator/src/cli/commands.rs
+++ b/crates/basilica-validator/src/cli/commands.rs
@@ -3,10 +3,7 @@ use std::path::PathBuf;
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Command {
-    Start {
-        #[arg(long)]
-        config: Option<PathBuf>,
-    },
+    Start,
 
     Stop,
 

--- a/crates/basilica-validator/src/cli/handlers/mod.rs
+++ b/crates/basilica-validator/src/cli/handlers/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::config::ValidatorConfig;
 use anyhow::Result;
 use basilica_common::config::ConfigValidation;
@@ -9,26 +11,25 @@ pub mod service;
 pub struct HandlerUtils;
 
 impl HandlerUtils {
-    pub fn load_config(config_path: Option<&str>) -> Result<ValidatorConfig> {
-        match config_path {
-            Some(path) if std::path::Path::new(path).exists() => {
-                tracing::info!("Loading configuration from: {}", path);
-                let config = ValidatorConfig::load_from_file(std::path::Path::new(path))?;
-                tracing::info!(
-                    "Configuration loaded: burn_uid={}, burn_percentage={:.2}%, weight_interval_blocks={}, netuid={}, network={}",
-                    config.emission.burn_uid,
-                    config.emission.burn_percentage,
-                    config.emission.weight_set_interval_blocks,
-                    config.bittensor.common.netuid,
-                    config.bittensor.common.network
-                );
-                Ok(config)
-            }
-            Some(path) => Err(anyhow::anyhow!("Configuration file not found: {}", path)),
-            None => Err(anyhow::anyhow!(
-                "Configuration file path is required for validator operation"
-            )),
+    pub fn load_config(config_path: PathBuf) -> Result<ValidatorConfig> {
+        if !config_path.exists() {
+            return Err(anyhow::anyhow!(
+                "Configuration file not found: {}",
+                config_path.display()
+            ));
         }
+
+        tracing::info!("Loading configuration from: {}", config_path.display());
+        let config = ValidatorConfig::load_from_file(config_path.as_path())?;
+        tracing::info!(
+            "Configuration loaded: burn_uid={}, burn_percentage={:.2}%, weight_interval_blocks={}, netuid={}, network={}",
+            config.emission.burn_uid,
+            config.emission.burn_percentage,
+            config.emission.weight_set_interval_blocks,
+            config.bittensor.common.netuid,
+            config.bittensor.common.network
+        );
+        Ok(config)
     }
 
     pub fn validate_config(config: &ValidatorConfig) -> Result<()> {

--- a/crates/basilica-validator/src/config/main_config.rs
+++ b/crates/basilica-validator/src/config/main_config.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use basilica_common::config::{
@@ -545,7 +545,7 @@ impl ValidatorConfig {
     }
 
     /// Load configuration from specific file
-    pub fn load_from_file(path: &std::path::Path) -> Result<Self> {
+    pub fn load_from_file(path: &Path) -> Result<Self> {
         Ok(loader::load_from_file::<Self>(path)?)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of configuration file paths across the application by switching from string-based paths to a dedicated path type, resulting in more robust and consistent file path management.
  * Simplified command-line argument structures and related logic for configuration file usage, reducing ambiguity and potential errors.
  * Enhanced logging and output formatting for file paths to provide clearer information to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->