### PR TITLE
refactor(cli): simplify rental cost display by using API-provided costs

### DIFF
--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -600,6 +600,43 @@ pub async fn list_rentals_validator(
             message: format!("Failed to list rentals: {e}"),
         })?;
 
+    // Get cost data from billing service for this user's rentals
+    // - current_cost: accumulated total from billing.rentals.total_cost column
+    // - hourly_cost: calculated from base_price_per_gpu * gpu_count in CommunityCloudData
+    let cost_map: std::collections::HashMap<String, (String, Option<f64>)> =
+        if let Some(ref billing_client) = state.billing_client {
+            match billing_client
+                .get_active_rentals_for_user(user_id, None, None)
+                .await
+            {
+                Ok(response) => response
+                    .rentals
+                    .into_iter()
+                    .map(|r| {
+                        // Extract hourly rate from community cloud data if available
+                        let hourly_rate = match &r.cloud_type {
+                            Some(
+                                basilica_protocol::billing::active_rental::CloudType::Community(
+                                    data,
+                                ),
+                            ) => Some(data.base_price_per_gpu * data.gpu_count as f64),
+                            _ => None,
+                        };
+                        (
+                            format!("rental-{}", r.rental_id),
+                            (r.current_cost, hourly_rate),
+                        )
+                    })
+                    .collect(),
+                Err(e) => {
+                    tracing::warn!("Failed to fetch billing costs, will use None: {}", e);
+                    std::collections::HashMap::new()
+                }
+            }
+        } else {
+            std::collections::HashMap::new()
+        };
+
     // Filter to only include user's rentals and use node details from validator response
     let mut api_rentals = Vec::new();
 
@@ -619,6 +656,12 @@ pub async fn list_rentals_validator(
                     .ok()
             });
 
+        // Get cost info from billing (graceful degradation if unavailable)
+        let (accumulated_cost, hourly_cost) = cost_map
+            .get(&rental.rental_id)
+            .map(|(cost, rate)| (Some(cost.clone()), *rate))
+            .unwrap_or((None, None));
+
         // Create API rental item with node details from validator response
         api_rentals.push(ApiRentalListItem {
             rental_id: rental.rental_id,
@@ -634,6 +677,8 @@ pub async fn list_rentals_validator(
             location: rental.location,
             network_speed: rental.network_speed,
             port_mappings,
+            hourly_cost,
+            accumulated_cost,
         });
     }
 

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -431,10 +431,6 @@ pub struct PsFilters {
     /// Use detailed view (shows rental and node IDs)
     #[arg(long)]
     pub detailed: bool,
-
-    /// Show all rental history instead of just active rentals
-    #[arg(long)]
-    pub history: bool,
 }
 
 /// Options for viewing logs

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -25,7 +25,6 @@ use color_eyre::Section;
 use console::style;
 use reqwest::StatusCode;
 use rust_decimal::prelude::ToPrimitive;
