### PR TITLE
fix(wireguard): ensure peer persistence and idempotent iptables rules

### DIFF
--- a/crates/basilica-api/src/ssh/client.rs
+++ b/crates/basilica-api/src/ssh/client.rs
@@ -544,12 +544,28 @@ impl K3sSshClient {
     ) -> Result<(), ApiError> {
         let client = self.connect_to_server(server).await?;
 
-        // Use wg set to add peer dynamically
-        // SaveConfig=true in wg0.conf means this will persist
+        // Add peer to runtime with wg set AND persist to config file
+        // This ensures the peer survives WireGuard restarts
         let command = format!(
             "sudo wg set wg0 peer '{}' allowed-ips '{}/32' persistent-keepalive 25 && \
+             if ! grep -q 'PublicKey = {}' /etc/wireguard/wg0.conf 2>/dev/null; then \
+               sudo tee -a /etc/wireguard/wg0.conf > /dev/null <<'PEER'\n\n\
+[Peer]\n\
+# Node: {}\n\
+PublicKey = {}\n\
+AllowedIPs = {}/32\n\
+PersistentKeepalive = 25\n\
+PEER\n\
+             fi && \
              echo 'Peer added: {} -> {}'",
-            public_key, allowed_ip, node_id, allowed_ip
+            public_key,
+            allowed_ip,
+            public_key,
+            node_id,
+            public_key,
+            allowed_ip,
+            node_id,
+            allowed_ip
         );
 
         let result = tokio::time::timeout(self.timeout, client.execute(&command))
@@ -626,15 +642,24 @@ impl K3sSshClient {
     ) -> Result<(), ApiError> {
         let client = self.connect_to_server(server).await?;
 
-        let command = format!("sudo wg set wg0 peer '{}' remove", public_key);
+        // Remove from runtime AND from config file using awk for reliable block removal
+        let command = format!(
+            "sudo wg set wg0 peer '{}' remove 2>/dev/null || true; \
+             sudo awk '/^\\[Peer\\]/{{ block=$0; skip=0; next }} \
+                       /^\\[/{{ if(!skip) print block; block=$0; skip=0; next }} \
+                       {{ block=block\"\\n\"$0; if(/PublicKey = {}/) skip=1 }} \
+                       END{{ if(!skip) print block }}' /etc/wireguard/wg0.conf > /tmp/wg0.conf.tmp && \
+             sudo mv /tmp/wg0.conf.tmp /etc/wireguard/wg0.conf && \
+             sudo chmod 600 /etc/wireguard/wg0.conf || true",
+            public_key, public_key
+        );
 
         let result = tokio::time::timeout(self.timeout, client.execute(&command))
             .await
             .map_err(|_| ApiError::SshCommandTimeout)?
             .map_err(|e| ApiError::SshCommandFailed(e.to_string()))?;
 
-        // Ignore errors if peer doesn't exist
-        if result.exit_status != 0 && !result.stderr.contains("not found") {
+        if result.exit_status != 0 {
             return Err(ApiError::SshCommandFailed(format!(
                 "Failed to remove WireGuard peer: {}",
                 result.stderr

--- a/orchestrator/ansible/roles/wireguard/tasks/main.yml
+++ b/orchestrator/ansible/roles/wireguard/tasks/main.yml
@@ -166,42 +166,10 @@
     comment: "NAT WireGuard to VPC for remote GPU nodes"
   tags: ['wireguard', 'iptables']
 
-- name: Save iptables rules for persistence
-  ansible.builtin.shell: |
-    iptables-save > /etc/iptables.rules.v4
-  changed_when: true
-  tags: ['wireguard', 'iptables']
-
-- name: Deploy iptables-restore systemd service
-  ansible.builtin.copy:
-    content: |
-      [Unit]
-      Description=Restore iptables rules
-      Before=network-pre.target
-      Wants=network-pre.target
-
-      [Service]
-      Type=oneshot
-      ExecStart=/sbin/iptables-restore /etc/iptables.rules.v4
-      RemainAfterExit=yes
-
-      [Install]
-      WantedBy=multi-user.target
-    dest: /etc/systemd/system/iptables-restore.service
-    owner: root
-    group: root
-    mode: '0644'
-  register: iptables_service
-  tags: ['wireguard', 'iptables']
-
-- name: Enable iptables-restore service
-  ansible.builtin.systemd:
-    name: iptables-restore
-    enabled: yes
-    daemon_reload: "{{ iptables_service.changed }}"
-  tags: ['wireguard', 'iptables']
-
 # Security hardening: Rate limiting and FORWARD chain restrictions
+# Note: All iptables rules must be added BEFORE saving, and hashlimit requires
+# manual idempotency handling since ansible.builtin.iptables doesn't support it
+
 - name: Install iptables hashlimit module dependencies
   ansible.builtin.apt:
     name: xtables-addons-common
@@ -212,7 +180,8 @@
   ansible.builtin.shell: |
     iptables -C INPUT -p udp --dport {{ wireguard_port }} -m hashlimit \
       --hashlimit-name wireguard_handshake --hashlimit-mode srcip \
-      --hashlimit-above 10/minute --hashlimit-burst 5 -j DROP 2>/dev/null
+      --hashlimit-above 10/minute --hashlimit-burst 5 \
+      -m comment --comment "Rate limit WireGuard handshakes" -j DROP 2>/dev/null
   register: wg_ratelimit_check
   failed_when: false
   changed_when: false
@@ -222,8 +191,8 @@
   ansible.builtin.shell: |
     iptables -A INPUT -p udp --dport {{ wireguard_port }} -m hashlimit \
       --hashlimit-name wireguard_handshake --hashlimit-mode srcip \
-      --hashlimit-above 10/minute --hashlimit-burst 5 -j DROP \
-      -m comment --comment "Rate limit WireGuard handshakes"
+      --hashlimit-above 10/minute --hashlimit-burst 5 \
+      -m comment --comment "Rate limit WireGuard handshakes" -j DROP
   when: wg_ratelimit_check.rc != 0
   tags: ['wireguard', 'security']
 
@@ -317,11 +286,41 @@
     - net.ipv4.conf.default.send_redirects
   tags: ['wireguard', 'security', 'sysctl']
 
-- name: Update saved iptables rules with security rules
+# Save and persist iptables rules - must be AFTER all rules are added
+- name: Save iptables rules for persistence
   ansible.builtin.shell: |
     iptables-save > /etc/iptables.rules.v4
   changed_when: true
-  tags: ['wireguard', 'security']
+  tags: ['wireguard', 'iptables']
+
+- name: Deploy iptables-restore systemd service
+  ansible.builtin.copy:
+    content: |
+      [Unit]
+      Description=Restore iptables rules
+      Before=network-pre.target
+      Wants=network-pre.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/sbin/iptables-restore /etc/iptables.rules.v4
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+    dest: /etc/systemd/system/iptables-restore.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: iptables_service
+  tags: ['wireguard', 'iptables']
+
+- name: Enable iptables-restore service
+  ansible.builtin.systemd:
+    name: iptables-restore
+    enabled: yes
+    daemon_reload: "{{ iptables_service.changed }}"
+  tags: ['wireguard', 'iptables']
 
 # WireGuard monitoring setup
 - name: Setup WireGuard Prometheus monitoring

--- a/orchestrator/scripts/onboard.sh
+++ b/orchestrator/scripts/onboard.sh
@@ -370,13 +370,35 @@ setup_wireguard() {
         die "Unsupported package manager. Please install WireGuard manually."
     fi
 
-    log "Generating WireGuard keypair..."
     umask 077
     mkdir -p /etc/wireguard
-    wg genkey > /etc/wireguard/private.key
-    wg pubkey < /etc/wireguard/private.key > /etc/wireguard/public.key
-    WG_PRIVATE_KEY=$(cat /etc/wireguard/private.key)
-    WG_PUBLIC_KEY=$(cat /etc/wireguard/public.key)
+
+    # Preserve existing keys if they exist and are valid
+    if [ -f /etc/wireguard/private.key ] && [ -f /etc/wireguard/public.key ]; then
+        local existing_priv existing_pub
+        existing_priv=$(cat /etc/wireguard/private.key 2>/dev/null)
+        existing_pub=$(cat /etc/wireguard/public.key 2>/dev/null)
+
+        # Validate keys are non-empty and properly formatted (44 chars base64)
+        if [ -n "$existing_priv" ] && [ -n "$existing_pub" ] && \
+           [ ${#existing_pub} -eq 44 ]; then
+            log "Using existing WireGuard keypair (public key: ${existing_pub:0:8}...)"
+            WG_PRIVATE_KEY="$existing_priv"
+            WG_PUBLIC_KEY="$existing_pub"
+        else
+            log "Existing keys invalid, generating new WireGuard keypair..."
+            wg genkey > /etc/wireguard/private.key
+            wg pubkey < /etc/wireguard/private.key > /etc/wireguard/public.key
+            WG_PRIVATE_KEY=$(cat /etc/wireguard/private.key)
+            WG_PUBLIC_KEY=$(cat /etc/wireguard/public.key)
+        fi
+    else
+        log "Generating WireGuard keypair..."
+        wg genkey > /etc/wireguard/private.key
+        wg pubkey < /etc/wireguard/private.key > /etc/wireguard/public.key
+        WG_PRIVATE_KEY=$(cat /etc/wireguard/private.key)
+        WG_PUBLIC_KEY=$(cat /etc/wireguard/public.key)
+    fi
 
     log "Creating WireGuard configuration with multiple peers..."
 


### PR DESCRIPTION
* Preserve existing WireGuard keys in onboard.sh instead of regenerating
* Persist peers to wg0.conf file when adding via API SSH commands
* Remove peers from config file when removing via API SSH commands
* Fix iptables rate limit check to include comment module for idempotency
* Move iptables persistence to after all rules are added

## Summary

Brief description of what this PR does.

## Related Issues

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

List the main changes in this PR:

- 
- 
- 

## Testing

### How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing completed

### Test Configuration

- OS: 
- Rust version: 
- Bittensor version (if applicable): 

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format my code
- [ ] I have run `cargo clippy` and addressed all warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Context

Add any other context about the PR here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WireGuard peer removal now properly cleans up both runtime and persistent configuration
  * Network firewall rules now correctly persist across system restarts
  * Enhanced error handling for configuration failures

* **Improvements**
  * WireGuard peer additions automatically persist to configuration files
  * System setup reuses existing WireGuard keys instead of regenerating them

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->