### PR TITLE
fix(api): error when explicitly provided config file doesn't exist

### DIFF
--- a/crates/basilica-api/src/config/mod.rs
+++ b/crates/basilica-api/src/config/mod.rs
@@ -247,6 +247,10 @@ impl Config {
         if let Some(path) = path_override {
             if path.exists() {
                 figment = figment.merge(Toml::file(&path));
+            } else {
+                return Err(ConfigError::FileNotFound {
+                    path: path.display().to_string(),
+                });
             }
         } else {
             let default_path = PathBuf::from("basilica-api.toml");


### PR DESCRIPTION
Previously, if a config file path was explicitly provided via `--config` but the file didn't exist, it was silently ignored and defaults were used instead. This could lead to confusing behavior where users think their config is being applied when it isn't.

Now returns a `FileNotFound` error to alert the user of the misconfiguration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Configuration file loading now properly reports errors when a custom configuration file path is specified but doesn't exist. Instead of silently continuing with defaults, the system clearly indicates the missing file, helping you troubleshoot configuration issues more efficiently. Standard configuration paths remain unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->