### PR TITLE
refactor(billing): remove final_cost from FinalizeRentalRequest

### DIFF
--- a/crates/basilica-api/src/api/routes/rentals.rs
+++ b/crates/basilica-api/src/api/routes/rentals.rs
@@ -435,7 +435,6 @@ pub async fn stop_rental(
         let finalize_request = FinalizeRentalRequest {
             rental_id: owned_rental.rental_id.clone(),
             end_time: Some(end_timestamp),
-            final_cost: String::new(), // Let billing service calculate from tracked usage
             termination_reason: request
                 .reason
                 .clone()

--- a/crates/basilica-api/src/api/routes/secure_cloud.rs
+++ b/crates/basilica-api/src/api/routes/secure_cloud.rs
@@ -483,7 +483,6 @@ pub async fn stop_secure_cloud_rental(
         let finalize_request = FinalizeRentalRequest {
             rental_id: rental_id.clone(),
             end_time: Some(end_timestamp),
-            final_cost: String::new(), // Let billing service use tracked cost
             termination_reason: "user_requested".to_string(),
         };
 

--- a/crates/basilica-billing/src/grpc/billing_service.rs
+++ b/crates/basilica-billing/src/grpc/billing_service.rs
@@ -689,32 +689,14 @@ impl BillingService for BillingServiceImpl {
                 rental.cloud_type, rental_id, rental.actual_cost
             );
 
-            // Calculate final cost based on duration and pricing
             let duration = end_time - rental.started_at;
-            let hours = rust_decimal::Decimal::from(duration.num_seconds())
-                / rust_decimal::Decimal::from(3600);
-            let calculated_cost =
-                rental.base_price_per_gpu * rust_decimal::Decimal::from(rental.gpu_count) * hours;
-
-            let final_cost_decimal = if req.final_cost.is_empty() {
-                // Use actual_cost if set, otherwise calculate from duration
-                if rental.actual_cost.as_decimal() > rust_decimal::Decimal::ZERO {
-                    rental.actual_cost.as_decimal()
-                } else {
-                    calculated_cost
-                }
-            } else {
-                req.final_cost
-                    .parse::<rust_decimal::Decimal>()
-                    .map_err(|e| Status::invalid_argument(format!("Invalid final_cost: {}", e)))?
-            };
+            let final_cost_decimal = rental.actual_cost.as_decimal();
 
             // Update rental status to completed
             let mut rental = rental.clone();
             rental.state = crate::domain::types::RentalState::Completed;
             rental.last_updated = end_time;
             rental.ended_at = Some(end_time);
-            rental.actual_cost = CreditBalance::from_decimal(final_cost_decimal);
 
             self.rental_repository
                 .update_rental(&rental)

--- a/crates/basilica-billing/tests/bdd/scenarios/event_processing.rs
+++ b/crates/basilica-billing/tests/bdd/scenarios/event_processing.rs
@@ -202,7 +202,6 @@ async fn test_event_timestamps_ordered() {
 
     let finalize_request = FinalizeRentalRequest {
         rental_id: track_response.tracking_id.clone(),
-        final_cost: "14.0".to_string(),
         end_time: None,
         termination_reason: String::new(),
     };

--- a/crates/basilica-billing/tests/bdd/scenarios/rental_management.rs
+++ b/crates/basilica-billing/tests/bdd/scenarios/rental_management.rs
@@ -334,7 +334,6 @@ async fn test_finalize_rental_charges_correct_amount() {
 
     let finalize_request = FinalizeRentalRequest {
         rental_id: track_response.tracking_id.clone(),
-        final_cost: "25.0".to_string(),
         end_time: None,
         termination_reason: String::new(),
     };

--- a/crates/basilica-protocol/proto/billing.proto
+++ b/crates/basilica-protocol/proto/billing.proto
@@ -163,7 +163,8 @@ message ActiveRental {
 message FinalizeRentalRequest {
     string rental_id = 1;
     google.protobuf.Timestamp end_time = 2;
-    string final_cost = 3; // Decimal string
+    reserved 3;
+    reserved "final_cost";
     string termination_reason = 4;
 }
 

--- a/crates/basilica-protocol/src/gen/basilica.billing.v1.rs
+++ b/crates/basilica-protocol/src/gen/basilica.billing.v1.rs
@@ -243,9 +243,6 @@ pub struct FinalizeRentalRequest {
     pub rental_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
     pub end_time: ::core::option::Option<::prost_types::Timestamp>,
-    /// Decimal string
-    #[prost(string, tag = "3")]
-    pub final_cost: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
     pub termination_reason: ::prost::alloc::string::String,
 }


### PR DESCRIPTION
Use tracked actual_cost instead of accepting external final cost value.

The billing service now uses the rental's tracked `actual_cost` directly when finalizing, rather than accepting an externally-provided `final_cost` parameter that could override it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated billing cost calculation to derive final charges directly from tracked usage data, improving accuracy of rental charge computation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->