### PR TITLE
refactor(validator): remove redundant hardware columns from miner_executors table

### DIFF
--- a/crates/basilica-validator/src/gpu/epoch_filtering_test.rs
+++ b/crates/basilica-validator/src/gpu/epoch_filtering_test.rs
@@ -46,16 +46,14 @@ mod tests {
             // Seed miner_executors table with online status
             let executor_key = format!("{}:{}", &miner_id, &executor_id);
             sqlx::query(
-                "INSERT OR REPLACE INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, gpu_specs, cpu_specs, status, gpu_uuids, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT OR REPLACE INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, status, gpu_uuids, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&executor_key)
             .bind(&miner_id)
             .bind(&executor_id)
             .bind("http://127.0.0.1:50051")
             .bind(profile.gpu_counts.values().sum::<u32>() as i64)
-            .bind("[]") // Empty gpu_specs JSON array
-            .bind("{}") // Empty cpu_specs JSON object
             .bind("online")
             .bind("") // Empty gpu_uuids, we'll use gpu_uuid_assignments instead
             .bind(now.to_rfc3339())

--- a/crates/basilica-validator/src/gpu/epoch_test.rs
+++ b/crates/basilica-validator/src/gpu/epoch_test.rs
@@ -65,19 +65,15 @@ mod tests {
             }
 
             // Seed miner_executors table
-            let gpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
-            let cpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
             sqlx::query(
-                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, gpu_specs, cpu_specs, status, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, status, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&executor_id)
             .bind(&miner_id)
             .bind(&executor_id)
             .bind("127.0.0.1:8080")
             .bind(profile.gpu_counts.values().sum::<u32>() as i64)
-            .bind(&gpu_specs)
-            .bind(&cpu_specs)
             .bind("verified") // Set status to 'verified' for tests
             .bind(now.to_rfc3339())
             .bind(now.to_rfc3339())

--- a/crates/basilica-validator/src/gpu/gpu_scoring.rs
+++ b/crates/basilica-validator/src/gpu/gpu_scoring.rs
@@ -560,19 +560,15 @@ mod tests {
             }
 
             // Seed miner_executors table
-            let gpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
-            let cpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
             sqlx::query(
-                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, gpu_specs, cpu_specs, status, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, status, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&executor_id)
             .bind(&miner_id)
             .bind(&executor_id)
             .bind("127.0.0.1:8080")
             .bind(profile.gpu_counts.values().sum::<u32>() as i64)
-            .bind(&gpu_specs)
-            .bind(&cpu_specs)
             .bind("online")
             .bind(now.to_rfc3339())
             .bind(now.to_rfc3339())

--- a/crates/basilica-validator/src/persistence/gpu_profile_repository.rs
+++ b/crates/basilica-validator/src/persistence/gpu_profile_repository.rs
@@ -900,19 +900,15 @@ mod tests {
             }
 
             // Seed miner_executors table
-            let gpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
-            let cpu_specs = serde_json::to_string(&HashMap::<String, String>::new())?;
             sqlx::query(
-                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, gpu_specs, cpu_specs, status, created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, status, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&executor_id)
             .bind(&miner_id)
             .bind(&executor_id)
             .bind("127.0.0.1:8080")
             .bind(profile.gpu_counts.values().sum::<u32>() as i64)
-            .bind(&gpu_specs)
-            .bind(&cpu_specs)
             .bind("online")
             .bind(now.to_rfc3339())
             .bind(now.to_rfc3339())
@@ -1137,16 +1133,14 @@ mod tests {
 
         // Insert executor
         sqlx::query(
-            "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, gpu_specs, cpu_specs, status, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO miner_executors (id, miner_id, executor_id, grpc_address, gpu_count, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(format!("{}_{}", miner_id, executor_id))
         .bind(&miner_id)
         .bind(executor_id)
         .bind("127.0.0.1:8080")
         .bind(5i64) // Total GPUs
-        .bind("{}")
-        .bind("{}")
         .bind("online")
         .bind(Utc::now().to_rfc3339())
         .bind(Utc::now().to_rfc3339())


### PR DESCRIPTION
## Summary

This PR removes redundant hardware profile columns from the `miner_executors` table to eliminate data duplication and improve data consistency.

## Changes

### Columns Removed
- `gpu_specs` - GPU specifications (now fetched from `gpu_uuid_assignments`)
- `cpu_specs` - CPU specifications (now fetched from `executor_hardware_profile`)
- `location` - Location information (now fetched from `executor_network_profile`)