### PR TITLE
feat(cloud): add VIP managed machines S3 configuration

### DIFF
--- a/scripts/cloud/compute.tf
+++ b/scripts/cloud/compute.tf
@@ -407,6 +407,13 @@ module "basilica_api_service" {
     BASILICA_API_WIREGUARD__ENABLED = tostring(var.wireguard_enabled)
     BASILICA_API_WIREGUARD__SERVERS = jsonencode(var.wireguard_servers)
 
+    # VIP (Managed Machines) Configuration
+    # Set s3_bucket and s3_key to sync VIP machines from S3
+    BASILICA_API_AGGREGATOR__VIP__S3_BUCKET          = var.vip_s3_bucket
+    BASILICA_API_AGGREGATOR__VIP__S3_KEY             = var.vip_s3_key
+    BASILICA_API_AGGREGATOR__VIP__S3_REGION          = var.vip_s3_region != "" ? var.vip_s3_region : var.aws_region
+    BASILICA_API_AGGREGATOR__VIP__POLL_INTERVAL_SECS = tostring(var.vip_poll_interval_secs)
+
     # Logging
     RUST_LOG = "basilica_api=debug,basilica_protocol=info,kube=debug"
   }
@@ -430,6 +437,35 @@ module "basilica_api_service" {
   tags = local.common_tags
 
   depends_on = [module.rds, module.basilica_api_alb]
+}
+
+# =============================================================================
+# VIP S3 ACCESS POLICY
+# =============================================================================
+# Grant the API service permission to read VIP machine data from S3
+# This is only created when VIP is enabled and S3 bucket is configured
+
+resource "aws_iam_role_policy" "api_vip_s3_access" {
+  count = var.vip_s3_bucket != "" ? 1 : 0
+  name  = "${local.name_prefix}-api-vip-s3-access"
+  role  = module.basilica_api_service.task_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.vip_s3_bucket}",
+          "arn:aws:s3:::${var.vip_s3_bucket}/${var.vip_s3_key}"
+        ]
+      }
+    ]
+  })
 }
 
 # =============================================================================

--- a/scripts/cloud/modules/ecs-service/outputs.tf
+++ b/scripts/cloud/modules/ecs-service/outputs.tf
@@ -23,6 +23,11 @@ output "task_role_arn" {
   value       = aws_iam_role.task.arn
 }
 
+output "task_role_name" {
+  description = "Task role name"
+  value       = aws_iam_role.task.name
+}
+
 output "security_group_id" {
   description = "ECS tasks security group ID"
   value       = var.ecs_tasks_security_group_id

--- a/scripts/cloud/terraform.tfvars.example
+++ b/scripts/cloud/terraform.tfvars.example
@@ -115,3 +115,37 @@ hyperstack_api_key = "your-hyperstack-api-key"
 # k3s_vpc_cidr is the CIDR block of the K3s VPC (e.g., 10.101.0.0/16)
 k3s_vpc_peering_connection_id = ""
 k3s_vpc_cidr                  = ""
+
+# =============================================================================
+# VIP (MANAGED MACHINES) CONFIGURATION
+# =============================================================================
+# VIP allows team-managed GPU machines to be synced from an S3 CSV file
+# and made available to specific users through the rental system.
+
+# S3 bucket containing VIP machines CSV file
+# Example: "my-company-vip-machines"
+vip_s3_bucket = ""
+
+# S3 object key for the CSV file
+# Example: "vip/machines.csv"
+vip_s3_key = ""
+
+# S3 region (optional - defaults to aws_region if not specified)
+# Example: "us-east-2"
+vip_s3_region = ""
+
+# Polling interval in seconds (how often to sync from S3)
+# Default: 60 seconds
+vip_poll_interval_secs = 60
+
+# =============================================================================
+# VIP CSV FILE FORMAT
+# =============================================================================
+# The CSV file in S3 should have the following columns:
+# vip_machine_id, assigned_user, active, ssh_host, ssh_port, ssh_user,
+# gpu_type, gpu_count, region, hourly_rate, vcpu_count, system_memory_gb, notes
+#
+# Example CSV:
+# vip_machine_id,assigned_user,active,ssh_host,ssh_port,ssh_user,gpu_type,gpu_count,region,hourly_rate,vcpu_count,system_memory_gb,notes
+# machine-001,auth0|user123,1,10.0.0.1,22,ubuntu,H100,8,us-east-1,25.00,128,500,Production H100 cluster
+# machine-002,auth0|user456,1,10.0.0.2,22,ubuntu,A100,4,us-west-2,12.00,64,256,

--- a/scripts/cloud/variables.tf
+++ b/scripts/cloud/variables.tf
@@ -194,3 +194,31 @@ variable "k3s_vpc_cidr" {
   description = "CIDR block of the K3s VPC (e.g., 10.101.0.0/16). Required for routing traffic via VPC peering."
   default     = ""
 }
+
+# =============================================================================
+# VIP (Managed Machines) Configuration
+# =============================================================================
+
+variable "vip_s3_bucket" {
+  type        = string
+  description = "S3 bucket name containing VIP machines CSV file"
+  default     = ""
+}
+
+variable "vip_s3_key" {
+  type        = string
+  description = "S3 object key for VIP machines CSV file (e.g., 'vip/machines.csv')"
+  default     = ""
+}
+
+variable "vip_s3_region" {
+  type        = string
+  description = "AWS region for VIP S3 bucket (defaults to aws_region if not specified)"
+  default     = ""
+}
+
+variable "vip_poll_interval_secs" {
+  type        = number
+  description = "Polling interval in seconds for VIP machine sync (default: 60)"
+  default     = 60
+}


### PR DESCRIPTION
Adds Terraform configuration for syncing VIP (managed machines) from S3.

New variables:
- `vip_s3_bucket` / `vip_s3_key` - S3 location of machines CSV
- `vip_s3_region` - Optional region override
- `vip_poll_interval_secs` - Sync frequency

When `vip_s3_bucket` is set, an IAM policy is attached to grant the API service S3 read access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VIP (Managed Machines) configuration support with S3 integration for machine synchronization
  * Introduced new configuration parameters: S3 bucket location, object key, region, and polling interval

* **Chores**
  * Exposed task role name as a service configuration output

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->