### PR TITLE
feat(cli): display port mappings in rental tables

### DIFF
--- a/crates/basilica-api/migrations/005_add_port_mappings.sql
+++ b/crates/basilica-api/migrations/005_add_port_mappings.sql
@@ -1,0 +1,10 @@
+-- Add port_mappings column to user_rentals table
+ALTER TABLE user_rentals
+ADD COLUMN IF NOT EXISTS port_mappings JSONB;
+
+-- Add port_mappings column to terminated_user_rentals table
+ALTER TABLE terminated_user_rentals
+ADD COLUMN IF NOT EXISTS port_mappings JSONB;
+
+-- Add index for JSONB queries on port_mappings if needed in the future
+CREATE INDEX IF NOT EXISTS idx_user_rentals_port_mappings ON user_rentals USING GIN (port_mappings);

--- a/crates/basilica-api/src/api/extractors/ownership.rs
+++ b/crates/basilica-api/src/api/extractors/ownership.rs
@@ -19,6 +19,7 @@ struct UserRentalRow {
     rental_id: String,
     user_id: String,
     ssh_credentials: Option<String>,
+    port_mappings: Option<sqlx::types::JsonValue>,
     #[allow(dead_code)]
     created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -32,6 +33,7 @@ pub struct OwnedRental {
     pub rental_id: String,
     pub user_id: String,
     pub ssh_credentials: Option<String>,
+    pub port_mappings: Option<sqlx::types::JsonValue>,
 }
 
 #[async_trait]
@@ -70,6 +72,7 @@ impl FromRequestParts<AppState> for OwnedRental {
                     rental_id: row.rental_id,
                     user_id: row.user_id,
                     ssh_credentials: row.ssh_credentials,
+                    port_mappings: row.port_mappings,
                 })
             }
             None => {
@@ -92,8 +95,8 @@ async fn get_rental_ownership(
 ) -> Result<Option<UserRentalRow>, sqlx::Error> {
     let row = sqlx::query_as::<_, UserRentalRow>(
         r#"
-        SELECT rental_id, user_id, ssh_credentials, created_at
-        FROM user_rentals 
+        SELECT rental_id, user_id, ssh_credentials, port_mappings, created_at
+        FROM user_rentals
         WHERE rental_id = $1 AND user_id = $2
         "#,
     )
@@ -110,22 +113,24 @@ fn get_auth_context_from_parts(parts: &Parts) -> Option<&AuthContext> {
     parts.extensions.get::<AuthContext>()
 }
 
-/// Store a new rental ownership record with optional SSH credentials
+/// Store a new rental ownership record with optional SSH credentials and port mappings
 pub async fn store_rental_ownership(
     db: &PgPool,
     rental_id: &str,
     user_id: &str,
     ssh_credentials: Option<&str>,
+    port_mappings: Option<sqlx::types::JsonValue>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO user_rentals (rental_id, user_id, ssh_credentials)
-        VALUES ($1, $2, $3)
+        INSERT INTO user_rentals (rental_id, user_id, ssh_credentials, port_mappings)
+        VALUES ($1, $2, $3, $4)
         "#,
     )
     .bind(rental_id)
     .bind(user_id)
     .bind(ssh_credentials)
+    .bind(port_mappings)
     .execute(db)
     .await?;
 
@@ -163,6 +168,14 @@ pub struct RentalWithSshStatus {
     pub has_ssh: bool,
 }
 
+/// Struct to hold rental details including SSH status and port mappings
+#[derive(Debug)]
+pub struct RentalWithDetails {
+    pub rental_id: String,
+    pub has_ssh: bool,
+    pub port_mappings: Option<sqlx::types::JsonValue>,
+}
+
 /// Get all rentals owned by a specific user with SSH availability status
 pub async fn get_user_rentals_with_ssh(
     db: &PgPool,
@@ -189,12 +202,40 @@ pub async fn get_user_rentals_with_ssh(
         .collect())
 }
 
+/// Get all rentals owned by a specific user with SSH status and port mappings
+pub async fn get_user_rentals_with_details(
+    db: &PgPool,
+    user_id: &str,
+) -> Result<Vec<RentalWithDetails>, sqlx::Error> {
+    let records: Vec<(String, Option<String>, Option<sqlx::types::JsonValue>)> = sqlx::query_as(
+        r#"
+        SELECT rental_id, ssh_credentials, port_mappings
+        FROM user_rentals
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(records
+        .into_iter()
+        .map(|(rental_id, ssh_credentials, port_mappings)| RentalWithDetails {
+            rental_id,
+            has_ssh: ssh_credentials.is_some(),
+            port_mappings,
+        })
+        .collect())
+}
+
 /// Structure for historical rental records
 #[derive(Debug, FromRow)]
 pub struct TerminatedUserRentalRow {
     pub rental_id: String,
     pub user_id: String,
     pub ssh_credentials: Option<String>,
+    pub port_mappings: Option<sqlx::types::JsonValue>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub stopped_at: chrono::DateTime<chrono::Utc>,
     pub stop_reason: Option<String>,
@@ -213,8 +254,8 @@ pub async fn archive_rental_ownership(
     // First, copy the rental to terminated_user_rentals table
     sqlx::query(
         r#"
-        INSERT INTO terminated_user_rentals (rental_id, user_id, ssh_credentials, created_at, stopped_at, stop_reason)
-        SELECT rental_id, user_id, ssh_credentials, created_at, NOW(), $2
+        INSERT INTO terminated_user_rentals (rental_id, user_id, ssh_credentials, port_mappings, created_at, stopped_at, stop_reason)
+        SELECT rental_id, user_id, ssh_credentials, port_mappings, created_at, NOW(), $2
         FROM user_rentals
         WHERE rental_id = $1
         "#,
@@ -256,7 +297,7 @@ pub async fn get_user_rental_history(
     let records = if let Some(limit) = limit {
         sqlx::query_as::<_, TerminatedUserRentalRow>(
             r#"
-            SELECT rental_id, user_id, ssh_credentials, created_at, stopped_at, stop_reason
+            SELECT rental_id, user_id, ssh_credentials, port_mappings, created_at, stopped_at, stop_reason
             FROM terminated_user_rentals
             WHERE user_id = $1
             ORDER BY stopped_at DESC
@@ -270,7 +311,7 @@ pub async fn get_user_rental_history(
     } else {
         sqlx::query_as::<_, TerminatedUserRentalRow>(
             r#"
-            SELECT rental_id, user_id, ssh_credentials, created_at, stopped_at, stop_reason
+            SELECT rental_id, user_id, ssh_credentials, port_mappings, created_at, stopped_at, stop_reason
             FROM terminated_user_rentals
             WHERE user_id = $1
             ORDER BY stopped_at DESC
@@ -292,7 +333,7 @@ pub async fn get_rental_history_by_id(
 ) -> Result<Option<TerminatedUserRentalRow>, sqlx::Error> {
     let record = sqlx::query_as::<_, TerminatedUserRentalRow>(
         r#"
-        SELECT rental_id, user_id, ssh_credentials, created_at, stopped_at, stop_reason
+        SELECT rental_id, user_id, ssh_credentials, port_mappings, created_at, stopped_at, stop_reason
         FROM terminated_user_rentals
         WHERE rental_id = $1
         "#,
@@ -361,7 +402,7 @@ mod tests {
             .is_none());
 
         // Store ownership with SSH credentials
-        store_rental_ownership(&db, rental_id, user_id, ssh_creds)
+        store_rental_ownership(&db, rental_id, user_id, ssh_creds, None)
             .await
             .expect("Failed to store ownership");
 

--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -3,7 +3,7 @@
 use crate::{
     api::{
         extractors::ownership::{
-            archive_rental_ownership, get_user_rentals_with_ssh, store_rental_ownership,
+            archive_rental_ownership, get_user_rentals_with_details, store_rental_ownership,
             OwnedRental,
         },
         middleware::AuthContext,
@@ -44,10 +44,16 @@ pub async fn get_rental_status(
     let client = &state.validator_client;
     let validator_response = client.get_rental_status(&owned_rental.rental_id).await?;
 
-    // Create extended response with SSH credentials from database
+    // Deserialize port mappings from JSON
+    let port_mappings = owned_rental.port_mappings.and_then(|json| {
+        serde_json::from_value::<Vec<basilica_validator::rental::PortMapping>>(json).ok()
+    });
+
+    // Create extended response with SSH credentials and port mappings from database
     let response_with_ssh = RentalStatusWithSshResponse::from_validator_response(
         validator_response,
         owned_rental.ssh_credentials,
+        port_mappings,
     );
 
     Ok(Json(response_with_ssh))
@@ -160,12 +166,20 @@ pub async fn start_rental(
         .start_rental(validator_request)
         .await?;
 
-    // Store ownership record in database with SSH credentials
+    // Serialize port mappings from validator response
+    let port_mappings_json = if !validator_response.container_info.mapped_ports.is_empty() {
+        Some(serde_json::to_value(&validator_response.container_info.mapped_ports).ok())
+    } else {
+        None
+    };
+
+    // Store ownership record in database with SSH credentials and port mappings
     if let Err(e) = store_rental_ownership(
         &state.db,
         &validator_response.rental_id,
         user_id,
         validator_response.ssh_credentials.as_deref(),
+        port_mappings_json.flatten(),
     )
     .await
     {
@@ -323,17 +337,19 @@ pub async fn list_rentals_validator(
     // Get user ID from auth context (already extracted via Extension)
     let user_id = &auth_context.user_id;
 
-    // Get user's rental IDs with SSH status from database
-    let user_rentals_with_ssh = get_user_rentals_with_ssh(&state.db, user_id)
+    // Get user's rental IDs with SSH status and port mappings from database
+    let user_rentals_with_details = get_user_rentals_with_details(&state.db, user_id)
         .await
         .map_err(|e| crate::error::ApiError::Internal {
             message: format!("Failed to get user rentals: {}", e),
         })?;
 
-    // Create a map for quick lookup of SSH status
+    // Create maps for quick lookup of SSH status and port mappings
     let mut ssh_status_map = std::collections::HashMap::new();
-    for rental in &user_rentals_with_ssh {
+    let mut port_mappings_map = std::collections::HashMap::new();
+    for rental in &user_rentals_with_details {
         ssh_status_map.insert(rental.rental_id.clone(), rental.has_ssh);
+        port_mappings_map.insert(rental.rental_id.clone(), rental.port_mappings.clone());
     }
 
     // Get all rentals from validator
@@ -355,6 +371,15 @@ pub async fn list_rentals_validator(
             None => continue, // User doesn't own this rental
         };
 
+        // Get port mappings from database and deserialize
+        let port_mappings = port_mappings_map
+            .get(&rental.rental_id)
+            .and_then(|json_opt| json_opt.as_ref())
+            .and_then(|json| {
+                serde_json::from_value::<Vec<basilica_validator::rental::PortMapping>>(json.clone())
+                    .ok()
+            });
+
         // Create API rental item with node details from validator response
         api_rentals.push(ApiRentalListItem {
             rental_id: rental.rental_id,
@@ -369,6 +394,7 @@ pub async fn list_rentals_validator(
             cpu_specs: rental.cpu_specs,
             location: rental.location,
             network_speed: rental.network_speed,
+            port_mappings,
         });
     }
 

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -13,8 +13,7 @@ use crate::CliError;
 use basilica_common::utils::{parse_env_vars, parse_port_mappings};
 use basilica_sdk::types::{
     GpuRequirements, ListAvailableNodesQuery, ListRentalsQuery, LocationProfile, NodeSelection,
-    RentalState, RentalStatusResponse, ResourceRequirementsRequest, SshAccess,
-    StartRentalApiRequest,
+    RentalState, ResourceRequirementsRequest, SshAccess, StartRentalApiRequest,
 };
 use basilica_sdk::ApiError;
 use basilica_validator::gpu::categorization::GpuCategory;
@@ -291,6 +290,21 @@ pub async fn handle_up(
         response.rental_id
     ));
 
+    // Display port mappings if available
+    if !response.container_info.mapped_ports.is_empty() {
+        println!("\nPort Mappings:");
+        for port_mapping in &response.container_info.mapped_ports {
+            if port_mapping.container_port == 22 {
+                // SSH port is already shown in SSH connection instructions
+                continue;
+            }
+            println!(
+                "  Container Port {} → Host Port {} ({})",
+                port_mapping.container_port, port_mapping.host_port, port_mapping.protocol
+            );
+        }
+    }
+
     // Handle SSH based on options
     if options.no_ssh {
         // SSH disabled entirely, nothing to do
@@ -437,15 +451,7 @@ pub async fn handle_status(
     if json {
         json_output(&status)?;
     } else {
-        // Convert to validator's RentalStatusResponse for display (without SSH credentials)
-        let display_status = RentalStatusResponse {
-            rental_id: status.rental_id,
-            status: status.status,
-            node: status.node,
-            created_at: status.created_at,
-            updated_at: status.updated_at,
-        };
-        display_rental_status(&display_status);
+        display_rental_status_with_details(&status);
     }
 
     Ok(())
@@ -1016,7 +1022,7 @@ fn split_remote_path(path: &str) -> (Option<String>, String) {
     }
 }
 
-fn display_rental_status(status: &RentalStatusResponse) {
+fn display_rental_status_with_details(status: &basilica_sdk::types::RentalStatusWithSshResponse) {
     println!("Rental Status: {}", status.rental_id);
     println!("  Status: {:?}", status.status);
     println!("  Node: {}", status.node.id);
@@ -1029,20 +1035,26 @@ fn display_rental_status(status: &RentalStatusResponse) {
         status.updated_at.format("%Y-%m-%d %H:%M:%S UTC")
     );
 
-    // println!("\nNode Details:");
-    // println!("  GPUs: {} available", status.node.gpu_specs.len());
-    // for gpu in &status.node.gpu_specs {
-    //     println!("    - {} ({} GB)", gpu.name, gpu.memory_gb);
-    // }
-    // println!(
-    //     "  CPU: {} cores ({})",
-    //     status.node.cpu_specs.cores, status.node.cpu_specs.model
-    // );
-    // println!("  Memory: {} GB", status.node.cpu_specs.memory_gb);
-
-    // if let Some(location) = &status.node.location {
-    //     println!("  Location: {location}");
-    // }
+    // Display port mappings if available
+    if let Some(ref port_mappings) = status.port_mappings {
+        if !port_mappings.is_empty() {
+            println!("\nPort Mappings:");
+            for port_mapping in port_mappings {
+                if port_mapping.container_port == 22 {
+                    // SSH port
+                    println!(
+                        "  SSH: Container Port {} → Host Port {} ({})",
+                        port_mapping.container_port, port_mapping.host_port, port_mapping.protocol
+                    );
+                } else {
+                    println!(
+                        "  Container Port {} → Host Port {} ({})",
+                        port_mapping.container_port, port_mapping.host_port, port_mapping.protocol
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Display quick start commands after ps output

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -124,6 +124,8 @@ pub fn display_rental_items(
             state: String,
             #[tabled(rename = "SSH")]
             ssh: String,
+            #[tabled(rename = "Ports")]
+            ports: String,
             #[tabled(rename = "Image")]
             image: String,
             #[tabled(rename = "CPU")]
@@ -175,12 +177,16 @@ pub fn display_rental_items(
                 // Format SSH availability
                 let ssh = if rental.has_ssh { "✓" } else { "✗" };
 
+                // Format port mappings (show all ports in detailed view)
+                let ports = format_port_mappings(&rental.port_mappings, None);
+
                 DetailedRentalRowWithIds {
                     rental_id: rental.rental_id.clone(),
                     node_id,
                     gpu,
                     state: rental.state.to_string(),
                     ssh: ssh.to_string(),
+                    ports,
                     image: rental.container_image.clone(),
                     cpu,
                     ram,
@@ -203,6 +209,8 @@ pub fn display_rental_items(
             state: String,
             #[tabled(rename = "SSH")]
             ssh: String,
+            #[tabled(rename = "Ports")]
+            ports: String,
             #[tabled(rename = "Image")]
             image: String,
             #[tabled(rename = "CPU")]
@@ -246,10 +254,14 @@ pub fn display_rental_items(
                 // Format SSH availability
                 let ssh = if rental.has_ssh { "✓" } else { "✗" };
 
+                // Format port mappings (show up to 2-3 ports)
+                let ports = format_port_mappings(&rental.port_mappings, Some(2));
+
                 DetailedRentalRow {
                     gpu,
                     state: rental.state.to_string(),
                     ssh: ssh.to_string(),
+                    ports,
                     image: rental.container_image.clone(),
                     cpu,
                     ram,
@@ -300,6 +312,32 @@ pub fn display_rental_items(
     }
 
     Ok(())
+}
+
+/// Helper function to format port mappings
+fn format_port_mappings(
+    port_mappings: &Option<Vec<basilica_validator::rental::PortMapping>>,
+    max_count: Option<usize>,
+) -> String {
+    match port_mappings {
+        None => "-".to_string(),
+        Some(ports) if ports.is_empty() => "-".to_string(),
+        Some(ports) => {
+            let formatted_ports: Vec<String> = ports
+                .iter()
+                .map(|p| format!("{}→{}", p.container_port, p.host_port))
+                .collect();
+
+            match max_count {
+                Some(max) if formatted_ports.len() > max => {
+                    let shown = &formatted_ports[..max];
+                    let remaining = formatted_ports.len() - max;
+                    format!("{}, +{} more", shown.join(", "), remaining)
+                }
+                _ => formatted_ports.join(", "),
+            }
+        }
+    }
 }
 
 /// Helper function to format GPU info

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -84,6 +84,9 @@ pub struct ApiRentalListItem {
     /// Optional network speed information
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_speed: Option<NetworkSpeedInfo>,
+    /// Port mappings for this rental
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port_mappings: Option<Vec<basilica_validator::rental::PortMapping>>,
 }
 
 /// API list rentals response with GPU information
@@ -170,6 +173,10 @@ pub struct RentalStatusWithSshResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh_credentials: Option<String>,
 
+    /// Port mappings (from database)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port_mappings: Option<Vec<basilica_validator::rental::PortMapping>>,
+
     /// Creation timestamp
     pub created_at: chrono::DateTime<chrono::Utc>,
 
@@ -178,16 +185,18 @@ pub struct RentalStatusWithSshResponse {
 }
 
 impl RentalStatusWithSshResponse {
-    /// Create from validator response and database SSH credentials
+    /// Create from validator response, database SSH credentials, and port mappings
     pub fn from_validator_response(
         response: ValidatorRentalStatusResponse,
         ssh_credentials: Option<String>,
+        port_mappings: Option<Vec<basilica_validator::rental::PortMapping>>,
     ) -> Self {
         Self {
             rental_id: response.rental_id,
             status: response.status,
             node: response.node,
             ssh_credentials,
+            port_mappings,
             created_at: response.created_at,
             updated_at: response.updated_at,
         }


### PR DESCRIPTION
## Summary
Display port mappings in CLI rental list and status commands.

## Changes
- **Database**: Added `port_mappings` JSONB column to `user_rentals` and `terminated_user_rentals` tables
- **API**: Extended rental list endpoint to fetch and return port mappings from database
- **SDK**: Added `port_mappings` field to `ApiRentalListItem` type
- **CLI**: Display port mappings in rental tables:
  - `basilica up`: Shows port mappings after rental creation
  - `basilica status`: Shows all port mappings
  - `basilica ps`: Shows port mappings (up to 2 in standard view)
  - `basilica ps --detailed`: Shows all port mappings
  - `basilica ps --compact`: No port mappings (minimal view)

## Example Output
```
┌──────────┬────────┬─────┬──────────────────┬────────────┐
│ GPU      │ State  │ SSH │ Ports            │ Created    │
├──────────┼────────┼─────┼──────────────────┼────────────┤
│ 1x H100  │ Active │ ✓   │ 22→52234, 80→80  │ 10-04 12:00│
└──────────┴────────┴─────┴──────────────────┴────────────┘
```