### PR TITLE
fix(rental): always enable GPU runtime for containers

### DIFF
--- a/crates/basilica-validator/src/rental/container_client.rs
+++ b/crates/basilica-validator/src/rental/container_client.rs
@@ -204,12 +204,11 @@ impl ContainerClient {
             resource_strings.push("-m".to_string());
             resource_strings.push(format!("{}m", spec.resources.memory_mb));
         }
-        if spec.resources.gpu_count > 0 {
-            resource_strings.push("--gpus".to_string());
-            resource_strings.push("all".to_string());
-            resource_strings.push("--runtime".to_string());
-            resource_strings.push("nvidia".to_string());
-        }
+
+        resource_strings.push("--gpus".to_string());
+        resource_strings.push("all".to_string());
+        resource_strings.push("--runtime".to_string());
+        resource_strings.push("nvidia".to_string());
 
         // Volumes
         let volume_strings: Vec<String> = spec


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All container deployments now run with GPU support enabled by default. GPU runtime and allocation flags are included automatically, so workloads can access GPUs without extra configuration. This change standardizes runtime behavior across deployments, even when no explicit GPU count is specified. No user-facing settings need to be changed now.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->