### PR TITLE
fix(logging): disable ANSI colors for cloud deployments

### DIFF
--- a/crates/basilica-common/src/logging/mod.rs
+++ b/crates/basilica-common/src/logging/mod.rs
@@ -43,16 +43,29 @@ pub fn init_logging<L: LogLevel>(
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter))
     };
 
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(true) // Show module path
+        // .with_file(true) // Show source file
+        // .with_line_number(true) // Show line number
+        .compact(); // Use compact format
+
+    let fmt_layer = match resolve_ansi_override() {
+        Some(ansi) => fmt_layer.with_ansi(ansi),
+        None => fmt_layer,
+    };
+
     tracing_subscriber::registry()
         .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(true) // Show module path
-                // .with_file(true) // Show source file
-                // .with_line_number(true) // Show line number
-                .compact(), // Use compact format
-        )
+        .with(fmt_layer)
         .init();
 
     Ok(())
+}
+
+fn resolve_ansi_override() -> Option<bool> {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return Some(false);
+    }
+
+    None
 }

--- a/scripts/cloud/compute.tf
+++ b/scripts/cloud/compute.tf
@@ -176,6 +176,7 @@ module "billing_service" {
 
     # Logging
     RUST_LOG = "basilica_billing=info,basilica_protocol=info"
+    NO_COLOR = "1"
   }
 
   # No secrets needed - using environment variables
@@ -271,6 +272,7 @@ module "payments_service" {
 
     # Logging
     RUST_LOG = "basilica_payments=info,bittensor=info,basilica_protocol=info"
+    NO_COLOR = "1"
   }
 
   # Secrets from AWS Secrets Manager
@@ -409,6 +411,7 @@ module "basilica_api_service" {
 
     # Logging
     RUST_LOG = "basilica_api=debug,basilica_protocol=info,kube=debug"
+    NO_COLOR = "1"
   }
 
   # Secrets from AWS Secrets Manager


### PR DESCRIPTION
Cloud log aggregators don't support ANSI escape codes, causing ASCII artifacts in logs.

This PR:
- Adds `NO_COLOR` environment variable support to the logging module
- Sets `NO_COLOR=1` for billing, payments, and API services in cloud compute config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the NO_COLOR environment variable to disable colored output in logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->