### PR TITLE
refactor(cli): remove hardcoded SSH key paths from config

### DIFF
--- a/config/cli.toml.example
+++ b/config/cli.toml.example
@@ -11,13 +11,8 @@ request_timeout = 120
 
 # SSH Configuration
 [ssh]
-# Path to your SSH public key for instance access
-# This key will be added to provisioned instances
-key_path = "~/.ssh/basilica.pub"
-
-# Path to your SSH private key for instance access
-# This key will be used to connect to provisioned instances
-private_key_path = "~/.ssh/basilica"
+# SSH connection timeout in seconds (default: 30)
+connection_timeout = 30
 
 # Docker Image Configuration
 [image]

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -476,10 +476,26 @@ async fn handle_secure_cloud_rental_with_offering(
 
     if options.detach {
         if let Some(ssh_cmd) = &response.ssh_command {
+            // Look up the private key for display
+            let private_key_path = {
+                let ssh_key = api_client
+                    .get_ssh_key()
+                    .await
+                    .map_err(|e| CliError::Internal(eyre!(e)))?
+                    .ok_or_else(|| {
+                        CliError::Internal(
+                            eyre!("No SSH key registered with Basilica")
+                                .suggestion("Run 'basilica ssh-keys add' to register your SSH key"),
+                        )
+                    })?;
+
+                crate::ssh::find_private_key_for_public_key(&ssh_key.public_key)
+                    .map_err(CliError::Internal)?
+            };
             display_secure_cloud_reconnection_instructions(
                 &response.rental_id,
                 ssh_cmd,
-                config,
+                &private_key_path,
                 "To connect to this rental:",
             )?;
         } else {
@@ -524,7 +540,7 @@ async fn handle_secure_cloud_rental_with_offering(
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
-                Some(private_key_path),
+                private_key_path.clone(),
                 RENTAL_READY_TIMEOUT,
             )
             .await
@@ -534,7 +550,7 @@ async fn handle_secure_cloud_rental_with_offering(
                     display_secure_cloud_reconnection_instructions(
                         &response.rental_id,
                         ssh_cmd,
-                        config,
+                        &private_key_path,
                         "To reconnect to this rental:",
                     )?;
                 }
@@ -543,7 +559,7 @@ async fn handle_secure_cloud_rental_with_offering(
                     display_secure_cloud_reconnection_instructions(
                         &response.rental_id,
                         ssh_cmd,
-                        config,
+                        &private_key_path,
                         "Try manually connecting using:",
                     )?;
                 }
@@ -645,10 +661,26 @@ async fn handle_community_cloud_rental_with_selection(
     };
 
     if options.detach {
+        // Look up the private key for display
+        let private_key_path = {
+            let ssh_key = api_client
+                .get_ssh_key()
+                .await
+                .map_err(|e| CliError::Internal(eyre!(e)))?
+                .ok_or_else(|| {
+                    CliError::Internal(
+                        eyre!("No SSH key registered with Basilica")
+                            .suggestion("Run 'basilica ssh-keys add' to register your SSH key"),
+                    )
+                })?;
+
+            crate::ssh::find_private_key_for_public_key(&ssh_key.public_key)
+                .map_err(CliError::Internal)?
+        };
         display_ssh_connection_instructions(
             &response.rental_id,
             ssh_creds,
-            config,
+            &private_key_path,
             "SSH connection options:",
         )?;
     } else {
@@ -684,7 +716,7 @@ async fn handle_community_cloud_rental_with_selection(
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
-                Some(private_key_path),
+                private_key_path.clone(),
                 RENTAL_READY_TIMEOUT,
             )
             .await
@@ -694,7 +726,7 @@ async fn handle_community_cloud_rental_with_selection(
                     display_ssh_connection_instructions(
                         &response.rental_id,
                         ssh_creds,
-                        config,
+                        &private_key_path,
                         "To reconnect to this rental:",
                     )?;
                 }
@@ -703,7 +735,7 @@ async fn handle_community_cloud_rental_with_selection(
                     display_ssh_connection_instructions(
                         &response.rental_id,
                         ssh_creds,
-                        config,
+                        &private_key_path,
                         "Try manually connecting using:",
                     )?;
                 }
@@ -1224,7 +1256,17 @@ pub async fn handle_status(
             if json {
                 json_output(&status)?;
             } else {
-                display_rental_status_with_details(&status, config);
+                // Try to find the private key for display
+                let private_key_path =
+                    api_client
+                        .get_ssh_key()
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|ssh_key| {
+                            crate::ssh::find_private_key_for_public_key(&ssh_key.public_key).ok()
+                        });
+                display_rental_status_with_details(&status, private_key_path.as_deref());
             }
         }
         ComputeCategory::SecureCloud => {
@@ -1724,7 +1766,7 @@ pub async fn handle_exec(
     // Use SSH client to execute command
     let ssh_client = SshClient::new(&config.ssh)?;
     ssh_client
-        .execute_command(&ssh_access, &command, Some(private_key_path))
+        .execute_command(&ssh_access, &command, private_key_path)
         .await?;
     Ok(())
 }
@@ -1788,7 +1830,7 @@ pub async fn handle_ssh(
 
     // Open interactive session with port forwarding options
     ssh_client
-        .interactive_session_with_options(&ssh_access, &options, Some(private_key_path))
+        .interactive_session_with_options(&ssh_access, &options, private_key_path)
         .await?;
     Ok(())
 }
@@ -1875,22 +1917,12 @@ pub async fn handle_cp(
 
     if is_upload {
         ssh_client
-            .upload_file(
-                &ssh_access,
-                &local_path,
-                &remote_path,
-                Some(private_key_path),
-            )
+            .upload_file(&ssh_access, &local_path, &remote_path, private_key_path)
             .await?;
         Ok(())
     } else {
         ssh_client
-            .download_file(
-                &ssh_access,
-                &remote_path,
-                &local_path,
-                Some(private_key_path),
-            )
+            .download_file(&ssh_access, &remote_path, &local_path, private_key_path)
             .await?;
         Ok(())
     }
@@ -2095,7 +2127,7 @@ async fn poll_secure_cloud_rental_status(
 async fn retry_ssh_connection(
     ssh_client: &SshClient,
     ssh_access: &SshAccess,
-    private_key_override: Option<PathBuf>,
+    private_key_path: PathBuf,
     max_wait: Duration,
 ) -> Result<(), CliError> {
     const INITIAL_INTERVAL: Duration = Duration::from_secs(2);
@@ -2115,14 +2147,14 @@ async fn retry_ssh_connection(
         // First test connectivity without starting an interactive session
         // This captures stderr so we don't print raw SSH errors
         match ssh_client
-            .test_connection(ssh_access, private_key_override.clone())
+            .test_connection(ssh_access, private_key_path.clone())
             .await
         {
             Ok(_) => {
                 // Connection test succeeded, now start the actual interactive session
                 complete_spinner_and_clear(spinner);
                 return ssh_client
-                    .interactive_session(ssh_access, private_key_override)
+                    .interactive_session(ssh_access, private_key_path)
                     .await
                     .map_err(|e| CliError::Internal(eyre!("SSH session failed: {}", e)));
             }
@@ -2166,14 +2198,11 @@ async fn retry_ssh_connection(
 fn display_ssh_connection_instructions(
     rental_id: &str,
     ssh_credentials: &str,
-    config: &CliConfig,
+    private_key_path: &std::path::Path,
     message: &str,
 ) -> Result<(), CliError> {
     // Parse SSH credentials to get components
     let (host, port, username) = parse_ssh_credentials(ssh_credentials)?;
-
-    // Get the private key path from config
-    let private_key_path = &config.ssh.private_key_path;
 
     println!();
     print_info(message);
@@ -2211,14 +2240,11 @@ fn display_ssh_connection_instructions(
 fn display_secure_cloud_reconnection_instructions(
     rental_id: &str,
     ssh_command: &str,
-    config: &CliConfig,
+    private_key_path: &std::path::Path,
     message: &str,
 ) -> Result<(), CliError> {
     // Parse SSH command to get components
     let (host, port, username) = parse_ssh_credentials(ssh_command)?;
-
-    // Get the private key path from config
-    let private_key_path = &config.ssh.private_key_path;
 
     println!();
     print_info(message);
@@ -2262,7 +2288,7 @@ fn split_remote_path(path: &str) -> (Option<String>, String) {
 
 fn display_rental_status_with_details(
     status: &basilica_sdk::types::RentalStatusWithSshResponse,
-    config: &CliConfig,
+    private_key_path: Option<&std::path::Path>,
 ) {
     println!("Rental Status: {}", status.rental_id);
     println!("  Status: {:?}", status.status);
@@ -2291,8 +2317,6 @@ fn display_rental_status_with_details(
     // Display SSH connection instructions if available
     if let Some(ref ssh_credentials) = status.ssh_credentials {
         if let Ok((host, port, username)) = parse_ssh_credentials(ssh_credentials) {
-            let private_key_path = &config.ssh.private_key_path;
-
             println!();
             print_info("SSH Connection:");
             println!();
@@ -2308,19 +2332,30 @@ fn display_rental_status_with_details(
             println!();
 
             // Option 2: Using standard SSH command
-            println!("  2. Using standard SSH:");
-            println!(
-                "     {}",
-                console::style(format!(
-                    "ssh -i {} -p {} {}@{}",
-                    compress_path(private_key_path),
-                    port,
-                    username,
-                    host
-                ))
-                .cyan()
-                .bold()
-            );
+            if let Some(key_path) = private_key_path {
+                println!("  2. Using standard SSH:");
+                println!(
+                    "     {}",
+                    console::style(format!(
+                        "ssh -i {} -p {} {}@{}",
+                        compress_path(key_path),
+                        port,
+                        username,
+                        host
+                    ))
+                    .cyan()
+                    .bold()
+                );
+            } else {
+                println!("  2. Using standard SSH:");
+                println!(
+                    "     {}",
+                    console::style(format!("ssh -p {} {}@{}", port, username, host))
+                        .cyan()
+                        .bold()
+                );
+                println!("     {}", style("(private key not found locally)").yellow());
+            }
         }
     }
 }

--- a/crates/basilica-cli/src/config/mod.rs
+++ b/crates/basilica-cli/src/config/mod.rs
@@ -56,10 +56,6 @@ impl Default for ApiConfig {
 /// SSH configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SshConfig {
-    /// Default SSH public key path
-    pub key_path: PathBuf,
-    /// SSH private key path
-    pub private_key_path: PathBuf,
     /// SSH connection timeout in seconds (default: 30)
     #[serde(default = "default_ssh_timeout")]
     pub connection_timeout: u64,
@@ -76,27 +72,8 @@ fn default_api_request_timeout() -> u64 {
 impl Default for SshConfig {
     fn default() -> Self {
         Self {
-            key_path: PathBuf::from("~/.ssh/basilica_ed25519.pub"),
-            private_key_path: PathBuf::from("~/.ssh/basilica_ed25519"),
             connection_timeout: 30,
         }
-    }
-}
-
-impl SshConfig {
-    /// Check if SSH keys exist at the configured paths
-    pub fn ssh_keys_exist(&self) -> bool {
-        self.key_path.exists() && self.private_key_path.exists()
-    }
-
-    /// Check if SSH keys are missing (neither exists)
-    pub fn ssh_keys_missing(&self) -> bool {
-        !self.key_path.exists() && !self.private_key_path.exists()
-    }
-
-    /// Check if SSH key pair is incomplete (only one exists)
-    pub fn ssh_keys_incomplete(&self) -> bool {
-        self.key_path.exists() != self.private_key_path.exists()
     }
 }
 
@@ -215,14 +192,6 @@ impl CliConfig {
 
     /// Expand tilde (~) in path fields
     fn expand_paths(&mut self) {
-        if let Some(path_str) = self.ssh.key_path.to_str() {
-            let expanded = shellexpand::tilde(path_str);
-            self.ssh.key_path = PathBuf::from(expanded.as_ref());
-        }
-        if let Some(path_str) = self.ssh.private_key_path.to_str() {
-            let expanded = shellexpand::tilde(path_str);
-            self.ssh.private_key_path = PathBuf::from(expanded.as_ref());
-        }
         if let Some(path_str) = self.wallet.base_wallet_path.to_str() {
             let expanded = shellexpand::tilde(path_str);
             self.wallet.base_wallet_path = PathBuf::from(expanded.as_ref());
@@ -238,10 +207,6 @@ impl CliConfig {
         };
 
         let mut config = self.clone();
-
-        // Compress SSH paths
-        config.ssh.key_path = Self::compress_path(&config.ssh.key_path, &home_dir);
-        config.ssh.private_key_path = Self::compress_path(&config.ssh.private_key_path, &home_dir);
 
         // Compress wallet path
         config.wallet.base_wallet_path =
@@ -300,27 +265,6 @@ impl CliConfig {
         };
 
         map.insert("api.base_url".to_string(), self.api.base_url.clone());
-
-        // Compress SSH key paths
-        let ssh_key_path = if let Some(ref home) = home_dir {
-            Self::compress_path(&self.ssh.key_path, home)
-        } else {
-            self.ssh.key_path.clone()
-        };
-        map.insert(
-            "ssh.key_path".to_string(),
-            ssh_key_path.to_string_lossy().to_string(),
-        );
-
-        let ssh_private_key_path = if let Some(ref home) = home_dir {
-            Self::compress_path(&self.ssh.private_key_path, home)
-        } else {
-            self.ssh.private_key_path.clone()
-        };
-        map.insert(
-            "ssh.private_key_path".to_string(),
-            ssh_private_key_path.to_string_lossy().to_string(),
-        );
 
         map.insert(
             "ssh.connection_timeout".to_string(),

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -53,12 +53,8 @@ impl SshClient {
     fn ssh_access_to_connection_details(
         &self,
         ssh_access: &SshAccess,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<SshConnectionDetails> {
-        // Use override if provided, otherwise fall back to configured key
-        let private_key_path =
-            private_key_override.unwrap_or_else(|| self.config.private_key_path.clone());
-
         if !private_key_path.exists() {
             return Err(eyre!(
                 "SSH private key not found at: {}",
@@ -86,9 +82,9 @@ impl SshClient {
         &self,
         ssh_access: &SshAccess,
         command: &str,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
         debug!(
             "Executing command via SSH: ssh -i {} -p {} {}@{} '{}'",
@@ -131,9 +127,9 @@ impl SshClient {
     pub async fn test_connection(
         &self,
         ssh_access: &SshAccess,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
         debug!(
             "Testing SSH connectivity to {}@{}:{}",
@@ -174,9 +170,9 @@ impl SshClient {
     pub async fn interactive_session(
         &self,
         ssh_access: &SshAccess,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
         info!(
             "Opening SSH session to {}@{}",
@@ -297,9 +293,9 @@ impl SshClient {
         &self,
         ssh_access: &SshAccess,
         options: &crate::cli::commands::SshOptions,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
         info!(
             "Opening SSH session to {}@{}",
@@ -394,9 +390,9 @@ impl SshClient {
         ssh_access: &SshAccess,
         local_path: &str,
         remote_path: &str,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
         let local = Path::new(local_path);
 
         info!("Uploading {} to {}", local_path, ssh_access.host);
@@ -420,9 +416,9 @@ impl SshClient {
         ssh_access: &SshAccess,
         remote_path: &str,
         local_path: &str,
-        private_key_override: Option<std::path::PathBuf>,
+        private_key_path: std::path::PathBuf,
     ) -> Result<()> {
-        let details = self.ssh_access_to_connection_details(ssh_access, private_key_override)?;
+        let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
         let local = Path::new(local_path);
 
         info!("Downloading {} from {}", remote_path, ssh_access.host);


### PR DESCRIPTION
Removes `ssh.key_path` and `ssh.private_key_path` from CLI config. Instead, the private key is dynamically located by matching against the public key registered with Basilica using `find_private_key_for_public_key()`.

This simplifies configuration and enables SSH to work correctly when the user has multiple SSH keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * SSH authentication mechanism refactored to derive keys dynamically from API, eliminating the need for SSH key configuration in files.
  * Added SSH connection timeout setting (30 seconds default) for improved connection stability.

* **Chores**
  * Removed legacy SSH key path configuration options from config files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->