### PR TITLE
fix(install): skip download when current version matches latest

### DIFF
--- a/scripts/web/install.sh
+++ b/scripts/web/install.sh
@@ -412,6 +412,7 @@ check_existing_installation() {
             # Check if versions match
             if [ "$current_version_clean" = "$latest_version_clean" ]; then
                 print_info "You already have the latest version!"
+                exit 0
             elif [ "$current_version_clean" != "unknown" ]; then
                 print_warning "Update available!"
             fi
@@ -430,12 +431,8 @@ check_existing_installation() {
             return 0
         fi
 
-        # Adjust prompt based on version comparison
-        if [ "$current_version_clean" = "$latest_version_clean" ] && [ "$latest_version_clean" != "unable to fetch" ]; then
-            printf "Do you want to reinstall? [y/N]: "
-        else
-            printf "Do you want to update? [y/N]: "
-        fi
+        # Prompt for update
+        printf "Do you want to update? [y/N]: "
 
         if read -r response < /dev/tty 2>/dev/null; then
             case "$response" in


### PR DESCRIPTION
## Summary

Optimizes the install script to avoid unnecessary downloads when the installed version already matches the latest version.

## Changes

- Added `exit 0` after detecting matching versions 
- Removed the "Do you want to reinstall?" prompt for matching versions
- Simplified prompt logic to only ask "Do you want to update?" when there's an actual update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now exits immediately with success when the latest version is already installed.
  * Rate-limit handling unchanged and clearly reported before exiting.

* **Chores**
  * Simplified interactive prompt to always ask: “Do you want to update? [y/N]:”.
  * Removed conditional “reinstall” vs “update” prompt logic.
  * Non-interactive (piped) behavior remains unchanged; only interactive prompts are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->