### PR TITLE
fix(billing): use provider_instance_id for secure cloud rental events

### DIFF
--- a/crates/basilica-billing/src/domain/billing_handlers.rs
+++ b/crates/basilica-billing/src/domain/billing_handlers.rs
@@ -591,7 +591,10 @@ impl EventHandlers for BillingEventHandlers {
                 id: rental_id.to_string(),
             })?;
 
-        if rental.state == RentalState::Completed || rental.state == RentalState::Failed {
+        if rental.state == RentalState::Completed
+            || rental.state == RentalState::Failed
+            || rental.state == RentalState::FailedInsufficientCredits
+        {
             debug!("Rental {} already ended, skipping", rental_id);
             return Ok(());
         }

--- a/crates/basilica-billing/src/domain/rentals.rs
+++ b/crates/basilica-billing/src/domain/rentals.rs
@@ -217,6 +217,14 @@ impl Rental {
             .map(|s| s.as_str())
     }
 
+    /// Node identifier to use when emitting events.
+    /// For community rentals this is the node_id; for secure rentals we
+    /// fall back to provider_instance_id so validation passes and events
+    /// stay consistent with rental_start/telemetry.
+    pub fn event_node_id(&self) -> Option<&str> {
+        self.node_id().or_else(|| self.provider_instance_id())
+    }
+
     /// Get offering_id (secure cloud only)
     pub fn offering_id(&self) -> Option<&str> {
         self.metadata.get("offering_id").map(|s| s.as_str())
@@ -529,7 +537,14 @@ pub async fn finalize_rental_core(
 
     let idempotency_key = generate_idempotency_key(rental.id.as_uuid(), &event_data);
 
-    let node_id = rental.node_id().unwrap_or("").to_string();
+    // Secure cloud rentals do not carry node_id; use provider_instance_id instead.
+    let node_id = rental
+        .event_node_id()
+        .ok_or_else(|| BillingError::ValidationError {
+            field: "node_id".to_string(),
+            message: "node_id or provider_instance_id is required for usage event".to_string(),
+        })?
+        .to_string();
     let validator_id = rental.validator_id().map(|s| s.to_string());
 
     let usage_event = UsageEvent {

--- a/crates/basilica-billing/src/grpc/billing_service.rs
+++ b/crates/basilica-billing/src/grpc/billing_service.rs
@@ -594,7 +594,14 @@ impl BillingService for BillingServiceImpl {
         let idempotency_key = generate_idempotency_key(rental_id.as_uuid(), &event_data);
 
         // Extract node_id and validator_id from metadata for events
-        let node_id = rental.node_id().unwrap_or("").to_string();
+        let node_id = rental
+            .event_node_id()
+            .ok_or_else(|| {
+                Status::failed_precondition(
+                    "rental is missing node_id/provider_instance_id for status event",
+                )
+            })?
+            .to_string();
         let validator_id = rental.validator_id().map(|s| s.to_string());
 
         let status_change_event = UsageEvent {


### PR DESCRIPTION
## Summary
- Fix secure cloud rentals failing to emit billing events due to missing node_id
- Fall back to provider_instance_id for secure rentals when node_id is not available
- Add proper error handling instead of silently using empty strings
- Handle FailedInsufficientCredits as terminal rental state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rental failures due to insufficient credits to prevent orphaned transactions
  * Enhanced validation and error reporting for billing events to ensure data integrity
  * Refined status-change operations with stricter precondition checks for required identifiers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->