### PR TITLE
fix(build): prevent unnecessary rebuilds when .env is missing

### DIFF
--- a/crates/basilica-common/build.rs
+++ b/crates/basilica-common/build.rs
@@ -9,8 +9,10 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    // Tell Cargo to rerun this build script if .env files change
-    println!("cargo:rerun-if-changed=.env");
+    // Tell Cargo to rerun this build script if .env files change (only if file exists)
+    if Path::new(".env").exists() {
+        println!("cargo:rerun-if-changed=.env");
+    }
 
     // Tell Cargo to rerun this build script if these environment variables change
     println!("cargo:rerun-if-env-changed=BASILICA_AUTH0_DOMAIN");


### PR DESCRIPTION
Only emit `cargo:rerun-if-changed=.env` when the file exists.

Previously, the missing file caused `basilica-common` to be marked stale on every build, triggering cascading rebuilds of 10+ dependent crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build efficiency by preventing unnecessary rebuild triggers when environment configuration files are not present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->