### PR TITLE
feat(cli): simplify GPU display format in compact mode

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -95,7 +95,7 @@ pub async fn handle_ls(
         available: Some(true), // Filter for available executors only
         min_gpu_memory: filters.memory_min,
         gpu_type: filters.gpu_type,
-        min_gpu_count: filters.gpu_min,
+        min_gpu_count: Some(filters.gpu_min.unwrap_or(1)),
     };
 
     let spinner = create_spinner("Scanning global GPU availability...");

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -144,15 +144,25 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], detailed: bool) -> Re
                         GpuCategory::from_str(&first_gpu.name).unwrap().to_string()
                     };
 
-                    if rental.gpu_specs.len() > 1 {
-                        format!(
-                            "{}x {} ({}GB)",
-                            rental.gpu_specs.len(),
-                            gpu_display_name,
-                            first_gpu.memory_gb
-                        )
+                    if detailed {
+                        // Detailed mode: show memory
+                        if rental.gpu_specs.len() > 1 {
+                            format!(
+                                "{}x {} ({}GB)",
+                                rental.gpu_specs.len(),
+                                gpu_display_name,
+                                first_gpu.memory_gb
+                            )
+                        } else {
+                            format!("1x {} ({}GB)", gpu_display_name, first_gpu.memory_gb)
+                        }
                     } else {
-                        format!("1x {} ({}GB)", gpu_display_name, first_gpu.memory_gb)
+                        // Non-detailed mode: no memory
+                        if rental.gpu_specs.len() > 1 {
+                            format!("{}x {}", rental.gpu_specs.len(), gpu_display_name)
+                        } else {
+                            format!("1x {}", gpu_display_name)
+                        }
                     }
                 } else {
                     // List each GPU
@@ -165,7 +175,11 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], detailed: bool) -> Re
                             } else {
                                 GpuCategory::from_str(&g.name).unwrap().to_string()
                             };
-                            format!("{} ({}GB)", display_name, g.memory_gb)
+                            if detailed {
+                                format!("{} ({}GB)", display_name, g.memory_gb)
+                            } else {
+                                display_name
+                            }
                         })
                         .collect::<Vec<_>>()
                         .join(", ")
@@ -244,7 +258,7 @@ pub fn display_available_executors_compact(executors: &[AvailableExecutor]) -> R
             let gpu = &executor.executor.gpu_specs[0];
             let category = GpuCategory::from_str(&gpu.name).unwrap();
             let gpu_count = executor.executor.gpu_specs.len();
-            format!("{}x {} ({}GB)", gpu_count, category, gpu.memory_gb)
+            format!("{}x {}", gpu_count, category)
         };
 
         location_groups


### PR DESCRIPTION
## Summary
Simplifies the GPU display format in the CLI by removing memory information from compact mode and only showing it in detailed mode. This makes the output cleaner and more readable for quick scans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “detailed” display mode that shows GPU memory; non-detailed mode hides memory for cleaner lists.

- Style
  - Simplified grouped and compact labels by removing the “GB” suffix from GPU keys and summaries.
  - Updated rental list formatting to consistently reflect detailed vs. non-detailed views (e.g., “2x GPUName” vs. “2x GPUName (16GB)”).

- Bug Fixes
  - Listing available executors now defaults to a minimum of 1 GPU when no filter is provided, improving result consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->