### PR TITLE
feat(cli): add --all flag to stop all active rentals

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `--all` flag for `down` command to stop all active rentals at once
+
 ## [0.3.2]
 
 ### Changed

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -159,8 +159,8 @@ impl Args {
             Commands::Logs { target, options } => {
                 handlers::gpu_rental::handle_logs(target.clone(), options.clone(), config).await?;
             }
-            Commands::Down { target } => {
-                handlers::gpu_rental::handle_down(target.clone(), config).await?;
+            Commands::Down { target, all } => {
+                handlers::gpu_rental::handle_down(target.clone(), *all, config).await?;
             }
             Commands::Exec { command, target } => {
                 handlers::gpu_rental::handle_exec(target.clone(), command.clone(), config).await?;

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -54,6 +54,10 @@ pub enum Commands {
     Down {
         /// Rental UID/HUID to terminate (optional)
         target: Option<String>,
+
+        /// Stop all active rentals
+        #[arg(long, conflicts_with = "target")]
+        all: bool,
     },
 
     /// Execute commands on instances


### PR DESCRIPTION
## Summary

Adds a `--all` flag to the `basilica down` subcommand to enable stopping all active rentals in one operation.

## Changes

- Added `--all` flag to the `Down` command variant that conflicts with the `target` parameter
- Modified `handle_down` function to accept and process the `all` flag
- When `--all` is used, the command:
  - Fetches all active rentals from the API
  - Stops each rental sequentially with progress indicators
  - Continues with remaining rentals even if some fail
  - Displays a summary showing success/failure counts

## Usage

```bash
# Stop a specific rental (existing behavior)
basilica down <rental_id>

# Stop all active rentals (new)
basilica down --all
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --all flag to the down command to stop all active rentals at once. Mutually exclusive with specifying a target. Provides per-rental progress, clear success/failure summaries, and handles the case when no active rentals are found.

- Documentation
  - Updated changelog with an Unreleased entry documenting the new --all flag for the down command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->