### PR TITLE
chore(deps): remove unused dependencies across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,12 +773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,12 +850,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "argon2"
@@ -2092,7 +2080,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap-verbosity-flag",
- "criterion",
  "dashmap 5.5.3",
  "figment",
  "futures",
@@ -2100,14 +2087,12 @@ dependencies = [
  "hex",
  "hyper 0.14.32",
  "jsonwebtoken",
- "mockall",
  "moka",
  "nonzero_ext",
  "once_cell",
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "redis",
  "regex",
  "reqwest 0.11.27",
  "serde",
@@ -2125,9 +2110,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "utoipa",
- "utoipa-swagger-ui",
  "uuid",
- "weighted-rs",
  "wiremock",
 ]
 
@@ -2218,7 +2201,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "shell-escape",
  "shellexpand",
  "tabled",
  "tempfile",
@@ -2267,7 +2249,6 @@ dependencies = [
  "signature",
  "sp-core",
  "sqlx",
- "ssh-key",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2289,7 +2270,6 @@ dependencies = [
  "base64 0.21.7",
  "basilica-common",
  "basilica-protocol",
- "bittensor",
  "blake3",
  "bollard",
  "chrono",
@@ -2297,13 +2277,11 @@ dependencies = [
  "clap-verbosity-flag",
  "figment",
  "flume",
- "fs_extra",
  "futures-util",
  "hex",
  "http 0.2.12",
  "metrics",
  "metrics-exporter-prometheus",
- "mockall",
  "num_cpus",
  "nvml-wrapper",
  "once_cell",
@@ -2313,7 +2291,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serial_test",
  "sqlx",
  "sysinfo",
  "tempfile",
@@ -2347,23 +2324,18 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "collateral-contract",
- "cron",
- "deadpool",
  "figment",
  "futures",
- "governor",
  "hex",
  "jsonwebtoken",
  "metrics",
  "metrics-exporter-prometheus",
- "mockall",
  "prost 0.12.6",
  "prost-types",
  "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serial_test",
  "socket2 0.5.10",
  "sqlx",
  "tempfile",
@@ -2446,13 +2418,9 @@ dependencies = [
  "basilica-validator",
  "bytes",
  "chrono",
- "console",
- "dialoguer",
  "etcetera",
  "futures",
  "futures-util",
- "indicatif",
- "keyring",
  "oauth2",
  "rand 0.8.5",
  "reqwest 0.11.27",
@@ -2470,7 +2438,6 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
- "webbrowser",
  "wiremock",
 ]
 
@@ -2520,8 +2487,6 @@ dependencies = [
  "lru 0.12.5",
  "metrics",
  "metrics-exporter-prometheus",
- "mockall",
- "nalgebra 0.32.6",
  "num_cpus",
  "p256",
  "prost 0.12.6",
@@ -2532,7 +2497,6 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serial_test",
  "sha2 0.10.9",
  "signature",
  "sqlx",
@@ -2702,7 +2666,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-test",
  "tracing",
 ]
 
@@ -3291,12 +3254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,33 +3324,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -3566,11 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
- "futures-core",
  "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -3860,53 +3786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
-name = "cron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
-dependencies = [
- "chrono",
- "nom",
- "once_cell",
 ]
 
 [[package]]
@@ -5274,16 +5153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5972,16 +5841,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
-dependencies = [
- "cfg-if",
- "crunchy",
 ]
 
 [[package]]
@@ -6697,7 +6556,6 @@ dependencies = [
  "basilica-protocol",
  "basilica-validator",
  "chrono",
- "criterion",
  "dirs 5.0.1",
  "futures",
  "hex",
@@ -7070,21 +6928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "linux-keyutils",
- "log",
- "security-framework 2.11.1",
- "security-framework 3.3.0",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7216,17 +7059,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9eda9dcf4f2a99787827661f312ac3219292549c2ee992bf9a6248ffb066bf7"
 dependencies = [
- "nalgebra 0.33.2",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
-dependencies = [
- "bitflags 2.9.2",
- "libc",
+ "nalgebra",
 ]
 
 [[package]]
@@ -7532,16 +7365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7630,23 +7453,6 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nalgebra"
-version = "0.32.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "serde",
- "simba 0.8.1",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
@@ -7656,19 +7462,8 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.9.0",
+ "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -7811,7 +7606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -8095,12 +7889,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -10608,34 +10396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "polkadot-ckb-merkle-mountain-range"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11966,30 +11726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "combine",
- "futures",
- "futures-util",
- "itoa",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1_smol",
- "socket2 0.4.10",
- "tokio",
- "tokio-retry",
- "tokio-util",
- "url",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12342,40 +12078,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-embed"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.106",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
-dependencies = [
- "sha2 0.10.9",
- "walkdir",
-]
 
 [[package]]
 name = "rust_decimal"
@@ -12901,15 +12603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13011,12 +12704,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -13318,31 +13005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13352,12 +13014,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -13413,12 +13069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13456,19 +13106,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "simba"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
 ]
 
 [[package]]
@@ -13982,16 +13619,6 @@ dependencies = [
  "sp-api",
  "sp-std",
  "staging-xcm",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -15876,16 +15503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15975,17 +15592,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
- "tokio",
 ]
 
 [[package]]
@@ -16643,22 +16249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-swagger-ui"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b39868d43c011961e04b41623e050aedf2cc93652562ff7935ce0f819aaf2da"
-dependencies = [
- "axum 0.7.9",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "utoipa",
- "zip",
-]
-
-[[package]]
 name = "uuid"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17226,15 +16816,6 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "weighted-rs"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b2872b8d86cdeeffd9d5fcc25ec9e843904eb966d24fa81e1d7db29c30c23"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "westend-runtime-constants"
@@ -18010,18 +17591,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]
 
 [[package]]

--- a/crates/basilica-api/Cargo.toml
+++ b/crates/basilica-api/Cargo.toml
@@ -61,11 +61,9 @@ nonzero_ext = { workspace = true }
 
 # OpenAPI documentation
 utoipa = { workspace = true }
-utoipa-swagger-ui = { workspace = true }
 
 # Caching
 moka = { workspace = true }
-redis = { workspace = true, optional = true }
 
 
 # Concurrent collections
@@ -89,21 +87,17 @@ bs58 = { workspace = true }
 regex = { workspace = true }
 
 # Load balancing algorithms
-weighted-rs = { workspace = true }
 rand = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
-mockall = { workspace = true }
 wiremock = { workspace = true }
 
 [features]
-default = ["server", "redis-cache", "utoipa"]
+default = ["server", "utoipa"]
 server = []
 client = []
-redis-cache = ["redis"]
 utoipa = []
-full = ["server", "client", "redis-cache", "utoipa"]
+full = ["server", "client", "utoipa"]
 
 [[bin]]
 name = "basilica-api"

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -45,9 +45,6 @@ tabled = { workspace = true }
 # Shell completions
 clap_complete = { workspace = true }
 
-# SSH functionality (using external ssh command for now)
-shell-escape = { workspace = true }
-
 # File operations
 shellexpand = { workspace = true }
 etcetera = { workspace = true }

--- a/crates/basilica-common/Cargo.toml
+++ b/crates/basilica-common/Cargo.toml
@@ -43,7 +43,6 @@ p256 = { workspace = true }
 signature = { workspace = true }
 pbkdf2 = { workspace = true }
 argon2 = { workspace = true }
-ssh-key = { workspace = true }
 zeroize = { workspace = true }
 base64 = { workspace = true }
 data-encoding = { workspace = true }

--- a/crates/basilica-executor/Cargo.toml
+++ b/crates/basilica-executor/Cargo.toml
@@ -41,7 +41,6 @@ prost-types = { workspace = true }
 # Internal dependencies
 basilica-common = { path = "../basilica-common", features = ["sqlite"] }
 basilica-protocol = { path = "../basilica-protocol" }
-bittensor = { path = "../bittensor" }
 
 # Additional required dependencies
 clap = { workspace = true }
@@ -54,8 +53,6 @@ hex = { workspace = true }
 # Executor-specific dependencies
 # GPU monitoring
 nvml-wrapper = { workspace = true }
-# File system utilities
-fs_extra = { workspace = true }
 # System information
 num_cpus = { workspace = true }
 # TOML configuration
@@ -69,8 +66,6 @@ http = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-serial_test = { workspace = true }
-mockall = { workspace = true }
 
 [features]
 default = []

--- a/crates/basilica-miner/Cargo.toml
+++ b/crates/basilica-miner/Cargo.toml
@@ -55,18 +55,9 @@ bittensor = { path = "../bittensor" }
 # HTTP client for external communications
 reqwest = { workspace = true }
 
-# Task scheduling and job management
-cron = { workspace = true }
-
 # Configuration
 toml = { workspace = true }
 url = { workspace = true }
-
-# Connection pooling
-deadpool = { workspace = true }
-
-# Rate limiting
-governor = { workspace = true }
 
 # JSON Web Tokens for authentication
 jsonwebtoken = { workspace = true }
@@ -82,8 +73,6 @@ rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-serial_test = { workspace = true }
-mockall = { workspace = true }
 futures = { workspace = true }
 
 [features]

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -44,15 +44,10 @@ oauth2 = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 rand = { workspace = true }
-keyring = { workspace = true }
 etcetera = { workspace = true }
-webbrowser = { workspace = true }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
-console = { workspace = true }
-dialoguer = { workspace = true }
-indicatif = { workspace = true }
 
 # Internal dependencies
 basilica-common = { path = "../basilica-common" }

--- a/crates/basilica-validator/Cargo.toml
+++ b/crates/basilica-validator/Cargo.toml
@@ -70,7 +70,6 @@ reqwest = { workspace = true }
 tempfile = { workspace = true }
 
 # Challenge implementation dependencies
-nalgebra = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 sha2 = { workspace = true }
@@ -94,8 +93,6 @@ utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-serial_test = { workspace = true }
-mockall = { workspace = true }
 
 [features]
 default = ["client"]

--- a/crates/bittensor/Cargo.toml
+++ b/crates/bittensor/Cargo.toml
@@ -49,5 +49,4 @@ name = "generate-metadata"
 path = "src/bin/generate-metadata.rs"
 required-features = ["generate-metadata"]
 
-[dev-dependencies]
-tokio-test = { workspace = true } 
+[dev-dependencies] 

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -36,7 +36,6 @@ tonic = { workspace = true, features = ["tls", "tls-roots"] }
 sqlx = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 
 [[test]]
 name = "miner_executor_flow"


### PR DESCRIPTION
## Summary

This PR removes unused dependencies identified by `cargo +nightly udeps` across the entire Basilica workspace, reducing build times and binary sizes.

- Removed unused dependencies from basilica-api, basilica-cli, basilica-common, basilica-executor, basilica-miner, basilica-sdk, basilica-validator, bittensor, and integration-tests crates
- Reduced Cargo.lock by ~430 lines
- All packages compile successfully after removal