### PR TITLE
refactor(billing): simplify CostUpdateData to track price_per_gpu

### DIFF
--- a/crates/basilica-billing/src/domain/billing_handlers.rs
+++ b/crates/basilica-billing/src/domain/billing_handlers.rs
@@ -371,8 +371,25 @@ impl EventHandlers for BillingEventHandlers {
                 id: rental_id.to_string(),
             })?;
 
-        let new_cost = CreditBalance::from_decimal(cost_data.total_cost);
-        rental.actual_cost = new_cost;
+        let new_price = cost_data.price_per_gpu;
+        if new_price <= Decimal::ZERO {
+            return Err(BillingError::ValidationError {
+                field: "price_per_gpu".to_string(),
+                message: "price_per_gpu must be greater than zero".to_string(),
+            });
+        }
+
+        let old_price = rental.base_price_per_gpu;
+
+        if new_price == old_price {
+            info!(
+                "Cost update for rental {} ignored: price unchanged at {}",
+                rental_id, new_price
+            );
+            return Ok(());
+        }
+
+        rental.base_price_per_gpu = new_price;
 
         self.rental_repository.update_rental(&rental).await?;
 
@@ -381,15 +398,18 @@ impl EventHandlers for BillingEventHandlers {
             &rental_id.to_string(),
             rental.user_id.as_uuid().ok(),
             serde_json::json!({
-                "total_cost": cost_data.total_cost,
-                "hourly_rate": cost_data.hourly_rate,
-                "duration_hours": cost_data.duration_hours,
+                "old_price_per_gpu": old_price.to_string(),
+                "new_price_per_gpu": new_price.to_string(),
+                "reason": cost_data.reason,
                 "timestamp": event.timestamp,
             }),
         )
         .await?;
 
-        info!("Updated cost for rental {} to {}", rental_id, new_cost);
+        info!(
+            "Updated price for rental {} from {} to {}",
+            rental_id, old_price, new_price
+        );
 
         Ok(())
     }

--- a/crates/basilica-billing/src/domain/processor.rs
+++ b/crates/basilica-billing/src/domain/processor.rs
@@ -257,9 +257,10 @@ pub struct StatusChangeData {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CostUpdateData {
-    pub total_cost: Decimal,
-    pub hourly_rate: Option<Decimal>,
-    pub duration_hours: Option<Decimal>,
+    /// New price per GPU per hour
+    pub price_per_gpu: Decimal,
+    /// Optional reason/context for the price change
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/basilica-billing/src/storage/rentals.rs
+++ b/crates/basilica-billing/src/storage/rentals.rs
@@ -188,7 +188,8 @@ impl RentalRepository for SqlRentalRepository {
             r#"
             UPDATE billing.rentals
             SET status = $2, resource_spec = $3,
-                updated_at = $4, end_time = $5, metadata = $6, total_cost = $7
+                updated_at = $4, end_time = $5, metadata = $6,
+                total_cost = $7, base_price_per_gpu = $8
             WHERE rental_id = $1
             "#,
         )
@@ -203,6 +204,7 @@ impl RentalRepository for SqlRentalRepository {
         } else {
             Some(total_cost)
         })
+        .bind(rental.base_price_per_gpu)
         .execute(self.connection.pool())
         .await
         .map_err(|e| BillingError::DatabaseError {
@@ -350,7 +352,8 @@ impl SqlRentalRepository {
             r#"
             UPDATE billing.rentals
             SET status = $2, resource_spec = $3,
-                updated_at = $4, end_time = $5, metadata = $6, total_cost = $7
+                updated_at = $4, end_time = $5, metadata = $6,
+                total_cost = $7, base_price_per_gpu = $8
             WHERE rental_id = $1
             "#,
         )
@@ -365,6 +368,7 @@ impl SqlRentalRepository {
         } else {
             Some(total_cost)
         })
+        .bind(rental.base_price_per_gpu)
         .execute(&mut **tx)
         .await
         .map_err(|e| BillingError::DatabaseError {


### PR DESCRIPTION
Simplifies cost update event handling by tracking `price_per_gpu` instead of computed totals.

Changes:
- `CostUpdateData` now contains `price_per_gpu` and optional `reason` instead of `total_cost`, `hourly_rate`, `duration_hours`
- Handler validates price is positive and skips updates when price unchanged
- SQL queries updated to persist `base_price_per_gpu` on rental updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reason field to track context for billing price changes.
  * Introduced price-per-GPU tracking in billing events with old and new price information.

* **Refactor**
  * Updated billing cost calculation to use price-per-GPU model instead of hourly rates.
  * Simplified billing event payload to focus on price change data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->