### PR TITLE
feat(cli): show local SSH key path in status and ssh-keys list

### DIFF
--- a/crates/basilica-api/src/api/routes/secure_cloud.rs
+++ b/crates/basilica-api/src/api/routes/secure_cloud.rs
@@ -35,6 +35,7 @@ type RentalQueryRow = (
     Option<i32>,                           // vcpu_count (from gpu_offerings)
     Option<i32>,                           // system_memory_gb (from gpu_offerings)
     Option<String>,                        // region (from gpu_offerings)
+    Option<String>,                        // ssh_public_key (from ssh_keys)
 );
 
 /// Get SSH public key for user and validate ownership
@@ -135,12 +136,14 @@ pub async fn list_secure_cloud_rentals(
     Extension(auth): Extension<AuthContext>,
 ) -> Result<impl IntoResponse, ApiError> {
     // 1. Query secure_cloud_rentals table for this user, JOIN with gpu_offerings for resource specs
+    //    and ssh_keys for the public key (for local key matching in CLI)
     let rentals: Vec<RentalQueryRow> = sqlx::query_as(
         "SELECT r.id, r.provider, r.provider_instance_id, r.offering_id, r.instance_type, \
          r.location_code, r.status, r.ip_address, r.created_at, r.stopped_at, \
-         o.vcpu_count, o.system_memory_gb, o.region \
+         o.vcpu_count, o.system_memory_gb, o.region, k.public_key \
          FROM secure_cloud_rentals r \
          LEFT JOIN gpu_offerings o ON r.offering_id = o.id \
+         LEFT JOIN ssh_keys k ON r.ssh_key_id = k.id \
          WHERE r.user_id = $1 \
          ORDER BY r.created_at DESC",
     )
@@ -207,6 +210,7 @@ pub async fn list_secure_cloud_rentals(
                 db_vcpu_count,
                 db_system_memory_gb,
                 db_region,
+                ssh_public_key,
             )| {
                 let markup_multiplier =
                     1.0 + (state.pricing_config.secure_cloud_markup_percent / 100.0);
@@ -258,6 +262,7 @@ pub async fn list_secure_cloud_rentals(
                     created_at,
                     stopped_at,
                     ssh_command,
+                    ssh_public_key,
                     vcpu_count,
                     system_memory_gb,
                     accumulated_cost,

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -13,7 +13,7 @@ use crate::output::{
     compress_path, json_output, print_error, print_info, print_success, table_output,
 };
 use crate::progress::{complete_spinner_and_clear, complete_spinner_error, create_spinner};
-use crate::ssh::{parse_ssh_credentials, SshClient};
+use crate::ssh::{find_private_key_for_public_key, parse_ssh_credentials, SshClient};
 use crate::CliError;
 use basilica_common::types::{ComputeCategory, GpuCategory};
 use basilica_common::utils::{parse_env_vars, parse_port_mappings};
@@ -1264,8 +1264,31 @@ pub async fn handle_status(
                 if let Some(stopped_at) = &rental.stopped_at {
                     println!("  Stopped: {}", stopped_at);
                 }
-                if let Some(ssh_cmd) = &rental.ssh_command {
-                    println!("  SSH: {}", ssh_cmd);
+                // Show SSH command with private key path if available locally
+                if let Some(ip) = &rental.ip_address {
+                    if let Some(ref ssh_public_key) = rental.ssh_public_key {
+                        if let Ok(private_key_path) =
+                            find_private_key_for_public_key(ssh_public_key)
+                        {
+                            // Full SSH command with private key
+                            println!(
+                                "  SSH: {}",
+                                style(format!(
+                                    "ssh -i {} ubuntu@{}",
+                                    compress_path(&private_key_path),
+                                    ip
+                                ))
+                                .cyan()
+                            );
+                        } else {
+                            // Key not found locally, show basic command
+                            println!("  SSH: ssh ubuntu@{}", ip);
+                            println!("  SSH Key: {}", style("Not found locally").yellow());
+                        }
+                    } else {
+                        // No public key info, show basic command
+                        println!("  SSH: ssh ubuntu@{}", ip);
+                    }
                 }
             }
         }

--- a/crates/basilica-cli/src/cli/handlers/ssh_keys.rs
+++ b/crates/basilica-cli/src/cli/handlers/ssh_keys.rs
@@ -1,7 +1,8 @@
 //! SSH key management handlers for the Basilica CLI
 
 use crate::error::CliError;
-use crate::output::print_success;
+use crate::output::{compress_path, print_success};
+use crate::ssh::find_local_public_key_path;
 use basilica_sdk::BasilicaClient;
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
@@ -420,6 +421,17 @@ pub async fn handle_list_ssh_keys(client: &BasilicaClient) -> Result<(), CliErro
                 "  Created:    {}",
                 key.created_at.format("%Y-%m-%d %H:%M:%S")
             );
+
+            // Show local path if the key exists on this machine
+            if let Some(local_path) = find_local_public_key_path(&key.public_key) {
+                println!(
+                    "  Local Path: {}",
+                    style(compress_path(&local_path)).green()
+                );
+            } else {
+                println!("  Local Path: {}", style("Not found locally").yellow());
+            }
+
             println!();
             println!(
                 "{}",

--- a/crates/basilica-cli/src/ssh/key_matcher.rs
+++ b/crates/basilica-cli/src/ssh/key_matcher.rs
@@ -102,6 +102,59 @@ pub fn find_private_key_for_public_key(registered_public_key: &str) -> Result<Pa
     }
 }
 
+/// Find the local public key file that corresponds to a given public key string
+///
+/// This function searches ~/.ssh/ for .pub files and compares their content
+/// with the provided public key. When a match is found, it returns the path
+/// to the public key file.
+///
+/// # Arguments
+/// * `registered_public_key` - The public key string to search for
+///
+/// # Returns
+/// Some(PathBuf) to the matching public key file, or None if:
+/// - No ~/.ssh directory exists
+/// - No matching .pub file found
+/// - The public key is malformed
+pub fn find_local_public_key_path(registered_public_key: &str) -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let ssh_dir = PathBuf::from(home).join(".ssh");
+
+    if !ssh_dir.exists() {
+        return None;
+    }
+
+    let registered_key_parts = parse_public_key(registered_public_key).ok()?;
+
+    let entries = fs::read_dir(&ssh_dir).ok()?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        if !path.is_file() || path.extension().and_then(|s| s.to_str()) != Some("pub") {
+            continue;
+        }
+
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let file_key_parts = match parse_public_key(&content) {
+            Ok(parts) => parts,
+            Err(_) => continue,
+        };
+
+        if file_key_parts.key_type == registered_key_parts.key_type
+            && file_key_parts.key_data == registered_key_parts.key_data
+        {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
 /// Parsed components of an SSH public key
 #[derive(Debug, PartialEq)]
 struct PublicKeyParts {

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -2,7 +2,7 @@
 
 mod key_matcher;
 
-pub use key_matcher::find_private_key_for_public_key;
+pub use key_matcher::{find_local_public_key_path, find_private_key_for_public_key};
 
 use crate::config::SshConfig;
 use crate::error::{CliError, Result};

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -539,6 +539,10 @@ pub struct SecureCloudRentalListItem {
     /// SSH connection info
     pub ssh_command: Option<String>,
 
+    /// SSH public key associated with this rental (for local key matching)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssh_public_key: Option<String>,
+
     /// Number of vCPU cores
     pub vcpu_count: Option<u32>,
 


### PR DESCRIPTION
Add local SSH key path discovery to `basilica status` and `basilica ssh-keys list` commands.

When viewing SSH key info or secure cloud rental status, users can now see which local file corresponds to their registered key:
- **Green path**: Key found locally (e.g., `~/.ssh/basilica_ed25519.pub`)
- **Yellow "Not found locally"**: Key was registered from a different machine

This helps users working across multiple machines identify whether they have the correct SSH key available locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH public keys are now displayed alongside rental information, enabling better key management and tracking.
  * Rental status provides enhanced SSH commands that automatically detect and use locally stored private keys when available, improving connection setup experience.
  * SSH key listings now clearly indicate whether each key exists locally, simplifying key discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->