### PR TITLE
refactor(cli,api): update GPU count filtering for compact mode

### DIFF
--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -86,21 +86,9 @@ pub async fn start_rental(
             info!("Starting rental with specified executor: {}", executor_id);
             executor_id.clone()
         }
-        ExecutorSelection::GpuRequirements { gpu_requirements }
-        | ExecutorSelection::ExactGpuConfiguration { gpu_requirements } => {
-            // Determine if we need exact count matching
-            let require_exact_count = matches!(
-                &request.executor_selection,
-                ExecutorSelection::ExactGpuConfiguration { .. }
-            );
-
+        ExecutorSelection::ExactGpuConfiguration { gpu_requirements } => {
             info!(
-                "Selecting executor based on GPU requirements ({}): {:?}",
-                if require_exact_count {
-                    "exact"
-                } else {
-                    "minimum"
-                },
+                "Selecting executor based on GPU requirements (exact): {:?}",
                 gpu_requirements
             );
 
@@ -121,36 +109,25 @@ pub async fn start_rental(
                     message: format!("Failed to query available executors: {}", e),
                 })?;
 
-            // Filter for exact count if needed, otherwise use all results
-            let executors = if require_exact_count {
-                let exact_count = gpu_requirements.gpu_count as usize;
-                let filtered: Vec<_> = executors_response
-                    .available_executors
-                    .into_iter()
-                    .filter(|exec| exec.executor.gpu_specs.len() == exact_count)
-                    .collect();
+            // Filter for exact GPU count
+            let exact_count = gpu_requirements.gpu_count as usize;
+            let executors: Vec<_> = executors_response
+                .available_executors
+                .into_iter()
+                .filter(|exec| exec.executor.gpu_specs.len() == exact_count)
+                .collect();
 
-                if filtered.is_empty() {
-                    error!("No executors with exactly {} GPU(s) available", exact_count);
-                    return Err(crate::error::ApiError::NotFound {
-                        message: format!(
-                            "No executors with exactly {} GPU(s) matching requirements",
-                            exact_count
-                        ),
-                    });
-                }
-                filtered
-            } else {
-                if executors_response.available_executors.is_empty() {
-                    error!("No executors match the specified GPU requirements");
-                    return Err(crate::error::ApiError::NotFound {
-                        message: "executor matching GPU requirements".into(),
-                    });
-                }
-                executors_response.available_executors
-            };
+            if executors.is_empty() {
+                error!("No executors with exactly {} GPU(s) available", exact_count);
+                return Err(crate::error::ApiError::NotFound {
+                    message: format!(
+                        "No executors with exactly {} GPU(s) matching requirements",
+                        exact_count
+                    ),
+                });
+            }
 
-            // Randomly select an executor from the (possibly filtered) list
+            // Randomly select an executor from the filtered list
             let selected_id = select_best_executor(executors).ok_or_else(|| {
                 crate::error::ApiError::Internal {
                     message: "Failed to select executor".into(),
@@ -158,13 +135,8 @@ pub async fn start_rental(
             })?;
 
             info!(
-                "Selected executor {} from available executors {}",
-                selected_id,
-                if require_exact_count {
-                    format!("with exactly {} GPU(s)", gpu_requirements.gpu_count)
-                } else {
-                    "matching GPU requirements".to_string()
-                }
+                "Selected executor {} with exactly {} GPU(s)",
+                selected_id, exact_count
             );
             selected_id
         }

--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -86,9 +86,21 @@ pub async fn start_rental(
             info!("Starting rental with specified executor: {}", executor_id);
             executor_id.clone()
         }
-        ExecutorSelection::GpuRequirements { gpu_requirements } => {
+        ExecutorSelection::GpuRequirements { gpu_requirements }
+        | ExecutorSelection::ExactGpuConfiguration { gpu_requirements } => {
+            // Determine if we need exact count matching
+            let require_exact_count = matches!(
+                &request.executor_selection,
+                ExecutorSelection::ExactGpuConfiguration { .. }
+            );
+
             info!(
-                "Selecting executor based on GPU requirements: {:?}",
+                "Selecting executor based on GPU requirements ({}): {:?}",
+                if require_exact_count {
+                    "exact"
+                } else {
+                    "minimum"
+                },
                 gpu_requirements
             );
 
@@ -109,22 +121,50 @@ pub async fn start_rental(
                     message: format!("Failed to query available executors: {}", e),
                 })?;
 
-            if executors_response.available_executors.is_empty() {
-                error!("No executors match the specified GPU requirements");
-                return Err(crate::error::ApiError::NotFound {
-                    message: "executor matching GPU requirements".into(),
-                });
-            }
+            // Filter for exact count if needed, otherwise use all results
+            let executors = if require_exact_count {
+                let exact_count = gpu_requirements.gpu_count as usize;
+                let filtered: Vec<_> = executors_response
+                    .available_executors
+                    .into_iter()
+                    .filter(|exec| exec.executor.gpu_specs.len() == exact_count)
+                    .collect();
 
-            // Randomly select an executor from those matching GPU requirements
-            let selected_id = select_best_executor(executors_response.available_executors)
-                .ok_or_else(|| crate::error::ApiError::Internal {
+                if filtered.is_empty() {
+                    error!("No executors with exactly {} GPU(s) available", exact_count);
+                    return Err(crate::error::ApiError::NotFound {
+                        message: format!(
+                            "No executors with exactly {} GPU(s) matching requirements",
+                            exact_count
+                        ),
+                    });
+                }
+                filtered
+            } else {
+                if executors_response.available_executors.is_empty() {
+                    error!("No executors match the specified GPU requirements");
+                    return Err(crate::error::ApiError::NotFound {
+                        message: "executor matching GPU requirements".into(),
+                    });
+                }
+                executors_response.available_executors
+            };
+
+            // Randomly select an executor from the (possibly filtered) list
+            let selected_id = select_best_executor(executors).ok_or_else(|| {
+                crate::error::ApiError::Internal {
                     message: "Failed to select executor".into(),
-                })?;
+                }
+            })?;
 
             info!(
-                "Randomly selected executor {} from available executors matching GPU requirements",
-                selected_id
+                "Selected executor {} from available executors {}",
+                selected_id,
+                if require_exact_count {
+                    format!("with exactly {} GPU(s)", gpu_requirements.gpu_count)
+                } else {
+                    "matching GPU requirements".to_string()
+                }
             );
             selected_id
         }

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Default mode shows essential information without internal IDs
 - Enhanced interactive selector with improved GPU information display in detailed mode
 
+### Changed
+- Renamed `--gpu-min` to `--gpu-count` in the `up` command for clarity
+- GPU selection now uses exact count matching instead of minimum matching when provisioning instances
+  - `basilica up a100 --gpu-count 2` now gets executors with exactly 2 GPUs, not "at least 2"
+
+### Fixed
+- Compact mode GPU selections (e.g., selecting "1x A100") now correctly filter for executors with exactly that GPU count, not executors with more GPUs
+
 ## [0.3.3]
 
 ### Added

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -228,9 +228,9 @@ pub struct ListFilters {
 /// Options for provisioning instances
 #[derive(clap::Args, Debug, Clone)]
 pub struct UpOptions {
-    /// Minimum GPU count
+    /// Exact GPU count required
     #[arg(long)]
-    pub gpu_min: Option<u32>,
+    pub gpu_count: Option<u32>,
 
     /// Docker image to run
     #[arg(long)]

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -159,16 +159,16 @@ pub async fn handle_up(
                 ExecutorSelection::ExecutorId { executor_id }
             }
             TargetType::GpuCategory(gpu_category) => {
-                // GPU category specified - use automatic selection
+                // GPU category specified - use automatic selection with exact matching
                 let spinner =
                     create_spinner(&format!("Finding available {} executors...", gpu_category));
                 complete_spinner_and_clear(spinner);
 
-                ExecutorSelection::GpuRequirements {
+                ExecutorSelection::ExactGpuConfiguration {
                     gpu_requirements: GpuRequirements {
                         min_memory_gb: 0, // Default, no minimum memory requirement
                         gpu_type: Some(gpu_category.as_str()),
-                        gpu_count: options.gpu_min.unwrap_or(0),
+                        gpu_count: options.gpu_count.unwrap_or(0),
                     },
                 }
             }
@@ -182,7 +182,7 @@ pub async fn handle_up(
             available: Some(true),
             min_gpu_memory: None,
             gpu_type: None,
-            min_gpu_count: options.gpu_min,
+            min_gpu_count: options.gpu_count,
             location: options.country.as_ref().map(|country| LocationProfile {
                 city: None,
                 region: None,
@@ -257,7 +257,7 @@ pub async fn handle_up(
             cpu_cores: options.cpu_cores.unwrap_or(0.0),
             memory_mb: options.memory_mb.unwrap_or(0),
             storage_mb: options.storage_mb.unwrap_or(0),
-            gpu_count: options.gpu_min.unwrap_or(0),
+            gpu_count: options.gpu_count.unwrap_or(0),
             gpu_types: vec![],
         },
         command,

--- a/crates/basilica-cli/src/interactive/selector.rs
+++ b/crates/basilica-cli/src/interactive/selector.rs
@@ -318,7 +318,8 @@ impl InteractiveSelector {
             };
             Ok(ExecutorSelection::ExecutorId { executor_id })
         } else {
-            Ok(ExecutorSelection::GpuRequirements {
+            // Use ExactGpuConfiguration for compact mode to ensure exact GPU count matching
+            Ok(ExecutorSelection::ExactGpuConfiguration {
                 gpu_requirements: GpuRequirements {
                     gpu_type: Some(selected_config.1.clone()),
                     gpu_count: selected_config.2,

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -231,17 +231,10 @@ fn executor_by_id(executor_id: String) -> types::ExecutorSelection {
     types::ExecutorSelection::ExecutorId { executor_id }
 }
 
-/// Helper function to create executor selection by GPU requirements (minimum count)
+/// Helper function to create executor selection by GPU requirements (exact count)
 #[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 fn executor_by_gpu(gpu_requirements: types::GpuRequirements) -> types::ExecutorSelection {
-    types::ExecutorSelection::GpuRequirements { gpu_requirements }
-}
-
-/// Helper function to create executor selection with exact GPU configuration
-#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
-#[pyfunction]
-fn executor_by_exact_gpu(gpu_requirements: types::GpuRequirements) -> types::ExecutorSelection {
     types::ExecutorSelection::ExactGpuConfiguration { gpu_requirements }
 }
 
@@ -293,7 +286,6 @@ fn _basilica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Helper functions
     m.add_function(wrap_pyfunction!(executor_by_id, m)?)?;
     m.add_function(wrap_pyfunction!(executor_by_gpu, m)?)?;
-    m.add_function(wrap_pyfunction!(executor_by_exact_gpu, m)?)?;
 
     Ok(())
 }

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -231,11 +231,18 @@ fn executor_by_id(executor_id: String) -> types::ExecutorSelection {
     types::ExecutorSelection::ExecutorId { executor_id }
 }
 
-/// Helper function to create executor selection by GPU requirements
+/// Helper function to create executor selection by GPU requirements (minimum count)
 #[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
 #[pyfunction]
 fn executor_by_gpu(gpu_requirements: types::GpuRequirements) -> types::ExecutorSelection {
     types::ExecutorSelection::GpuRequirements { gpu_requirements }
+}
+
+/// Helper function to create executor selection with exact GPU configuration
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction)]
+#[pyfunction]
+fn executor_by_exact_gpu(gpu_requirements: types::GpuRequirements) -> types::ExecutorSelection {
+    types::ExecutorSelection::ExactGpuConfiguration { gpu_requirements }
 }
 
 /// Python module for Basilica SDK
@@ -286,6 +293,7 @@ fn _basilica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Helper functions
     m.add_function(wrap_pyfunction!(executor_by_id, m)?)?;
     m.add_function(wrap_pyfunction!(executor_by_gpu, m)?)?;
+    m.add_function(wrap_pyfunction!(executor_by_exact_gpu, m)?)?;
 
     Ok(())
 }

--- a/crates/basilica-sdk-python/src/types.rs
+++ b/crates/basilica-sdk-python/src/types.rs
@@ -323,7 +323,6 @@ impl From<GpuRequirements> for SdkGpuRequirements {
 #[derive(Clone)]
 pub enum ExecutorSelection {
     ExecutorId { executor_id: String },
-    GpuRequirements { gpu_requirements: GpuRequirements },
     ExactGpuConfiguration { gpu_requirements: GpuRequirements },
 }
 
@@ -332,11 +331,6 @@ impl From<ExecutorSelection> for SdkExecutorSelection {
         match selection {
             ExecutorSelection::ExecutorId { executor_id } => {
                 SdkExecutorSelection::ExecutorId { executor_id }
-            }
-            ExecutorSelection::GpuRequirements { gpu_requirements } => {
-                SdkExecutorSelection::GpuRequirements {
-                    gpu_requirements: gpu_requirements.into(),
-                }
             }
             ExecutorSelection::ExactGpuConfiguration { gpu_requirements } => {
                 SdkExecutorSelection::ExactGpuConfiguration {

--- a/crates/basilica-sdk-python/src/types.rs
+++ b/crates/basilica-sdk-python/src/types.rs
@@ -324,6 +324,7 @@ impl From<GpuRequirements> for SdkGpuRequirements {
 pub enum ExecutorSelection {
     ExecutorId { executor_id: String },
     GpuRequirements { gpu_requirements: GpuRequirements },
+    ExactGpuConfiguration { gpu_requirements: GpuRequirements },
 }
 
 impl From<ExecutorSelection> for SdkExecutorSelection {
@@ -334,6 +335,11 @@ impl From<ExecutorSelection> for SdkExecutorSelection {
             }
             ExecutorSelection::GpuRequirements { gpu_requirements } => {
                 SdkExecutorSelection::GpuRequirements {
+                    gpu_requirements: gpu_requirements.into(),
+                }
+            }
+            ExecutorSelection::ExactGpuConfiguration { gpu_requirements } => {
+                SdkExecutorSelection::ExactGpuConfiguration {
                     gpu_requirements: gpu_requirements.into(),
                 }
             }

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -113,8 +113,6 @@ pub struct LogStreamQuery {
 pub enum ExecutorSelection {
     /// Select a specific executor by ID
     ExecutorId { executor_id: String },
-    /// Select best available executor based on GPU requirements (minimum count)
-    GpuRequirements { gpu_requirements: GpuRequirements },
     /// Select executor with exact GPU configuration (exact count match)
     ExactGpuConfiguration { gpu_requirements: GpuRequirements },
 }

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -113,8 +113,10 @@ pub struct LogStreamQuery {
 pub enum ExecutorSelection {
     /// Select a specific executor by ID
     ExecutorId { executor_id: String },
-    /// Select best available executor based on GPU requirements
+    /// Select best available executor based on GPU requirements (minimum count)
     GpuRequirements { gpu_requirements: GpuRequirements },
+    /// Select executor with exact GPU configuration (exact count match)
+    ExactGpuConfiguration { gpu_requirements: GpuRequirements },
 }
 
 /// Start rental request with flexible executor selection

--- a/crates/basilica-validator/src/api/types.rs
+++ b/crates/basilica-validator/src/api/types.rs
@@ -29,7 +29,7 @@ impl Default for GpuRequirements {
         Self {
             min_memory_gb: 0,
             gpu_type: Some("b200".to_string()),
-            gpu_count: 1,
+            gpu_count: 0,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces exact GPU count filtering to ensure users get executors with the precise number of GPUs they request, particularly in compact mode selections.

When users select "1x A100" in compact mode, they now get executors with exactly 1 GPU, not 8x A100s.

## Changes
- Added `ExactGpuConfiguration` variant to `ExecutorSelection` enum
- Updated CLI compact mode and direct GPU category selection to use exact matching
- Changed CLI parameter from `--gpu-min` to `--gpu-count` for clearer semantics
- Implemented client-side filtering in API to avoid validator changes
- Refactored API handler to reduce code duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GPU provisioning now requires an exact GPU count match for executors.
  - New CLI flag: --gpu-count (replaces --gpu-min). Requests without an exact match will fail.
  - Interactive and SDK flows now use exact GPU configuration for more predictable selection.

- Bug Fixes
  - Compact mode (e.g., “1x A100”) now selects executors with exactly that GPU count.

- Documentation
  - Changelog updated with new flag and examples reflecting exact-count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->