### PR TITLE
feat(cli): separate authentication for development environment

### DIFF
--- a/crates/basilica-cli/src/auth/token_store.rs
+++ b/crates/basilica-cli/src/auth/token_store.rs
@@ -28,8 +28,7 @@ impl TokenStore {
         })?;
 
         // Detect environment based on Auth0 domain
-        let current_domain = basilica_common::auth0_domain();
-        let auth_file_name = if current_domain == basilica_common::auth_constants::AUTH0_DOMAIN {
+        let auth_file_name = if basilica_common::is_development_environment() {
             "auth.dev.json"
         } else {
             "auth.json"

--- a/crates/basilica-cli/src/config/mod.rs
+++ b/crates/basilica-cli/src/config/mod.rs
@@ -40,8 +40,7 @@ pub struct ApiConfig {
 impl Default for ApiConfig {
     fn default() -> Self {
         // Use localhost for development environment, production URL otherwise
-        let current_domain = basilica_common::auth0_domain();
-        let base_url = if current_domain == basilica_common::auth_constants::AUTH0_DOMAIN {
+        let base_url = if basilica_common::is_development_environment() {
             "http://localhost:8000".to_string()
         } else {
             "https://api.basilica.ai".to_string()

--- a/crates/basilica-common/src/auth_constants.rs
+++ b/crates/basilica-common/src/auth_constants.rs
@@ -53,3 +53,24 @@ pub const AUTH_CALLBACK_PORTS: &[u16] = &[34521, 45632, 23457, 51234, 38901];
 pub fn auth0_callback_ports() -> &'static [u16] {
     AUTH_CALLBACK_PORTS
 }
+
+/// Check if running in development environment
+///
+/// Returns `true` when the current Auth0 domain matches the compile-time default domain,
+/// indicating a development environment. Returns `false` when a different domain is
+/// configured via the `BASILICA_AUTH0_DOMAIN` environment variable.
+///
+/// # Examples
+///
+/// ```
+/// use basilica_common::is_development_environment;
+///
+/// if is_development_environment() {
+///     println!("Running in development mode");
+/// } else {
+///     println!("Running with custom Auth0 domain");
+/// }
+/// ```
+pub fn is_development_environment() -> bool {
+    auth0_domain() == AUTH0_DOMAIN
+}


### PR DESCRIPTION
## Summary
- Separate credential storage by environment (auth.dev.json vs auth.json)
- Default to localhost API in development environment
- Auto-detect environment based on Auth0 domain

## Benefits
Simplifies local development by automatically using localhost API and separate credentials when using the default Auth0 domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The CLI now automatically detects development vs. production environments.
  - In development, it connects to a local API endpoint; in production, it uses the public API.
  - Auth tokens are stored separately per environment (development vs. production), preventing cross-environment mix-ups and keeping sessions isolated.
  - Improves safety and convenience when switching between development and production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->