### PR TITLE
refactor(logging): improve log level configuration

### DIFF
--- a/crates/basilica-api/src/main.rs
+++ b/crates/basilica-api/src/main.rs
@@ -28,8 +28,15 @@ async fn main() -> Result<()> {
 
     // Initialize logging using the unified system
     let binary_name = env!("CARGO_BIN_NAME").replace("-", "_");
-    let default_filter = format!("{}=info,basilica_aggregator=debug", binary_name);
-    basilica_common::logging::init_logging(&args.verbosity, &binary_name, &default_filter)?;
+    let base_filter = format!(
+        "basilica_aggregator=debug,basilica_protocol=info,kube=debug,{}",
+        binary_name
+    );
+    let default_filter = format!(
+        "basilica_aggregator=debug,basilica_protocol=info,kube=debug,{}=info",
+        binary_name
+    );
+    basilica_common::logging::init_logging(&args.verbosity, &base_filter, &default_filter)?;
 
     // Install Prometheus metrics recorder and expose /metrics on a separate listener
     let handle = metrics_exporter_prometheus::PrometheusBuilder::new()

--- a/scripts/cloud/compute.tf
+++ b/scripts/cloud/compute.tf
@@ -334,8 +334,6 @@ module "basilica_api_service" {
 
   # Environment variables
   environment_variables = {
-    RUST_LOG = "debug"
-
     # Server Configuration
     BASILICA_API_SERVER__BIND_ADDRESS    = "0.0.0.0:8000"
     BASILICA_API_SERVER__MAX_CONNECTIONS = "10000"
@@ -420,7 +418,7 @@ module "basilica_api_service" {
     BASILICA_API_AGGREGATOR__PROVIDERS__HYPERSTACK__CALLBACK_BASE_URL = var.hyperstack_callback_base_url
 
     # Logging
-    RUST_LOG = "basilica_api=debug,basilica_protocol=info,kube=debug"
+    RUST_LOG = "basilica_api=debug,basilica_aggregator=debug,basilica_protocol=info,kube=debug"
     NO_COLOR = "1"
   }
 


### PR DESCRIPTION
Improves logging filter configuration for the API service:

- Updates `init_logging` call to use separate base and default filters, enabling per-verbosity level customization
- Removes duplicate `RUST_LOG` declaration in Terraform config
- Adds `basilica_aggregator=debug` to production log filter for better observability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration to use a two-tier scheme (global base + per-service defaults), enabling more granular, per-component log levels.
  * Set explicit log levels for additional components and applied a per-service default level.
  * Environment/config for the API service updated to include the aggregator component in its logging settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->