### PR TITLE
feat(resources): treat zero as unbounded for resource requirements

### DIFF
--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -252,6 +252,10 @@ pub struct UpOptions {
     #[arg(long)]
     pub memory_mb: Option<i64>,
 
+    /// Storage in MB
+    #[arg(long)]
+    pub storage_mb: Option<i64>,
+
     /// Command to run
     #[arg(long)]
     pub command: Vec<String>,

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -100,7 +100,7 @@ pub async fn handle_ls(
         available: Some(true), // Filter for available executors only
         min_gpu_memory: filters.memory_min,
         gpu_type,
-        min_gpu_count: Some(filters.gpu_min.unwrap_or(1)),
+        min_gpu_count: Some(filters.gpu_min.unwrap_or(0)),
         location: filters.country.map(|country| LocationProfile {
             city: None,
             region: None,
@@ -166,7 +166,7 @@ pub async fn handle_up(
                     gpu_requirements: GpuRequirements {
                         min_memory_gb: 0, // Default, no minimum memory requirement
                         gpu_type: Some(gpu_category.as_str()),
-                        gpu_count: options.gpu_min.unwrap_or(1),
+                        gpu_count: options.gpu_min.unwrap_or(0),
                     },
                 }
             }
@@ -246,10 +246,10 @@ pub async fn handle_up(
         environment: env_vars,
         ports: port_mappings,
         resources: ResourceRequirementsRequest {
-            cpu_cores: options.cpu_cores.unwrap_or(1.0),
-            memory_mb: options.memory_mb.unwrap_or(1024),
-            storage_mb: 102400,
-            gpu_count: options.gpu_min.unwrap_or(1),
+            cpu_cores: options.cpu_cores.unwrap_or(0.0),
+            memory_mb: options.memory_mb.unwrap_or(0),
+            storage_mb: options.storage_mb.unwrap_or(0),
+            gpu_count: options.gpu_min.unwrap_or(0),
             gpu_types: vec![],
         },
         command,

--- a/crates/basilica-validator/src/cli/handlers/rental.rs
+++ b/crates/basilica-validator/src/cli/handlers/rental.rs
@@ -181,10 +181,10 @@ async fn handle_start_rental(
         environment,
         ports: port_mappings,
         resources: ResourceRequirementsRequest {
-            cpu_cores: cpu_cores.unwrap_or(1.0),
-            memory_mb: memory_mb.unwrap_or(1024),
-            storage_mb: storage_mb.unwrap_or(102400), // Default to 100GB
-            gpu_count: gpu_count.unwrap_or(1),
+            cpu_cores: cpu_cores.unwrap_or(0.0),
+            memory_mb: memory_mb.unwrap_or(0),
+            storage_mb: storage_mb.unwrap_or(0),
+            gpu_count: gpu_count.unwrap_or(0),
             gpu_types: Vec::new(),
         },
         command,


### PR DESCRIPTION
## Summary

This PR updates resource requirement defaults to treat zero values as "unbounded" or "no specific requirement", giving the backend more flexibility in resource allocation.

All resource requirement defaults have been changed from specific values to zero:
- **cpu_cores**: `1.0` → `0.0` 
- **memory_mb**: `1024` → `0`
- **storage_mb**: `102400` → `0` 
- **gpu_count**: `1` → `0`

Zero values are now interpreted as "unbounded" - any available resource will match. Users can still specify explicit values when specific requirements are needed.