### PR TITLE
refactor(cli): limit usage data points table to last 10 entries

### DIFF
--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -1030,9 +1030,14 @@ pub fn display_rental_usage_detail(usage: &RentalUsageResponse) -> Result<()> {
             cost: String,
         }
 
+        const MAX_POINTS: usize = 10;
+        let total_points = usage.data_points.len();
+        let start_index = total_points.saturating_sub(MAX_POINTS);
+
         let rows: Vec<UsageDataRow> = usage
             .data_points
             .iter()
+            .skip(start_index)
             .map(|dp| UsageDataRow {
                 timestamp: dp.timestamp.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
                 cpu_percent: format!("{:.1}%", dp.cpu_percent),
@@ -1046,6 +1051,16 @@ pub fn display_rental_usage_detail(usage: &RentalUsageResponse) -> Result<()> {
         let mut table = Table::new(&rows);
         table.with(Style::modern());
         println!("{}", table);
+        if total_points > MAX_POINTS {
+            println!(
+                "{}",
+                style(format!(
+                    "Showing last {} of {} data points.",
+                    MAX_POINTS, total_points
+                ))
+                .dim()
+            );
+        }
         println!();
     } else {
         println!("{}", style("No usage data points available").yellow());


### PR DESCRIPTION
## Summary

Improve the readability of the `basilica usage <rental-id>` command output by limiting the usage data points table to display only the last 10 entries instead of all historical data points. When more than 10 data points exist, a dimmed message indicates the number shown vs. total available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Usage detail views now display a maximum of 10 recent data points for improved readability and performance
  * When additional historical data exists, a notice indicates how many of the latest points are shown relative to the total available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->