### PR TITLE
fix(billing): correct GPU count and pricing calculations for multi-GPU rentals

### DIFF
--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -321,10 +321,10 @@ pub async fn start_rental(
         let markup_multiplier = 1.0 + (state.pricing_config.community_markup_percent / 100.0);
         let marked_up_price = base_price_per_gpu * markup_multiplier;
 
+        // Get total GPU count from the resource spec (each GPU is a separate entry with count=1)
         let gpu_count = resource_spec
             .as_ref()
-            .and_then(|spec| spec.gpus.first())
-            .map(|gpu| gpu.count)
+            .map(|spec| spec.gpus.len() as u32)
             .unwrap_or(1);
 
         let track_request = TrackRentalRequest {

--- a/crates/basilica-api/src/api/routes/secure_cloud.rs
+++ b/crates/basilica-api/src/api/routes/secure_cloud.rs
@@ -212,22 +212,24 @@ pub async fn list_secure_cloud_rentals(
                     1.0 + (state.pricing_config.secure_cloud_markup_percent / 100.0);
 
                 // Try to find the offering to get GPU details and pricing
-                let (gpu_type, gpu_count, hourly_cost) =
-                    if let Some(offering) = offerings_map.get(offering_id.as_str()) {
-                        let base_rate = offering.hourly_rate_per_gpu.to_f64().unwrap_or(0.0);
-                        let gpu_count = offering.gpu_count;
-                        let hourly_cost = base_rate * markup_multiplier;
+                let (gpu_type, gpu_count, hourly_cost) = if let Some(offering) =
+                    offerings_map.get(offering_id.as_str())
+                {
+                    let base_rate = offering.hourly_rate_per_gpu.to_f64().unwrap_or(0.0);
+                    let gpu_count = offering.gpu_count;
+                    // Total hourly cost = per-GPU price × markup × number of GPUs
+                    let hourly_cost = base_rate * markup_multiplier * f64::from(gpu_count.max(1));
 
-                        (offering.gpu_type.to_string(), gpu_count, hourly_cost)
-                    } else {
-                        // Fallback if offering not found (e.g., offering expired)
-                        tracing::warn!(
-                            "Offering {} not found for rental {}, using defaults",
-                            offering_id,
-                            rental_id
-                        );
-                        ("unknown".to_string(), 0, 0.0)
-                    };
+                    (offering.gpu_type.to_string(), gpu_count, hourly_cost)
+                } else {
+                    // Fallback if offering not found (e.g., offering expired)
+                    tracing::warn!(
+                        "Offering {} not found for rental {}, using defaults",
+                        offering_id,
+                        rental_id
+                    );
+                    ("unknown".to_string(), 0, 0.0)
+                };
 
                 // Use resource specs from database JOIN (already available)
                 let vcpu_count = db_vcpu_count.map(|v| v as u32);

--- a/crates/basilica-miner/src/node_manager.rs
+++ b/crates/basilica-miner/src/node_manager.rs
@@ -34,8 +34,8 @@ pub struct NodeConfig {
     pub port: u16,
     /// SSH username for validator access
     pub username: String,
-    /// Hourly rental rate in dollars (e.g., 2.50 for $2.50/hour per GPU)
-    pub hourly_rate_dollars: f64,
+    /// Hourly rental rate in dollars per GPU (e.g., 2.50 for $2.50/hour/GPU)
+    pub hourly_rate_per_gpu: f64,
     /// Additional SSH options
     pub additional_opts: Option<String>,
 }
@@ -404,7 +404,7 @@ mod tests {
             host: "192.168.1.100".to_string(),
             port: 22,
             username: "basilica".to_string(),
-            hourly_rate_dollars: 2.5,
+            hourly_rate_per_gpu: 2.5,
             additional_opts: None,
         };
 

--- a/crates/basilica-miner/src/validator_comms.rs
+++ b/crates/basilica-miner/src/validator_comms.rs
@@ -346,7 +346,7 @@ impl MinerDiscovery for MinerDiscoveryService {
             .map(|registered_node| {
                 // Convert hourly rate from dollars to cents for network transmission
                 let hourly_rate_cents =
-                    (registered_node.config.hourly_rate_dollars * 100.0).round() as u32;
+                    (registered_node.config.hourly_rate_per_gpu * 100.0).round() as u32;
 
                 basilica_protocol::miner_discovery::NodeConnectionDetails {
                     node_id: registered_node.node_id,

--- a/crates/basilica-miner/tests/unit/node_manager_tests.rs
+++ b/crates/basilica-miner/tests/unit/node_manager_tests.rs
@@ -11,7 +11,7 @@ async fn test_node_registration() {
         host: "192.168.1.100".to_string(),
         port: 22,
         username: "basilica".to_string(),
-        hourly_rate_dollars: 2.5,
+        hourly_rate_per_gpu: 2.5,
         additional_opts: None,
     };
 
@@ -41,7 +41,7 @@ async fn test_list_nodes() {
                 host: "192.168.1.100".to_string(),
                 port: 22,
                 username: "basilica".to_string(),
-                hourly_rate_dollars: 2.5,
+                hourly_rate_per_gpu: 2.5,
                 additional_opts: None,
             },
         )
@@ -55,7 +55,7 @@ async fn test_list_nodes() {
                 host: "192.168.1.101".to_string(),
                 port: 22,
                 username: "basilica".to_string(),
-                hourly_rate_dollars: 2.5,
+                hourly_rate_per_gpu: 2.5,
                 additional_opts: None,
             },
         )
@@ -69,7 +69,7 @@ async fn test_list_nodes() {
                 host: "192.168.1.102".to_string(),
                 port: 22,
                 username: "basilica".to_string(),
-                hourly_rate_dollars: 2.5,
+                hourly_rate_per_gpu: 2.5,
                 additional_opts: None,
             },
         )
@@ -98,7 +98,7 @@ async fn test_unregister_node() {
                 host: "192.168.1.100".to_string(),
                 port: 22,
                 username: "basilica".to_string(),
-                hourly_rate_dollars: 2.5,
+                hourly_rate_per_gpu: 2.5,
                 additional_opts: None,
             },
         )


### PR DESCRIPTION
## Summary
- Fix GPU count calculation in rentals to use total GPU count (`spec.gpus.len()`) instead of the first GPU's count field
- Fix secure cloud hourly cost calculation to multiply by GPU count for accurate multi-GPU pricing
- Rename `hourly_rate_dollars` to `hourly_rate_per_gpu` for semantic clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected GPU count calculation in rental pricing to accurately derive from total GPUs in resource specifications
  * Fixed hourly cost computation for secure cloud rentals to properly account for GPU quantity and markup multiplier

* **Tests**
  * Updated test cases to reflect pricing calculation changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->