### PR TITLE
fix(build): use actual .env path for rebuild trigger

### DIFF
--- a/crates/basilica-common/build.rs
+++ b/crates/basilica-common/build.rs
@@ -9,19 +9,17 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    // Tell Cargo to rerun this build script if .env files change (only if file exists)
-    if Path::new(".env").exists() {
-        println!("cargo:rerun-if-changed=.env");
-    }
-
     // Tell Cargo to rerun this build script if these environment variables change
     println!("cargo:rerun-if-env-changed=BASILICA_AUTH0_DOMAIN");
     println!("cargo:rerun-if-env-changed=BASILICA_AUTH0_CLIENT_ID");
     println!("cargo:rerun-if-env-changed=BASILICA_AUTH0_AUDIENCE");
     println!("cargo:rerun-if-env-changed=BASILICA_AUTH0_ISSUER");
 
-    // Try to load .env file from project root (ignore if it doesn't exist)
-    let _ = dotenvy::dotenv();
+    // Try to load .env file (searches current dir and parents).
+    // If found, tell Cargo to rebuild when it changes.
+    if let Ok(path) = dotenvy::dotenv() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
 
     // Default values (same as current hardcoded values)
     let defaults = [


### PR DESCRIPTION
Fixes the rerun-if-changed directive to use the path returned by dotenvy instead of checking a hardcoded location. This ensures the rebuild trigger correctly tracks the .env file that was actually loaded (which may be in a parent directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build system to intelligently search for environment configuration files within project directories and their parents, ensuring proper handling and management of build cache invalidation. This results in more reliable and consistent builds for all users compiling from source, with better support for various project structures and development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->