### PR TITLE
refactor(api): remove billing shadow mode and enforce balance checks

### DIFF
--- a/config/api.correct.toml
+++ b/config/api.correct.toml
@@ -18,6 +18,3 @@ discovery_interval = 30
 [billing]
 enabled = true
 endpoint = "http://localhost:50051"
-# Shadow mode: balance checks are performed and logged but rentals proceed regardless
-# Set to true to enforce balance requirements (block insufficient balance rentals)
-enforce_balance_checks = false

--- a/crates/basilica-api/src/api/middleware/balance.rs
+++ b/crates/basilica-api/src/api/middleware/balance.rs
@@ -35,27 +35,18 @@ pub async fn balance_validation_middleware(
                         Decimal::from_f64_retain(MIN_BALANCE_USD).unwrap_or(Decimal::ZERO);
 
                     if available_balance < min_balance {
-                        if state.config.billing.enforce_balance_checks {
-                            tracing::warn!(
-                                    "ENFORCED: Blocking rental for user {} with insufficient balance: {} < {}",
-                                    auth_context.user_id,
-                                    available_balance,
-                                    min_balance
-                                );
-                            return Err(ApiError::InsufficientBalance {
-                                    message: "Your account balance is below the minimum required to create rentals".to_string(),
-                                    current_balance: balance_response.available_balance.clone(),
-                                    required: MIN_BALANCE_USD.to_string(),
-                                }
-                                .into_response());
-                        } else {
-                            tracing::warn!(
-                                    "SHADOW MODE: User {} has insufficient balance ({} < {}) but rental is allowed to proceed. Enforcement disabled.",
-                                    auth_context.user_id,
-                                    available_balance,
-                                    min_balance
-                                );
+                        tracing::warn!(
+                            "Blocking rental for user {} with insufficient balance: {} < {}",
+                            auth_context.user_id,
+                            available_balance,
+                            min_balance
+                        );
+                        return Err(ApiError::InsufficientBalance {
+                            message: "Your account balance is below the minimum required to create rentals".to_string(),
+                            current_balance: balance_response.available_balance.clone(),
+                            required: MIN_BALANCE_USD.to_string(),
                         }
+                        .into_response());
                     } else {
                         tracing::debug!(
                             "User {} has sufficient balance: {} >= {}",

--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -347,63 +347,51 @@ pub async fn start_rental(
             })),
         };
 
-        match billing_client.track_rental(track_request).await {
-            Ok(_) => {
+        if let Err(e) = billing_client.track_rental(track_request).await {
+            error!("Failed to register rental with billing service: {}", e);
+
+            // Rollback: remove ownership record and terminate rental
+            if let Err(archive_err) = archive_rental_ownership(
+                &state.db,
+                &validator_response.rental_id,
+                Some("Failed to register with billing service - automatic rollback"),
+            )
+            .await
+            {
+                error!(
+                    "Failed to archive ownership for rental {} during rollback: {}",
+                    validator_response.rental_id, archive_err
+                );
+            }
+
+            let rollback_request = TerminateRentalRequest {
+                reason: Some(
+                    "Failed to register with billing service - automatic rollback".to_string(),
+                ),
+            };
+
+            if let Err(rollback_err) = state
+                .validator_client
+                .terminate_rental(&validator_response.rental_id, rollback_request)
+                .await
+            {
+                error!(
+                    "CRITICAL: Failed to rollback rental {} after billing registration failure: {}. Manual cleanup required.",
+                    validator_response.rental_id, rollback_err
+                );
+            } else {
                 info!(
-                    "Successfully registered rental {} with billing service",
+                    "Successfully rolled back rental {} after billing registration failure",
                     validator_response.rental_id
                 );
             }
-            Err(e) => {
-                let error_msg = format!("Failed to register rental with billing service: {}", e);
-                error!("{}", error_msg);
 
-                if state.config.billing.enforce_balance_checks {
-                    // Rollback: remove ownership record and terminate rental
-                    if let Err(archive_err) = archive_rental_ownership(
-                        &state.db,
-                        &validator_response.rental_id,
-                        Some("Failed to register with billing service - automatic rollback"),
-                    )
-                    .await
-                    {
-                        error!(
-                            "Failed to archive ownership for rental {} during rollback: {}",
-                            validator_response.rental_id, archive_err
-                        );
-                    }
-
-                    let rollback_request = TerminateRentalRequest {
-                        reason: Some(
-                            "Failed to register with billing service - automatic rollback"
-                                .to_string(),
-                        ),
-                    };
-
-                    if let Err(rollback_err) = state
-                        .validator_client
-                        .terminate_rental(&validator_response.rental_id, rollback_request)
-                        .await
-                    {
-                        error!(
-                            "CRITICAL: Failed to rollback rental {} after billing registration failure: {}. Manual cleanup required.",
-                            validator_response.rental_id, rollback_err
-                        );
-                    } else {
-                        info!(
-                            "Successfully rolled back rental {} after billing registration failure",
-                            validator_response.rental_id
-                        );
-                    }
-
-                    return Err(crate::error::ApiError::Internal {
-                        message: format!(
-                            "Failed to create rental: billing service unavailable - {}",
-                            e
-                        ),
-                    });
-                }
-            }
+            return Err(crate::error::ApiError::Internal {
+                message: format!(
+                    "Failed to create rental: billing service unavailable - {}",
+                    e
+                ),
+            });
         }
     }
 

--- a/crates/basilica-api/src/api/routes/secure_cloud.rs
+++ b/crates/basilica-api/src/api/routes/secure_cloud.rs
@@ -375,15 +375,28 @@ pub async fn start_secure_cloud_rental(
     };
 
     if let Some(ref billing_client) = state.billing_client {
-        billing_client
-            .track_rental(track_request)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to register with billing: {}", e);
-                ApiError::Internal {
-                    message: "Failed to register rental".to_string(),
-                }
-            })?;
+        if let Err(e) = billing_client.track_rental(track_request).await {
+            tracing::error!("Failed to register with billing: {}", e);
+
+            // Rollback: delete the deployed instance since billing registration failed
+            // This prevents orphaned instances running without billing tracking
+            if let Err(rollback_err) = state.aggregator_service.delete_deployment(&rental_id).await
+            {
+                tracing::error!(
+                    "CRITICAL: Failed to rollback deployment {} after billing failure: {}. Manual cleanup required.",
+                    rental_id, rollback_err
+                );
+            } else {
+                tracing::info!(
+                    "Successfully rolled back deployment {} after billing registration failure",
+                    rental_id
+                );
+            }
+
+            return Err(ApiError::Internal {
+                message: "Failed to register rental with billing service".to_string(),
+            });
+        }
     }
 
     // 5. Calculate hourly cost (total per-instance price with markup)
