### PR TITLE
refactor(cli): standardize credit display to 2 decimal places

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/balance.rs
+++ b/crates/basilica-cli/src/cli/handlers/balance.rs
@@ -5,7 +5,7 @@ use console::style;
 
 use crate::{
     error::CliError,
-    output::json_output,
+    output::{format_credits, json_output},
     progress::{complete_spinner_and_clear, complete_spinner_error, create_spinner},
 };
 
@@ -38,17 +38,17 @@ fn display_balance(balance: &basilica_sdk::BalanceResponse) {
     println!(
         "  {}: {} credits",
         style("Available").cyan(),
-        style(&balance.available).green().bold()
+        style(format_credits(&balance.available)).green().bold()
     );
     println!(
         "  {}: {} credits",
         style("Reserved").cyan(),
-        style(&balance.reserved).yellow()
+        style(format_credits(&balance.reserved)).yellow()
     );
     println!(
         "  {}: {} credits",
         style("Total").cyan(),
-        style(&balance.total).bold()
+        style(format_credits(&balance.total)).bold()
     );
     println!();
     println!(

--- a/crates/basilica-cli/src/output/mod.rs
+++ b/crates/basilica-cli/src/output/mod.rs
@@ -5,6 +5,7 @@ pub mod table_output;
 
 use color_eyre::eyre::{eyre, Result};
 use console::style;
+use rust_decimal::Decimal;
 use serde::Serialize;
 
 /// Output data as JSON
@@ -49,4 +50,21 @@ pub fn compress_path(path: &std::path::Path) -> String {
         }
     }
     path.display().to_string()
+}
+
+/// Format credit value with 2 decimal places
+///
+/// Parses a string credit value as Decimal and formats it with exactly 2 decimal places.
+/// Falls back to the original string if parsing fails.
+///
+/// # Examples
+/// ```
+/// let formatted = format_credits("1234.56789");
+/// assert_eq!(formatted, "1234.57");
+/// ```
+pub fn format_credits(value: &str) -> String {
+    value
+        .parse::<Decimal>()
+        .map(|d| format!("{:.2}", d))
+        .unwrap_or_else(|_| value.to_string())
 }

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -1,6 +1,9 @@
 //! Table formatting for CLI output
 
-use crate::error::{CliError, Result};
+use crate::{
+    error::{CliError, Result},
+    output::format_credits,
+};
 use basilica_api::country_mapping::get_country_name_from_code;
 use basilica_common::LocationProfile;
 use basilica_sdk::{
@@ -837,7 +840,7 @@ pub fn display_pricing_table(
         println!(
             "{}: {} credits",
             style("Your Balance").cyan(),
-            style(&balance.available).green().bold()
+            style(format_credits(&balance.available)).green().bold()
         );
     }
 


### PR DESCRIPTION
## Summary

Standardizes all credit displays in the CLI to show exactly 2 decimal places for consistency and readability.

## Before/After

**Before:**
```
Available: 5774.309307 credits
Reserved: 4320 credits
Total: 10094.309307 credits
```

**After:**
```
Available: 5772.92 credits
Reserved: 4320.00 credits
Total: 10092.92 credits
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved balance display formatting to consistently show credit amounts with exactly two decimal places across all output modes for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->