### PR TITLE
fix(api): improve rental health check resilience

### DIFF
--- a/crates/basilica-api/src/config/mod.rs
+++ b/crates/basilica-api/src/config/mod.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 /// Rental health check interval in seconds
-const RENTAL_HEALTH_CHECK_INTERVAL_SECS: u64 = 5;
+const RENTAL_HEALTH_CHECK_INTERVAL_SECS: u64 = 60;
 
 /// Bittensor integration configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/basilica-api/src/server.rs
+++ b/crates/basilica-api/src/server.rs
@@ -93,28 +93,13 @@ async fn process_rental_health_check(
             }
         }
         Err(e) => {
-            // Check if error indicates rental doesn't exist (404)
-            if e.to_string().contains("404") || e.to_string().contains("NOT_FOUND") {
-                // Rental not found on validator, archive it
-                if let Err(archive_err) = archive_rental_ownership(
-                    db,
-                    rental_id,
-                    Some("Health check: rental not found on validator"),
-                )
-                .await
-                {
-                    tracing::error!(
-                        "Failed to archive missing rental {}: {}",
-                        rental_id,
-                        archive_err
-                    );
-                } else {
-                    tracing::info!("Health check: Archived missing rental {}", rental_id);
-                }
-            } else {
-                // Log other errors at debug level to avoid spam
-                tracing::debug!("Health check failed for rental {}: {}", rental_id, e);
-            }
+            // Validator unavailable or having issues - don't change rental state
+            // The validator is the source of truth and will report actual status when available
+            tracing::warn!(
+                "Health check failed for rental {} (validator may be unavailable): {}",
+                rental_id,
+                e
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes overly aggressive rental health checking:
- Increase health check interval from 5s to 60s (reduces API load)
- Don't archive rentals on validator errors - only when validator explicitly reports Terminated/Failed status

## Motivation

Previous behavior would incorrectly archive rentals during transient validator issues. The validator is the source of truth for rental state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended rental health check interval to 60 seconds
  * Modified health check error handling to emit warnings instead of archiving missing rentals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->