@@ -441,7 +454,23 @@ pub async fn stop_secure_cloud_rental(
     let duration = stop_time.signed_duration_since(rental.1);
     let duration_hours = duration.num_seconds() as f64 / 3600.0;
 
-    // 2. Finalize rental in billing service (get accumulated cost)
+    // 2. Delete deployment via aggregator FIRST (rental_id IS the deployment_id)
+    // This must happen before billing finalization to ensure consistent state -
+    // if the provider API fails (e.g., instance not fully started), we don't
+    // want billing to mark the rental as completed.
+    state
+        .aggregator_service
+        .delete_deployment(&rental_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete deployment: {}", e);
+            ApiError::Internal {
+                message: "Failed to stop instance".to_string(),
+            }
+        })?;
+
+    // 3. Finalize rental in billing service (get accumulated cost)
+    // Only runs if deletion succeeded above
     let total_cost = if let Some(billing_client) = &state.billing_client {
         use basilica_protocol::billing::FinalizeRentalRequest;
         use prost_types::Timestamp;
@@ -472,18 +501,6 @@ pub async fn stop_secure_cloud_rental(
         tracing::warn!("Billing client not available, cannot get final cost");
         0.0
     };
-
-    // 3. Delete deployment via aggregator (rental_id IS the deployment_id)
-    state
-        .aggregator_service
-        .delete_deployment(&rental_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete deployment: {}", e);
-            ApiError::Internal {
-                message: "Failed to stop instance".to_string(),
-            }
-        })?;
 
     // 4. Archive rental to terminated_secure_cloud_rentals table
     if let Err(e) =

--- a/crates/basilica-api/src/config/mod.rs
+++ b/crates/basilica-api/src/config/mod.rs
@@ -108,15 +108,6 @@ pub struct BillingServiceConfig {
 
     /// Billing service gRPC endpoint
     pub endpoint: String,
-
-    /// Enforce balance checks (block rentals when insufficient balance)
-    /// When false, balance checks are performed and logged but rentals proceed regardless
-    #[serde(default = "default_enforce_balance_checks")]
-    pub enforce_balance_checks: bool,
-}
-
-fn default_enforce_balance_checks() -> bool {
-    false
 }
 
 impl Default for BillingServiceConfig {
@@ -124,7 +115,6 @@ impl Default for BillingServiceConfig {
         Self {
             enabled: true,
             endpoint: "http://localhost:50051".to_string(),
-            enforce_balance_checks: default_enforce_balance_checks(),
         }
     }
 }
@@ -389,31 +379,17 @@ mod tests {
         let config = BillingServiceConfig::default();
         assert!(config.enabled);
         assert_eq!(config.endpoint, "http://localhost:50051");
-        assert!(!config.enforce_balance_checks);
     }
 
     #[test]
-    fn test_billing_config_shadow_mode() {
+    fn test_billing_config_custom_endpoint() {
         let toml_str = r#"
             enabled = true
             endpoint = "https://billing.basilica.ai:50051"
-            enforce_balance_checks = false
         "#;
         let config: BillingServiceConfig = toml::from_str(toml_str).unwrap();
         assert!(config.enabled);
-        assert!(!config.enforce_balance_checks);
-    }
-
-    #[test]
-    fn test_billing_config_enforcement_mode() {
-        let toml_str = r#"
-            enabled = true
-            endpoint = "https://billing.basilica.ai:50051"
-            enforce_balance_checks = true
-        "#;
-        let config: BillingServiceConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.enabled);
-        assert!(config.enforce_balance_checks);
+        assert_eq!(config.endpoint, "https://billing.basilica.ai:50051");
     }
 
     #[test]
@@ -424,6 +400,5 @@ mod tests {
         "#;
         let config: BillingServiceConfig = toml::from_str(toml_str).unwrap();
         assert!(!config.enabled);
-        assert!(!config.enforce_balance_checks);
     }
 }


### PR DESCRIPTION
Removes the `enforce_balance_checks` config toggle. Balance checks are now always enforced, simplifying the codebase by eliminating shadow mode conditionals.

Also reorders `stop_secure_cloud_rental` to delete deployment before billing finalization, preventing a race condition where billing could mark a rental as completed even if the provider API failed to stop the instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Balance checks now consistently enforced during all rentals.
  * Added automatic rollback on billing failures to prevent inconsistent system state.
  * Improved transaction ordering in secure cloud rentals for better consistency.

* **Chores**
  * Removed balance enforcement configuration option; now always active by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->