-use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
@@ -1010,115 +1009,38 @@ pub async fn handle_ps(
     // Branch based on compute category
     match compute_category {
         Some(ComputeCategory::CommunityCloud) => {
-            // Existing community cloud logic
-            let spinner = if filters.history {
-                create_spinner("Fetching rental history...")
-            } else {
-                create_spinner("Fetching active rentals...")
-            };
+            let spinner = create_spinner("Fetching active rentals...");
 
             // Build query from filters - default to "active" if no status specified
             let query = Some(ListRentalsQuery {
-                status: if filters.history {
-                    None // No filter - get all rentals
-                } else {
-                    filters.status.or(Some(RentalState::Active)) // Default to active
-                },
+                status: filters.status.or(Some(RentalState::Active)),
                 gpu_type: filters.gpu_type.clone(),
                 min_gpu_count: filters.min_gpu_count,
             });
 
-            // Fetch rentals and usage history in parallel
-            // Use a reasonable limit for usage history to cover active rentals
-            // Add 5-second timeout for rentals to handle unresponsive validator
+            // Fetch rentals with 5-second timeout to handle unresponsive validator
             let rentals_future = api_client.list_rentals(query);
-            let (rentals_result, usage_result) = tokio::join!(
-                async {
-                    match timeout(Duration::from_secs(5), rentals_future).await {
-                        Ok(result) => result,
-                        Err(_) => {
-                            warn!("Validator request timed out after 5 seconds");
-                            Err(ApiError::Timeout)
-                        }
-                    }
-                },
-                api_client.list_usage_history(Some(100), None)
-            );
+            let rentals_result = match timeout(Duration::from_secs(5), rentals_future).await {
+                Ok(result) => result,
+                Err(_) => {
+                    warn!("Validator request timed out after 5 seconds");
+                    Err(ApiError::Timeout)
+                }
+            };
 
             let rentals_list = rentals_result.inspect_err(|_| {
                 complete_spinner_error(spinner.clone(), "Failed to load rentals")
             })?;
 
-            // Build usage map: rental_id -> usage record
-            // If usage fetch fails, continue with empty map (graceful degradation)
-            let usage_map: HashMap<String, basilica_sdk::types::RentalUsageRecord> = usage_result
-                .ok()
-                .map(|usage| {
-                    usage
-                        .rentals
-                        .into_iter()
-                        .map(|record| (record.rental_id.clone(), record))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // Pricing is now included in usage records (hourly_rate field)
-            let pricing_map: HashMap<String, String> = HashMap::new();
-
             complete_spinner_and_clear(spinner);
 
             if json {
                 json_output(&rentals_list)?;
-            } else if filters.history {
-                // History mode: use usage_map data and filter out active rentals
-                // Create a set of active rental IDs from the current rentals list
-                let active_rental_ids: std::collections::HashSet<String> = rentals_list
-                    .rentals
-                    .iter()
-                    .filter(|r| {
-                        // Only include rentals that are currently active or provisioning
-                        matches!(r.state, RentalState::Active | RentalState::Provisioning)
-                    })
-                    .map(|r| {
-                        // Strip "rental-" prefix to match usage_map format
-                        r.rental_id
-                            .strip_prefix("rental-")
-                            .unwrap_or(&r.rental_id)
-                            .to_string()
-                    })
-                    .collect();
-
-                // Filter usage_map to exclude active rentals
-                let historical_rentals: Vec<_> = usage_map
-                    .values()
-                    .filter(|r| !active_rental_ids.contains(&r.rental_id))
-                    .collect();
-
-                table_output::display_usage_history_for_ps(&historical_rentals, filters.detailed)?;
-
-                let total_cost: Decimal = historical_rentals
-                    .iter()
-                    .filter_map(|r| r.current_cost.parse::<Decimal>().ok())
-                    .sum();
-
-                println!();
-                println!(
-                    "{}: {}",
-                    style("Total Cost").cyan(),
-                    style(format!("${:.2}", total_cost)).green().bold()
-                );
-
-                println!("\nTotal: {} rentals", historical_rentals.len());
-
-                display_ps_quick_start_commands();
             } else {
                 table_output::display_rental_items(
                     &rentals_list.rentals[..],
                     !filters.compact,
                     filters.detailed,
-                    &usage_map,
-                    &pricing_map,
-                    false,
                 )?;
 
                 println!("\nTotal: {} active rentals", rentals_list.rentals.len());
@@ -1127,12 +1049,7 @@ pub async fn handle_ps(
             }
         }
         Some(ComputeCategory::SecureCloud) => {
-            // Secure cloud rentals logic
-            let spinner = if filters.history {
-                create_spinner("Fetching rental history...")
-            } else {
-                create_spinner("Fetching active rentals...")
-            };
+            let spinner = create_spinner("Fetching active rentals...");
 
             // Fetch secure cloud rentals
             let rentals_result = api_client.list_secure_cloud_rentals().await;
@@ -1146,22 +1063,12 @@ pub async fn handle_ps(
             if json {
                 json_output(&rentals_list)?;
             } else {
-                // Filter rentals based on history flag
-                let rentals_to_display: Vec<_> = if filters.history {
-                    // Show stopped rentals only
-                    rentals_list
-                        .rentals
-                        .iter()
-                        .filter(|r| r.stopped_at.is_some())
-                        .collect()
-                } else {
-                    // Show active/running rentals only
-                    rentals_list
-                        .rentals
-                        .iter()
-                        .filter(|r| r.stopped_at.is_none())
-                        .collect()
-                };
+                // Show active/running rentals only
+                let rentals_to_display: Vec<_> = rentals_list
+                    .rentals
+                    .iter()
+                    .filter(|r| r.stopped_at.is_none())
+                    .collect();
 
                 table_output::display_secure_cloud_rentals(
                     &rentals_to_display,
@@ -1169,12 +1076,10 @@ pub async fn handle_ps(
                     filters.detailed,
                 )?;
 
-                let label = if filters.history {
-                    "historical secure cloud rentals"
-                } else {
-                    "active secure cloud rentals"
-                };
-                println!("\nTotal: {} {}", rentals_to_display.len(), label);
+                println!(
+                    "\nTotal: {} active secure cloud rentals",
+                    rentals_to_display.len()
+                );
 
                 display_ps_quick_start_commands();
             }
@@ -1184,46 +1089,30 @@ pub async fn handle_ps(
             let spinner = create_spinner("Fetching rentals...");
 
             // Fetch both rental types in parallel
+            let query = Some(ListRentalsQuery {
+                status: filters.status.or(Some(RentalState::Active)),
+                gpu_type: filters.gpu_type.clone(),
+                min_gpu_count: filters.min_gpu_count,
+            });
+
             let (community_result, secure_result) = tokio::join!(
-                // Community cloud: rentals + usage
+                // Community cloud with 5-second timeout
                 async {
-                    let query = Some(ListRentalsQuery {
-                        status: if filters.history {
-                            None // No filter - get all rentals
-                        } else {
-                            filters.status.or(Some(RentalState::Active)) // Default to active
-                        },
-                        gpu_type: filters.gpu_type.clone(),
-                        min_gpu_count: filters.min_gpu_count,
-                    });
-
-                    // Add 5-second timeout for rentals to handle unresponsive validator
                     let rentals_future = api_client.list_rentals(query);
-                    let (rentals_result, usage_result) = tokio::join!(
-                        async {
-                            match timeout(Duration::from_secs(5), rentals_future).await {
-                                Ok(result) => result,
-                                Err(_) => {
-                                    warn!("Validator request timed out after 5 seconds");
-                                    Err(ApiError::Timeout)
-                                }
-                            }
-                        },
-                        api_client.list_usage_history(Some(100), None)
-                    );
-
-                    (rentals_result, usage_result)
+                    match timeout(Duration::from_secs(5), rentals_future).await {
+                        Ok(result) => result,
+                        Err(_) => {
+                            warn!("Validator request timed out after 5 seconds");
+                            Err(ApiError::Timeout)
+                        }
+                    }
                 },
-                // Secure cloud: just rentals
+                // Secure cloud
                 api_client.list_secure_cloud_rentals()
             );
 
-            // Process community cloud data
-            let (community_rentals_result, community_usage_result) = community_result;
-
             // Gracefully handle community cloud failures (e.g., validator timeout)
-            // Show empty list instead of failing the whole command
-            let community_rentals_list = match community_rentals_result {
+            let community_rentals_list = match community_result {
                 Ok(list) => list,
                 Err(e) => {
                     warn!("Failed to load community cloud rentals: {}", e);
@@ -1233,22 +1122,6 @@ pub async fn handle_ps(
                     }
                 }
             };
-
-            // Build usage map: rental_id -> usage record
-            let usage_map: HashMap<String, basilica_sdk::types::RentalUsageRecord> =
-                community_usage_result
-                    .ok()
-                    .map(|usage| {
-                        usage
-                            .rentals
-                            .into_iter()
-                            .map(|record| (record.rental_id.clone(), record))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-            // Pricing is now included in usage records (hourly_rate field)
-            let pricing_map: HashMap<String, String> = HashMap::new();
 
             // Process secure cloud data
             let secure_rentals_list = secure_result.inspect_err(|_| {
@@ -1269,65 +1142,16 @@ pub async fn handle_ps(
                 // Display community cloud table
                 println!("\n{}", style("Community Cloud Rentals").bold());
 
-                if filters.history {
-                    // History mode: use usage_map data and filter out active rentals
-                    let active_rental_ids: std::collections::HashSet<String> =
-                        community_rentals_list
-                            .rentals
-                            .iter()
-                            .filter(|r| {
-                                matches!(r.state, RentalState::Active | RentalState::Provisioning)
-                            })
-                            .map(|r| {
-                                r.rental_id
-                                    .strip_prefix("rental-")
-                                    .unwrap_or(&r.rental_id)
-                                    .to_string()
-                            })
-                            .collect();
+                table_output::display_rental_items(
+                    &community_rentals_list.rentals[..],
+                    !filters.compact,
+                    filters.detailed,
+                )?;
 
-                    let historical_rentals: Vec<_> = usage_map
-                        .values()
-                        .filter(|r| !active_rental_ids.contains(&r.rental_id))
-                        .collect();
-
-                    table_output::display_usage_history_for_ps(
-                        &historical_rentals,
-                        filters.detailed,
-                    )?;
-
-                    let total_cost: Decimal = historical_rentals
-                        .iter()
-                        .filter_map(|r| r.current_cost.parse::<Decimal>().ok())
-                        .sum();
-
-                    println!();
-                    println!(
-                        "{}: {}",
-                        style("Total Cost").cyan(),
-                        style(format!("${:.2}", total_cost)).green().bold()
-                    );
-
-                    println!(
-                        "\nTotal: {} community cloud rentals",
-                        historical_rentals.len()
-                    );
-                } else {
-                    // Active rentals
-                    table_output::display_rental_items(
-                        &community_rentals_list.rentals[..],
-                        !filters.compact,
-                        filters.detailed,
-                        &usage_map,
-                        &pricing_map,
-                        false,
-                    )?;
-
-                    println!(
-                        "\nTotal: {} community cloud rentals",
-                        community_rentals_list.rentals.len()
-                    );
-                }
+                println!(
+                    "\nTotal: {} community cloud rentals",
+                    community_rentals_list.rentals.len()
+                );
 
                 // Separator between tables
                 println!();
@@ -1335,19 +1159,11 @@ pub async fn handle_ps(
                 // Display secure cloud table
                 println!("{}", style("Secure Cloud Rentals").bold());
 
-                let secure_rentals_to_display: Vec<_> = if filters.history {
-                    secure_rentals_list
-                        .rentals
-                        .iter()
-                        .filter(|r| r.stopped_at.is_some())
-                        .collect()
-                } else {
-                    secure_rentals_list
-                        .rentals
-                        .iter()
-                        .filter(|r| r.stopped_at.is_none())
-                        .collect()
-                };
+                let secure_rentals_to_display: Vec<_> = secure_rentals_list
+                    .rentals
+                    .iter()
+                    .filter(|r| r.stopped_at.is_none())
+                    .collect();
 
                 table_output::display_secure_cloud_rentals(
                     &secure_rentals_to_display,
@@ -1355,12 +1171,10 @@ pub async fn handle_ps(
                     filters.detailed,
                 )?;
 
-                let label = if filters.history {
-                    "historical secure cloud rentals"
-                } else {
-                    "secure cloud rentals"
-                };
-                println!("\nTotal: {} {}", secure_rentals_to_display.len(), label);
+                println!(
+                    "\nTotal: {} secure cloud rentals",
+                    secure_rentals_to_display.len()
+                );
 
                 display_ps_quick_start_commands();
             }

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -114,238 +114,25 @@ pub fn display_rental_items(
     rentals: &[ApiRentalListItem],
     show_standard: bool,
     show_ids: bool,
-    usage_map: &HashMap<String, basilica_sdk::types::RentalUsageRecord>,
-    _pricing_map: &HashMap<String, String>,
-    is_history_mode: bool,
 ) -> Result<()> {
-    // Helper to calculate rate and cost for a rental
+    // Helper to get rate and cost for a rental from the API response fields
     let get_rental_pricing = |rental: &ApiRentalListItem| -> (String, String) {
-        // Strip "rental-" prefix if present to match usage API format
-        let lookup_id = rental
-            .rental_id
-            .strip_prefix("rental-")
-            .unwrap_or(&rental.rental_id);
+        let rate = rental
+            .hourly_cost
+            .map(|r| format!("${:.2}/hr", r))
+            .unwrap_or_else(|| "-".to_string());
 
-        // Get rate and cost from usage map if available
-        let (rate, cost) = if let Some(usage) = usage_map.get(lookup_id) {
-            let gpu_count = rental.gpu_specs.len();
-
-            // Get hourly rate from usage record
-            let rate = usage
-                .hourly_rate
-                .parse::<Decimal>()
-                .ok()
-                .map(|r| {
-                    let total_rate = r * Decimal::from(gpu_count);
-                    format!("${:.2}/hr", total_rate)
-                })
-                .unwrap_or_else(|| "-".to_string());
-
-            // Get cost from usage record
-            let cost = usage
-                .current_cost
-                .parse::<Decimal>()
-                .ok()
-                .map(|c| format!("${:.2}", c))
-                .unwrap_or_else(|| usage.current_cost.clone());
-
-            (rate, cost)
-        } else {
-            ("-".to_string(), "-".to_string())
-        };
+        let cost = rental
+            .accumulated_cost
+            .as_ref()
+            .and_then(|c| c.parse::<f64>().ok())
+            .map(|c| format!("${:.2}", c))
+            .unwrap_or_else(|| "-".to_string());
 
         (rate, cost)
     };
 
-    // Helper to calculate rental duration
-    let calculate_duration = |rental_id: &str| -> String {
-        let lookup_id = rental_id.strip_prefix("rental-").unwrap_or(rental_id);
-        if let Some(usage) = usage_map.get(lookup_id) {
-            let diff = usage.last_updated.signed_duration_since(usage.start_time);
-            let hours = diff.num_hours();
-            let minutes = diff.num_minutes() % 60;
-            if hours > 0 {
-                format!("{}h {}m", hours, minutes)
-            } else {
-                format!("{}m", minutes)
-            }
-        } else {
-            "-".to_string()
-        }
-    };
-
-    // Helper to format start time
-    let format_start_time = |rental_id: &str| -> String {
-        let lookup_id = rental_id.strip_prefix("rental-").unwrap_or(rental_id);
-        if let Some(usage) = usage_map.get(lookup_id) {
-            usage
-                .start_time
-                .with_timezone(&Local)
-                .format("%Y-%m-%d %H:%M")
-                .to_string()
-        } else {
-            "-".to_string()
-        }
-    };
-
-    if is_history_mode {
-        // History mode - show different columns
-        if show_ids {
-            // Detailed history view with IDs
-            #[derive(Tabled)]
-            struct DetailedHistoryRentalRowWithIds {
-                #[tabled(rename = "RENTAL ID")]
-                rental_id: String,
-                #[tabled(rename = "NODE ID")]
-                node_id: String,
-                #[tabled(rename = "GPU")]
-                gpu: String,
-                #[tabled(rename = "State")]
-                state: String,
-                #[tabled(rename = "SSH")]
-                ssh: String,
-                #[tabled(rename = "Ports (Host → Container)")]
-                ports: String,
-                #[tabled(rename = "Image")]
-                image: String,
-                #[tabled(rename = "CPU")]
-                cpu: String,
-                #[tabled(rename = "RAM")]
-                ram: String,
-                #[tabled(rename = "Location")]
-                location: String,
-                #[tabled(rename = "Total Cost")]
-                total_cost: String,
-                #[tabled(rename = "Started")]
-                started: String,
-                #[tabled(rename = "Duration")]
-                duration: String,
-            }
-
-            let rows: Vec<DetailedHistoryRentalRowWithIds> = rentals
-                .iter()
-                .map(|rental| {
-                    let node_id = rental
-                        .node_id
-                        .split_once("__")
-                        .map(|(_, id)| id)
-                        .unwrap_or(&rental.node_id)
-                        .to_string();
-                    let gpu = format_gpu_info(&rental.gpu_specs, true);
-                    let cpu = rental
-                        .cpu_specs
-                        .as_ref()
-                        .map(|cpu| format!("{} ({} cores)", cpu.model, cpu.cores))
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let ram = rental
-                        .cpu_specs
-                        .as_ref()
-                        .map(|cpu| format!("{}GB", cpu.memory_gb))
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let location = rental
-                        .location
-                        .as_ref()
-                        .and_then(|loc| LocationProfile::from_str(loc).ok())
-                        .map(|profile| profile.to_string())
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let ssh = if rental.has_ssh { "✓" } else { "✗" };
-                    let ports = format_port_mappings(&rental.port_mappings, None);
-                    let (_, total_cost) = get_rental_pricing(rental);
-
-                    DetailedHistoryRentalRowWithIds {
-                        rental_id: rental.rental_id.clone(),
-                        node_id,
-                        gpu,
-                        state: rental.state.to_string(),
-                        ssh: ssh.to_string(),
-                        ports,
-                        image: rental.container_image.clone(),
-                        cpu,
-                        ram,
-                        location,
-                        total_cost,
-                        started: format_start_time(&rental.rental_id),
-                        duration: calculate_duration(&rental.rental_id),
-                    }
-                })
-                .collect();
-
-            let mut table = Table::new(rows);
-            table.with(Style::modern());
-            println!("{table}");
-        } else {
-            // Standard history view without IDs
-            #[derive(Tabled)]
-            struct HistoryRentalRow {
-                #[tabled(rename = "GPU")]
-                gpu: String,
-                #[tabled(rename = "State")]
-                state: String,
-                #[tabled(rename = "SSH")]
-                ssh: String,
-                #[tabled(rename = "Ports (Host → Container)")]
-                ports: String,
-                #[tabled(rename = "Image")]
-                image: String,
-                #[tabled(rename = "CPU")]
-                cpu: String,
-                #[tabled(rename = "RAM")]
-                ram: String,
-                #[tabled(rename = "Location")]
-                location: String,
-                #[tabled(rename = "Total Cost")]
-                total_cost: String,
-                #[tabled(rename = "Started")]
-                started: String,
-                #[tabled(rename = "Duration")]
-                duration: String,
-            }
-
-            let rows: Vec<HistoryRentalRow> = rentals
-                .iter()
-                .map(|rental| {
-                    let gpu = format_gpu_info(&rental.gpu_specs, true);
-                    let cpu = rental
-                        .cpu_specs
-                        .as_ref()
-                        .map(|cpu| format!("{} ({} cores)", cpu.model, cpu.cores))
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let ram = rental
-                        .cpu_specs
-                        .as_ref()
-                        .map(|cpu| format!("{}GB", cpu.memory_gb))
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let location = rental
-                        .location
-                        .as_ref()
-                        .and_then(|loc| LocationProfile::from_str(loc).ok())
-                        .map(|profile| profile.to_string())
-                        .unwrap_or_else(|| "Unknown".to_string());
-                    let ssh = if rental.has_ssh { "✓" } else { "✗" };
-                    let ports = format_port_mappings(&rental.port_mappings, Some(2));
-                    let (_, total_cost) = get_rental_pricing(rental);
-
-                    HistoryRentalRow {
-                        gpu,
-                        state: rental.state.to_string(),
-                        ssh: ssh.to_string(),
-                        ports,
-                        image: rental.container_image.clone(),
-                        cpu,
-                        ram,
-                        location,
-                        total_cost,
-                        started: format_start_time(&rental.rental_id),
-                        duration: calculate_duration(&rental.rental_id),
-                    }
-                })
-                .collect();
-
-            let mut table = Table::new(rows);
-            table.with(Style::modern());
-            println!("{table}");
-        }
-    } else if show_ids {
+    if show_ids {
         // Detailed view with IDs
         #[derive(Tabled)]
         struct DetailedRentalRowWithIds {
@@ -1423,138 +1210,6 @@ pub fn display_rental_usage_detail(usage: &RentalUsageResponse) -> Result<()> {
     Ok(())
 }
 
-/// Display usage history for ps command with history flag
-pub fn display_usage_history_for_ps(
-    rentals: &[&basilica_sdk::types::RentalUsageRecord],
-    show_detailed: bool,
-) -> Result<()> {
-    if rentals.is_empty() {
-        println!("{}", style("No rental history found").yellow());
-        return Ok(());
-    }
-
-    if show_detailed {
-        #[derive(Tabled)]
-        struct DetailedHistoryRow {
-            #[tabled(rename = "Rental ID")]
-            rental_id: String,
-            #[tabled(rename = "Node ID")]
-            node_id: String,
-            #[tabled(rename = "Total Cost")]
-            total_cost: String,
-            #[tabled(rename = "Started")]
-            started: String,
-            #[tabled(rename = "Stopped")]
-            stopped: String,
-            #[tabled(rename = "Duration")]
-            duration: String,
-        }
-
-        let mut rows: Vec<DetailedHistoryRow> = rentals
-            .iter()
-            .map(|rental| {
-                let total_cost = rental
-                    .current_cost
-                    .parse::<Decimal>()
-                    .ok()
-                    .map(|cost| format!("${:.2}", cost))
-                    .unwrap_or_else(|| rental.current_cost.clone());
-
-                let diff = rental.last_updated.signed_duration_since(rental.start_time);
-                let hours = diff.num_hours();
-                let minutes = diff.num_minutes() % 60;
-                let duration = if hours > 0 {
-                    format!("{}h {}m", hours, minutes)
-                } else {
-                    format!("{}m", minutes)
-                };
-
-                DetailedHistoryRow {
-                    rental_id: rental.rental_id.clone(),
-                    node_id: rental.node_id.clone(),
-                    total_cost,
-                    started: rental
-                        .start_time
-                        .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M")
-                        .to_string(),
-                    stopped: rental
-                        .last_updated
-                        .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M")
-                        .to_string(),
-                    duration,
-                }
-            })
-            .collect();
-
-        rows.sort_by(|a, b| b.started.cmp(&a.started));
-
-        let mut table = Table::new(&rows);
-        table.with(Style::modern());
-        println!("{}", table);
-    } else {
-        #[derive(Tabled)]
-        struct HistoryRow {
-            #[tabled(rename = "Rental ID")]
-            rental_id: String,
-            #[tabled(rename = "Total Cost")]
-            total_cost: String,
-            #[tabled(rename = "Started")]
-            started: String,
-            #[tabled(rename = "Stopped")]
-            stopped: String,
-            #[tabled(rename = "Duration")]
-            duration: String,
-        }
-
-        let mut rows: Vec<HistoryRow> = rentals
-            .iter()
-            .map(|rental| {
-                let total_cost = rental
-                    .current_cost
-                    .parse::<Decimal>()
-                    .ok()
-                    .map(|cost| format!("${:.2}", cost))
-                    .unwrap_or_else(|| rental.current_cost.clone());
-
-                let diff = rental.last_updated.signed_duration_since(rental.start_time);
-                let hours = diff.num_hours();
-                let minutes = diff.num_minutes() % 60;
-                let duration = if hours > 0 {
-                    format!("{}h {}m", hours, minutes)
-                } else {
-                    format!("{}m", minutes)
-                };
-
-                HistoryRow {
-                    rental_id: rental.rental_id.clone(),
-                    total_cost,
-                    started: rental
-                        .start_time
-                        .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M")
-                        .to_string(),
-                    stopped: rental
-                        .last_updated
-                        .with_timezone(&Local)
-                        .format("%Y-%m-%d %H:%M")
-                        .to_string(),
-                    duration,
-                }
-            })
-            .collect();
-
-        rows.sort_by(|a, b| b.started.cmp(&a.started));
-
-        let mut table = Table::new(&rows);
-        table.with(Style::modern());
-        println!("{}", table);
-    }
-
-    Ok(())
-}
-
 /// Display usage history list
 pub fn display_usage_history(history: &UsageHistoryResponse) -> Result<()> {
     if history.rentals.is_empty() {
@@ -1715,23 +1370,13 @@ pub fn display_secure_cloud_rentals(
                     .map(|gb| format!("{}GB", gb))
                     .unwrap_or_else(|| "-".to_string());
 
-                // Use accumulated cost from billing service, or fallback to time-based estimate
-                let total_cost = if let Some(accumulated) = &rental.accumulated_cost {
-                    // Use actual cost from billing service (no ~ prefix)
-                    accumulated
-                        .parse::<f64>()
-                        .map(|cost| format!("${:.2}", cost))
-                        .unwrap_or_else(|_| accumulated.clone())
-                } else {
-                    // Fallback to time-based estimate (with ~ prefix)
-                    let duration = if let Some(stopped) = &rental.stopped_at {
-                        stopped.signed_duration_since(rental.created_at)
-                    } else {
-                        chrono::Utc::now().signed_duration_since(rental.created_at)
-                    };
-                    let hours = duration.num_seconds() as f64 / 3600.0;
-                    format!("~${:.2}", rental.hourly_cost * hours)
-                };
+                // Use accumulated cost from billing service - no fallback
+                let total_cost = rental
+                    .accumulated_cost
+                    .as_ref()
+                    .and_then(|c| c.parse::<f64>().ok())
+                    .map(|cost| format!("${:.2}", cost))
+                    .unwrap_or_else(|| "-".to_string());
 
                 DetailedRow {
                     rental_id: rental.rental_id.clone(),
@@ -1812,23 +1457,13 @@ pub fn display_secure_cloud_rentals(
                     .map(|gb| format!("{}GB", gb))
                     .unwrap_or_else(|| "-".to_string());
 
-                // Use accumulated cost from billing service, or fallback to time-based estimate
-                let total_cost = if let Some(accumulated) = &rental.accumulated_cost {
-                    // Use actual cost from billing service (no ~ prefix)
-                    accumulated
-                        .parse::<f64>()
-                        .map(|cost| format!("${:.2}", cost))
-                        .unwrap_or_else(|_| accumulated.clone())
-                } else {
-                    // Fallback to time-based estimate (with ~ prefix)
-                    let duration = if let Some(stopped) = &rental.stopped_at {
-                        stopped.signed_duration_since(rental.created_at)
-                    } else {
-                        chrono::Utc::now().signed_duration_since(rental.created_at)
-                    };
-                    let hours = duration.num_seconds() as f64 / 3600.0;
-                    format!("~${:.2}", rental.hourly_cost * hours)
-                };
+                // Use accumulated cost from billing service - no fallback
+                let total_cost = rental
+                    .accumulated_cost
+                    .as_ref()
+                    .and_then(|c| c.parse::<f64>().ok())
+                    .map(|cost| format!("${:.2}", cost))
+                    .unwrap_or_else(|| "-".to_string());
 
                 StandardRow {
                     provider: rental.provider.clone(),

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -88,6 +88,12 @@ pub struct ApiRentalListItem {
     /// Port mappings for this rental
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port_mappings: Option<Vec<basilica_validator::rental::PortMapping>>,
+    /// Hourly cost rate for this rental (includes markup)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hourly_cost: Option<f64>,
+    /// Accumulated cost from billing service
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accumulated_cost: Option<String>,
 }
 
 /// API list rentals response with GPU information


### PR DESCRIPTION
## Summary
- Move cost data sourcing from client-side usage history API calls to server-side billing service integration
- Remove `--history` flag from `basilica ps` command
- Simplify CLI code by eliminating usage/pricing map handling

## Why
The API now provides `hourly_cost` and `accumulated_cost` fields directly in the rental list response by querying the billing service server-side. This eliminates the need for the CLI to make separate usage history API calls and perform client-side cost calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rental listings now surface optional cost info: hourly rates and accumulated costs (may be absent if billing data unavailable).

* **Breaking Changes**
  * CLI history flag removed; CLI/PS commands now show only active/current rentals.

* **Improvements**
  * Simplified CLI/table and JSON outputs: pricing and totals come directly from the API, unified active-rentals display, and reduced output complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->