### PR TITLE
feat(cli): trigger billing service on login

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/auth.rs
+++ b/crates/basilica-cli/src/cli/handlers/auth.rs
@@ -17,7 +17,7 @@ pub async fn handle_login(device_code: bool, config: &CliConfig) -> Result<(), C
 /// Handle login with configurable options
 pub async fn handle_login_with_options(
     device_code: bool,
-    _config: &CliConfig,
+    config: &CliConfig,
     show_suggestions: bool,
 ) -> Result<(), CliError> {
     debug!("Starting login process, device_code: {}", device_code);
@@ -91,6 +91,12 @@ pub async fn handle_login_with_options(
     }
 
     complete_spinner_and_clear(spinner);
+
+    // Trigger billing service to create user entry
+    // We don't need the result - the call itself ensures the user exists in billing
+    if let Ok(client) = crate::client::create_authenticated_client(config).await {
+        let _ = client.get_balance().await;
+    }
 
     print_success("⛪ Login successful!");
     println!();


### PR DESCRIPTION
## Summary
Triggers the billing service upon successful CLI login to ensure the user entry is created in the billing system.

## Changes
- After login completes, creates an authenticated client and calls `get_balance()`
- The `get_balance()` call ensures the user exists in the billing system as a side effect
- Errors are silently ignored since this is a best-effort operation that shouldn't block login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication handler with additional validation step during login
  * Adjusted public function signature parameter naming for improved code clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->