### PR TITLE
feat(cli): add three-tier display system for ls, up, and ps commands

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Three-tier display system for `ls`, `up`, and `ps` commands with flexible output control:
+  - `--detailed` flag shows internal IDs (executor IDs in `ls`/`up`, rental IDs in `ps`) for debugging
+  - `--compact` flag provides minimal grouped display for cleaner overview
+  - Default mode shows essential information without internal IDs
+- Enhanced interactive selector with improved GPU information display in detailed mode
+
 ## [0.3.3]
 
 ### Added

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -216,9 +216,9 @@ pub struct ListFilters {
     #[arg(long)]
     pub country: Option<String>,
 
-    /// Show detailed GPU information (full GPU names)
+    /// Use compact view (group by country and GPU type)
     #[arg(long)]
-    pub detailed: bool,
+    pub compact: bool,
 }
 
 /// Options for provisioning instances
@@ -275,10 +275,6 @@ pub struct UpOptions {
     /// Create rental in detached mode (don't auto-connect via SSH)
     #[arg(short = 'd', long)]
     pub detach: bool,
-
-    /// Show detailed executor information (full GPU names and individual executors)
-    #[arg(long)]
-    pub detailed: bool,
 }
 
 /// Filters for listing active rentals
@@ -296,9 +292,9 @@ pub struct PsFilters {
     #[arg(long)]
     pub min_gpu_count: Option<u32>,
 
-    /// Show detailed GPU information (full GPU names)
+    /// Use compact view (minimal columns)
     #[arg(long)]
-    pub detailed: bool,
+    pub compact: bool,
 }
 
 /// Options for viewing logs

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -36,13 +36,13 @@ pub enum Commands {
 
     /// Check instance status
     Status {
-        /// Rental UID/HUID (optional)
+        /// Rental UUID (optional)
         target: Option<String>,
     },
 
     /// View instance logs
     Logs {
-        /// Rental UID/HUID (optional)
+        /// Rental UUID (optional)
         target: Option<String>,
 
         #[command(flatten)]
@@ -52,7 +52,7 @@ pub enum Commands {
     /// Terminate instance
     #[command(alias = "stop")]
     Down {
-        /// Rental UID/HUID to terminate (optional)
+        /// Rental UUID to terminate (optional)
         target: Option<String>,
 
         /// Stop all active rentals
@@ -65,7 +65,7 @@ pub enum Commands {
         /// Command to execute
         command: String,
 
-        /// Rental UID/HUID (optional)
+        /// Rental UUID (optional)
         #[arg(long)]
         target: Option<String>,
     },
@@ -73,7 +73,7 @@ pub enum Commands {
     /// SSH into instances
     #[command(alias = "connect")]
     Ssh {
-        /// Rental UID/HUID (optional)
+        /// Rental UUID (optional)
         target: Option<String>,
 
         #[command(flatten)]

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -219,6 +219,10 @@ pub struct ListFilters {
     /// Use compact view (group by country and GPU type)
     #[arg(long)]
     pub compact: bool,
+
+    /// Use detailed view (shows executor IDs)
+    #[arg(long)]
+    pub detailed: bool,
 }
 
 /// Options for provisioning instances
@@ -275,6 +279,14 @@ pub struct UpOptions {
     /// Create rental in detached mode (don't auto-connect via SSH)
     #[arg(short = 'd', long)]
     pub detach: bool,
+
+    /// Use compact view (group executors by GPU type)
+    #[arg(long)]
+    pub compact: bool,
+
+    /// Use detailed view (shows executor IDs during selection)
+    #[arg(long)]
+    pub detailed: bool,
 }
 
 /// Filters for listing active rentals
@@ -295,6 +307,10 @@ pub struct PsFilters {
     /// Use compact view (minimal columns)
     #[arg(long)]
     pub compact: bool,
+
+    /// Use detailed view (shows rental and executor IDs)
+    #[arg(long)]
+    pub detailed: bool,
 }
 
 /// Options for viewing logs

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -126,13 +126,14 @@ pub async fn handle_ls(
         json_output(&response)?;
     } else {
         // Use table_output module for consistent styling
-        if filters.detailed {
+        // Default to detailed view, use compact only if explicitly requested
+        if filters.compact {
+            table_output::display_available_executors_compact(&response.available_executors)?;
+        } else {
             table_output::display_available_executors_detailed(
                 &response.available_executors,
-                filters.detailed,
+                true,
             )?;
-        } else {
-            table_output::display_available_executors_compact(&response.available_executors)?;
         }
     }
 
@@ -198,7 +199,7 @@ pub async fn handle_up(
 
         // Use interactive selector to choose an executor
         let selector = crate::interactive::InteractiveSelector::new();
-        selector.select_executor(&response.available_executors, options.detailed)?
+        selector.select_executor(&response.available_executors, true)?
     };
 
     let spinner = create_spinner("Preparing rental request...");
@@ -382,7 +383,7 @@ pub async fn handle_ps(filters: PsFilters, json: bool, config: &CliConfig) -> Re
     if json {
         json_output(&rentals_list)?;
     } else {
-        table_output::display_rental_items(&rentals_list.rentals[..], filters.detailed)?;
+        table_output::display_rental_items(&rentals_list.rentals[..], !filters.compact)?;
         println!("\nTotal: {} active rentals", rentals_list.rentals.len());
 
         display_ps_quick_start_commands();

--- a/crates/basilica-cli/src/interactive/selector.rs
+++ b/crates/basilica-cli/src/interactive/selector.rs
@@ -49,11 +49,19 @@ impl InteractiveSelector {
         &self,
         executors: &[AvailableExecutor],
     ) -> Result<ExecutorSelection> {
-        // First pass: collect GPU info strings to determine max width
-        let gpu_infos: Vec<String> = executors
+        // Collect all display components to calculate proper column widths
+        struct DisplayComponents {
+            gpu_info: String,
+            cpu_info: String,
+            ram_info: String,
+            use_case: String,
+        }
+
+        let display_components: Vec<DisplayComponents> = executors
             .iter()
             .map(|executor| {
-                if executor.executor.gpu_specs.is_empty() {
+                // Format GPU info
+                let gpu_info = if executor.executor.gpu_specs.is_empty() {
                     "No GPUs".to_string()
                 } else {
                     let gpu = &executor.executor.gpu_specs[0];
@@ -67,31 +75,80 @@ impl InteractiveSelector {
                     } else {
                         format!("1x {}", gpu_display_name)
                     }
+                };
+
+                // Format CPU info - handle "Unknown" case
+                let cpu_info = if executor.executor.cpu_specs.model == "Unknown"
+                    || executor.executor.cpu_specs.cores == 0
+                {
+                    "Unknown CPU".to_string()
+                } else {
+                    format!(
+                        "{} ({} cores)",
+                        executor.executor.cpu_specs.model, executor.executor.cpu_specs.cores
+                    )
+                };
+
+                // Format RAM info
+                let ram_info = if executor.executor.cpu_specs.memory_gb == 0 {
+                    "Unknown".to_string()
+                } else {
+                    format!("{}GB", executor.executor.cpu_specs.memory_gb)
+                };
+
+                // Get use case description for GPUs
+                let use_case = if executor.executor.gpu_specs.is_empty() {
+                    "General compute".to_string()
+                } else {
+                    let gpu = &executor.executor.gpu_specs[0];
+                    GpuCategory::from_str(&gpu.name)
+                        .unwrap()
+                        .description()
+                        .to_string()
+                };
+
+                DisplayComponents {
+                    gpu_info,
+                    cpu_info,
+                    ram_info,
+                    use_case,
                 }
             })
             .collect();
 
-        // Calculate the maximum width needed for proper alignment
-        let max_width = gpu_infos.iter().map(|s| s.len()).max().unwrap_or(30);
-        let padding = max_width + 3;
-
-        // Create items for the selector with GPU info and use cases
-        let selector_items: Vec<String> = executors
+        // Calculate maximum widths for each column
+        let gpu_max_width = display_components
             .iter()
-            .zip(gpu_infos.iter())
-            .map(|(executor, gpu_info)| {
-                if executor.executor.gpu_specs.is_empty() {
-                    format!(
-                        "{:<width$} {}",
-                        gpu_info,
-                        "General GPU compute",
-                        width = padding
-                    )
-                } else {
-                    let gpu = &executor.executor.gpu_specs[0];
-                    let use_case = GpuCategory::from_str(&gpu.name).unwrap().description();
-                    format!("{:<width$} {}", gpu_info, use_case, width = padding)
-                }
+            .map(|c| c.gpu_info.len())
+            .max()
+            .unwrap_or(30);
+
+        let cpu_max_width = display_components
+            .iter()
+            .map(|c| c.cpu_info.len())
+            .max()
+            .unwrap_or(40);
+
+        let ram_max_width = display_components
+            .iter()
+            .map(|c| c.ram_info.len())
+            .max()
+            .unwrap_or(10);
+
+        // Create formatted items for the selector
+        let selector_items: Vec<String> = display_components
+            .iter()
+            .map(|components| {
+                format!(
+                    "{:<gpu_width$} │ {:<cpu_width$} │ {:<ram_width$} │ {}",
+                    components.gpu_info,
+                    components.cpu_info,
+                    components.ram_info,
+                    components.use_case,
+                    gpu_width = gpu_max_width,
+                    cpu_width = cpu_max_width,
+                    ram_width = ram_max_width
+                )
             })
             .collect();
 

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -105,9 +105,96 @@ pub fn display_rentals(rentals: &[RentalStatusResponse]) -> Result<()> {
 }
 
 /// Display rental items in table format
-pub fn display_rental_items(rentals: &[ApiRentalListItem], detailed: bool) -> Result<()> {
-    if detailed {
-        // Detailed view with full information
+pub fn display_rental_items(
+    rentals: &[ApiRentalListItem],
+    show_standard: bool,
+    show_ids: bool,
+) -> Result<()> {
+    if show_ids {
+        // Detailed view with IDs
+        #[derive(Tabled)]
+        struct DetailedRentalRowWithIds {
+            #[tabled(rename = "RENTAL ID")]
+            rental_id: String,
+            #[tabled(rename = "EXECUTOR ID")]
+            executor_id: String,
+            #[tabled(rename = "GPU")]
+            gpu: String,
+            #[tabled(rename = "State")]
+            state: String,
+            #[tabled(rename = "SSH")]
+            ssh: String,
+            #[tabled(rename = "Image")]
+            image: String,
+            #[tabled(rename = "CPU")]
+            cpu: String,
+            #[tabled(rename = "RAM")]
+            ram: String,
+            #[tabled(rename = "Location")]
+            location: String,
+            #[tabled(rename = "Created")]
+            created: String,
+        }
+
+        let rows: Vec<DetailedRentalRowWithIds> = rentals
+            .iter()
+            .map(|rental| {
+                // Extract the executor ID (remove miner prefix if present)
+                let executor_id = rental
+                    .executor_id
+                    .split_once("__")
+                    .map(|(_, id)| id)
+                    .unwrap_or(&rental.executor_id)
+                    .to_string();
+
+                // Format GPU info from specs
+                let gpu = format_gpu_info(&rental.gpu_specs, true);
+
+                // Format CPU info
+                let cpu = rental
+                    .cpu_specs
+                    .as_ref()
+                    .map(|cpu| format!("{} ({} cores)", cpu.model, cpu.cores))
+                    .unwrap_or_else(|| "Unknown".to_string());
+
+                // Format RAM info
+                let ram = rental
+                    .cpu_specs
+                    .as_ref()
+                    .map(|cpu| format!("{}GB", cpu.memory_gb))
+                    .unwrap_or_else(|| "Unknown".to_string());
+
+                // Format location
+                let location = rental
+                    .location
+                    .as_ref()
+                    .and_then(|loc| LocationProfile::from_str(loc).ok())
+                    .map(|profile| profile.to_string())
+                    .unwrap_or_else(|| "Unknown".to_string());
+
+                // Format SSH availability
+                let ssh = if rental.has_ssh { "✓" } else { "✗" };
+
+                DetailedRentalRowWithIds {
+                    rental_id: rental.rental_id.clone(),
+                    executor_id,
+                    gpu,
+                    state: rental.state.to_string(),
+                    ssh: ssh.to_string(),
+                    image: rental.container_image.clone(),
+                    cpu,
+                    ram,
+                    location,
+                    created: format_timestamp(&rental.created_at),
+                }
+            })
+            .collect();
+
+        let mut table = Table::new(rows);
+        table.with(Style::modern());
+        println!("{table}");
+    } else if show_standard {
+        // Standard view with full information (no IDs)
         #[derive(Tabled)]
         struct DetailedRentalRow {
             #[tabled(rename = "GPU")]
@@ -404,109 +491,158 @@ pub fn display_api_keys(keys: &[ApiKeyInfo]) -> Result<()> {
     Ok(())
 }
 
+/// Helper function to format GPU info for an executor
+fn format_executor_gpu_info(executor: &AvailableExecutor, show_full_gpu_names: bool) -> String {
+    if executor.executor.gpu_specs.is_empty() {
+        "No GPU".to_string()
+    } else if executor.executor.gpu_specs.len() == 1 {
+        // Single GPU
+        let gpu = &executor.executor.gpu_specs[0];
+        let gpu_display_name = if show_full_gpu_names {
+            gpu.name.clone()
+        } else {
+            GpuCategory::from_str(&gpu.name).unwrap().to_string()
+        };
+        format!("1x {}", gpu_display_name)
+    } else {
+        // Multiple GPUs - check if they're all the same model
+        let first_gpu = &executor.executor.gpu_specs[0];
+        let all_same = executor
+            .executor
+            .gpu_specs
+            .iter()
+            .all(|g| g.name == first_gpu.name && g.memory_gb == first_gpu.memory_gb);
+
+        if all_same {
+            // All GPUs are identical - use count prefix format
+            let gpu_display_name = if show_full_gpu_names {
+                first_gpu.name.clone()
+            } else {
+                GpuCategory::from_str(&first_gpu.name).unwrap().to_string()
+            };
+            format!(
+                "{}x {}",
+                executor.executor.gpu_specs.len(),
+                gpu_display_name
+            )
+        } else {
+            // Different GPU models - list them individually
+            let gpu_names: Vec<String> = executor
+                .executor
+                .gpu_specs
+                .iter()
+                .map(|g| {
+                    if show_full_gpu_names {
+                        g.name.clone()
+                    } else {
+                        GpuCategory::from_str(&g.name).unwrap().to_string()
+                    }
+                })
+                .collect();
+            gpu_names.join(", ")
+        }
+    }
+}
+
+/// Helper function to format location
+fn format_executor_location(location: &Option<String>) -> String {
+    location
+        .as_ref()
+        .map(|loc| {
+            LocationProfile::from_str(loc)
+                .ok()
+                .map(|profile| profile.to_string())
+                .unwrap_or_else(|| loc.clone())
+        })
+        .unwrap_or_else(|| "Unknown".to_string())
+}
+
 /// Display available executors in detailed format (individual executors)
 pub fn display_available_executors_detailed(
     executors: &[AvailableExecutor],
     show_full_gpu_names: bool,
+    show_ids: bool,
 ) -> Result<()> {
     if executors.is_empty() {
         println!("No available executors found matching the specified criteria.");
         return Ok(());
     }
 
-    #[derive(Tabled)]
-    struct DetailedExecutorRow {
-        #[tabled(rename = "GPU")]
-        gpu_info: String,
-        #[tabled(rename = "CPU")]
-        cpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
-        #[tabled(rename = "Location")]
-        location: String,
-    }
+    // Different structs based on whether we show IDs
+    if show_ids {
+        #[derive(Tabled)]
+        struct DetailedExecutorRowWithId {
+            #[tabled(rename = "EXECUTOR ID")]
+            executor_id: String,
+            #[tabled(rename = "GPU")]
+            gpu_info: String,
+            #[tabled(rename = "CPU")]
+            cpu: String,
+            #[tabled(rename = "RAM")]
+            ram: String,
+            #[tabled(rename = "Location")]
+            location: String,
+        }
 
-    let rows: Vec<DetailedExecutorRow> = executors
-        .iter()
-        .map(|executor| {
-            let gpu_info = if executor.executor.gpu_specs.is_empty() {
-                "No GPU".to_string()
-            } else if executor.executor.gpu_specs.len() == 1 {
-                // Single GPU
-                let gpu = &executor.executor.gpu_specs[0];
-                let gpu_display_name = if show_full_gpu_names {
-                    gpu.name.clone()
-                } else {
-                    GpuCategory::from_str(&gpu.name).unwrap().to_string()
-                };
-                format!("1x {}", gpu_display_name)
-            } else {
-                // Multiple GPUs - check if they're all the same model
-                let first_gpu = &executor.executor.gpu_specs[0];
-                let all_same = executor
+        let rows: Vec<DetailedExecutorRowWithId> = executors
+            .iter()
+            .map(|executor| {
+                // Extract the executor ID (remove miner prefix if present)
+                let executor_id = executor
                     .executor
-                    .gpu_specs
-                    .iter()
-                    .all(|g| g.name == first_gpu.name && g.memory_gb == first_gpu.memory_gb);
+                    .id
+                    .split_once("__")
+                    .map(|(_, id)| id)
+                    .unwrap_or(&executor.executor.id)
+                    .to_string();
 
-                if all_same {
-                    // All GPUs are identical - use count prefix format
-                    let gpu_display_name = if show_full_gpu_names {
-                        first_gpu.name.clone()
-                    } else {
-                        GpuCategory::from_str(&first_gpu.name).unwrap().to_string()
-                    };
-                    format!(
-                        "{}x {}",
-                        executor.executor.gpu_specs.len(),
-                        gpu_display_name
-                    )
-                } else {
-                    // Different GPU models - list them individually
-                    let gpu_names: Vec<String> = executor
-                        .executor
-                        .gpu_specs
-                        .iter()
-                        .map(|g| {
-                            if show_full_gpu_names {
-                                g.name.clone()
-                            } else {
-                                GpuCategory::from_str(&g.name).unwrap().to_string()
-                            }
-                        })
-                        .collect();
-                    gpu_names.join(", ")
+                DetailedExecutorRowWithId {
+                    executor_id,
+                    gpu_info: format_executor_gpu_info(executor, show_full_gpu_names),
+                    cpu: format!(
+                        "{} ({} cores)",
+                        executor.executor.cpu_specs.model, executor.executor.cpu_specs.cores
+                    ),
+                    ram: format!("{}GB", executor.executor.cpu_specs.memory_gb),
+                    location: format_executor_location(&executor.executor.location),
                 }
-            };
+            })
+            .collect();
 
-            // Parse and format location using LocationProfile's Display trait
-            let location = executor
-                .executor
-                .location
-                .as_ref()
-                .map(|loc| {
-                    LocationProfile::from_str(loc)
-                        .ok()
-                        .map(|profile| profile.to_string())
-                        .unwrap_or_else(|| loc.clone())
-                })
-                .unwrap_or_else(|| "Unknown".to_string());
+        let mut table = Table::new(rows);
+        table.with(Style::modern());
+        println!("{}", table);
+    } else {
+        #[derive(Tabled)]
+        struct DetailedExecutorRow {
+            #[tabled(rename = "GPU")]
+            gpu_info: String,
+            #[tabled(rename = "CPU")]
+            cpu: String,
+            #[tabled(rename = "RAM")]
+            ram: String,
+            #[tabled(rename = "Location")]
+            location: String,
+        }
 
-            DetailedExecutorRow {
-                gpu_info,
+        let rows: Vec<DetailedExecutorRow> = executors
+            .iter()
+            .map(|executor| DetailedExecutorRow {
+                gpu_info: format_executor_gpu_info(executor, show_full_gpu_names),
                 cpu: format!(
                     "{} ({} cores)",
                     executor.executor.cpu_specs.model, executor.executor.cpu_specs.cores
                 ),
                 ram: format!("{}GB", executor.executor.cpu_specs.memory_gb),
-                location,
-            }
-        })
-        .collect();
+                location: format_executor_location(&executor.executor.location),
+            })
+            .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{}", table);
+        let mut table = Table::new(rows);
+        table.with(Style::modern());
+        println!("{}", table);
+    }
+
     println!("\nTotal available executors: {}", executors.len());
 
     Ok(())

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -112,8 +112,6 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], detailed: bool) -> Re
         struct DetailedRentalRow {
             #[tabled(rename = "GPU")]
             gpu: String,
-            #[tabled(rename = "Rental ID")]
-            rental_id: String,
             #[tabled(rename = "State")]
             state: String,
             #[tabled(rename = "SSH")]
@@ -163,7 +161,6 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], detailed: bool) -> Re
 
                 DetailedRentalRow {
                     gpu,
-                    rental_id: rental.rental_id.clone(),
                     state: rental.state.to_string(),
                     ssh: ssh.to_string(),
                     image: rental.container_image.clone(),
@@ -421,8 +418,6 @@ pub fn display_available_executors_detailed(
     struct DetailedExecutorRow {
         #[tabled(rename = "GPU")]
         gpu_info: String,
-        #[tabled(rename = "Executor ID")]
-        id: String,
         #[tabled(rename = "CPU")]
         cpu: String,
         #[tabled(rename = "RAM")]
@@ -484,12 +479,6 @@ pub fn display_available_executors_detailed(
                 }
             };
 
-            // Remove miner prefix from executor ID if present
-            let executor_id = match executor.executor.id.split_once("__") {
-                Some((_, second)) => second.to_string(),
-                None => executor.executor.id.clone(),
-            };
-
             // Parse and format location using LocationProfile's Display trait
             let location = executor
                 .executor
@@ -505,7 +494,6 @@ pub fn display_available_executors_detailed(
 
             DetailedExecutorRow {
                 gpu_info,
-                id: executor_id,
                 cpu: format!(
                     "{} ({} cores)",
                     executor.executor.cpu_specs.model, executor.executor.cpu_specs.cores


### PR DESCRIPTION
## Summary

This PR improves GPU categorization and target type parsing in the Basilica CLI, providing better handling and validation of GPU types in various commands.

## Changes

### Enhanced Target Type Parsing
- Improved `TargetType` enum parsing to properly distinguish between executor IDs (UUIDs) and GPU categories
- Better error handling for invalid GPU types with descriptive error messages
- Fixed validation logic to correctly handle unknown GPU categories

### GPU Information Display
- Updated GPU type parameter documentation across CLI commands
- Enhanced interactive selector to show full GPU names in detailed mode
- Improved handling of GPU specifications in the rental commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --compact and --detailed flags to ls, up, and ps to toggle compact, standard, and detailed output.
  - Detailed view can optionally show executor/rental IDs; compact view groups/minimizes output.
  - Interactive selector and tables now show richer GPU, CPU, RAM, Location, SSH, and Created fields with improved formatting.

- Documentation
  - Help text updated to use “UUID” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->