### PR TITLE
feat(cli): add 'bs' shorthand alias for basilica command

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/upgrade.rs
+++ b/crates/basilica-cli/src/cli/handlers/upgrade.rs
@@ -142,14 +142,17 @@ fn ensure_alias_symlink() {
     let Some(parent) = current_exe.parent() else {
         return;
     };
+    let Some(binary_name) = current_exe.file_name() else {
+        return;
+    };
 
     let alias_path = parent.join("bs");
 
     // Remove existing symlink/file if present (ignore errors)
     let _ = std::fs::remove_file(&alias_path);
 
-    // Create new symlink
-    match symlink(&current_exe, &alias_path) {
+    // Create new symlink (relative, so it survives directory moves)
+    match symlink(binary_name, &alias_path) {
         Ok(_) => println!("Created 'bs' alias"),
         Err(e) => eprintln!("Failed to create 'bs' alias: {}", e),
     }

--- a/scripts/web/install.sh
+++ b/scripts/web/install.sh
@@ -527,9 +527,13 @@ install_binary() {
     mv -f "$TEMP_BINARY" "$INSTALL_DIR/$BINARY_NAME"
     chmod +x "$INSTALL_DIR/$BINARY_NAME"
 
-    # Create 'bs' alias symlink
+    # Create 'bs' alias symlink (relative, so it survives directory moves)
     print_step "Creating 'bs' alias..."
-    ln -sf "$INSTALL_DIR/$BINARY_NAME" "$INSTALL_DIR/bs"
+    if (cd "$INSTALL_DIR" && ln -sf "$BINARY_NAME" "bs") 2>/dev/null; then
+        print_info "'bs' alias created successfully"
+    else
+        print_warning "Failed to create 'bs' alias"
+    fi
 }
 
 # Setup shell completions


### PR DESCRIPTION
Adds a shorter `bs` alias for the `basilica` CLI, making it faster to type commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer and upgrade flow now create a short "bs" alias for the main command, letting you run either "basilica" or "bs".
  * Upgrade completion now suggests verifying the installation with both the main command and the "bs" alias.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->