### PR TITLE
fix(webhooks): use case-insensitive comparison for Hyperstack token

### DIFF
--- a/crates/basilica-aggregator/src/config.rs
+++ b/crates/basilica-aggregator/src/config.rs
@@ -258,6 +258,16 @@ impl Config {
                     "Hyperstack webhook_secret must be URL-safe (A-Z a-z 0-9 - _ . ~)".to_string(),
                 ));
             }
+            if hyperstack
+                .webhook_secret
+                .chars()
+                .any(|c| c.is_ascii_uppercase())
+            {
+                tracing::warn!(
+                    "Hyperstack webhook_secret contains uppercase characters; \
+                     Hyperstack lowercases callback URLs so token comparison will be case-insensitive"
+                );
+            }
             if hyperstack.callback_base_url.trim().is_empty() {
                 return Err(AggregatorError::Config(
                     "Hyperstack callback_base_url must be non-empty".to_string(),

--- a/crates/basilica-api/src/api/routes/webhooks.rs
+++ b/crates/basilica-api/src/api/routes/webhooks.rs
@@ -47,7 +47,8 @@ pub async fn hyperstack_callback(
         }
     };
 
-    if token != hyperstack_config.webhook_secret {
+    // Hyperstack lowercases callback URL query params, so compare case-insensitively
+    if token.to_lowercase() != hyperstack_config.webhook_secret.to_lowercase() {
         tracing::warn!("Invalid webhook token received");
         // Return 200 to avoid information leakage
         return (StatusCode::OK, Json(json!({ "status": "unauthorized" })));


### PR DESCRIPTION
Hyperstack automatically lowercases callback URL query parameters when storing and sending webhook callbacks. This caused token validation to fail when the configured webhook secret contained uppercase letters.

The fix normalizes the configured secret to lowercase before comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook token matching is now case-insensitive, preventing authentication failures due to case mismatches.

* **Chores / Notifications**
  * Added a warning when a configured webhook secret contains uppercase letters to alert about potential case-insensitive handling in callbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->