### PR TITLE
fix(billing): apply dynamic pricing in list_packages() method

### DIFF
--- a/crates/basilica-billing/src/storage/packages.rs
+++ b/crates/basilica-billing/src/storage/packages.rs
@@ -524,11 +524,40 @@ impl PackageRepository for SqlPackageRepository {
             })?;
 
         if let Some(row) = row {
-            let package = Self::row_to_billing_package(&row)?;
+            let mut package = Self::row_to_billing_package(&row)?;
             info!(
                 "Found matching package {} for GPU model {}",
                 package.id, gpu_model
             );
+
+            // Apply dynamic pricing if pricing service is configured
+            // The pricing service handles the enabled/disabled check internally
+            if let Some(pricing_service) = &self.pricing_service {
+                match pricing_service
+                    .get_price_with_fallback(&package.gpu_model, package.hourly_rate.as_decimal())
+                    .await
+                {
+                    Ok(dynamic_price) => {
+                        debug!(
+                            "Package {}: using price ${}/hr for {} (static was ${}/hr)",
+                            package.id,
+                            dynamic_price,
+                            package.gpu_model,
+                            package.hourly_rate.as_decimal()
+                        );
+                        package.hourly_rate = CreditBalance::from_decimal(dynamic_price);
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to get price for {}: {}. Using static price ${}/hr",
+                            package.gpu_model,
+                            e,
+                            package.hourly_rate.as_decimal()
+                        );
+                    }
+                }
+            }
+
             Ok(package)
         } else {
             warn!(


### PR DESCRIPTION
## Problem

The CLI (`basilica ls` and `basilica ps`) was showing static prices instead of dynamic market-based prices.

## Root Cause

`list_packages()` returned static database prices, while `get_package()` correctly applied dynamic pricing. This inconsistency caused the CLI to display outdated pricing.

## Solution

Applied the same dynamic pricing logic from `get_package()` to `list_packages()`, with graceful fallback to static prices if dynamic pricing fails.

## Changes

- Updated `list_packages()` in `crates/basilica-billing/src/storage/packages.rs`
- Added pricing service integration with fallback handling
- Added debug logging for pricing decisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package pricing is now dynamically updated from the pricing service when packages are retrieved.

* **Improvements**
  * Real-time price fetching ensures the most current hourly rates are shown.
  * Pricing gracefully falls back to static rates if the pricing service is unavailable.
  * Enhanced logging and error handling around pricing updates to surface pricing changes and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->