### PR TITLE
fix(webhooks): finalize billing when Hyperstack VMs are deleted externally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.21.7",
  "basilica-aggregator",

--- a/crates/basilica-api/src/api/routes/webhooks.rs
+++ b/crates/basilica-api/src/api/routes/webhooks.rs
@@ -1,6 +1,6 @@
 //! Webhook handlers for external provider callbacks
 
-use crate::server::AppState;
+use crate::{api::extractors::ownership::archive_secure_cloud_rental, server::AppState};
 use axum::{
     extract::{rejection::JsonRejection, Query, State},
     http::StatusCode,
@@ -9,6 +9,9 @@ use axum::{
 };
 use basilica_aggregator::models::DeploymentStatus;
 use basilica_aggregator::providers::hyperstack::HyperstackCallback;
+use basilica_protocol::billing::{FinalizeRentalRequest, RentalStatus};
+use chrono::Utc;
+use prost_types::Timestamp;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -142,6 +145,68 @@ pub async fn hyperstack_callback(
             "ssh_user": "ubuntu"
         })
     });
+
+    // Determine whether this is a terminal delete event (not just "deleting")
+    let raw_status = payload
+        .data
+        .as_ref()
+        .and_then(|d| d.get("status"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(payload.operation_status());
+    let raw_status_lower = raw_status.to_lowercase();
+
+    if matches!(new_status, DeploymentStatus::Deleted) && raw_status_lower != "deleting" {
+        tracing::info!(
+            rental_id = %rental_id,
+            raw_status = %raw_status,
+            "Webhook indicates VM deletion; finalizing billing and archiving rental"
+        );
+
+        if let Some(billing_client) = state.billing_client.as_deref() {
+            let now = Utc::now();
+            let end_timestamp = Timestamp {
+                seconds: now.timestamp(),
+                nanos: now.timestamp_subsec_nanos() as i32,
+            };
+
+            let finalize_request = FinalizeRentalRequest {
+                rental_id: rental_id.clone(),
+                end_time: Some(end_timestamp),
+                termination_reason: "vm_deleted_externally".to_string(),
+                target_status: RentalStatus::Stopped.into(),
+            };
+
+            if let Err(e) = billing_client.finalize_rental(finalize_request).await {
+                tracing::error!(
+                    error = %e,
+                    rental_id = %rental_id,
+                    "Failed to finalize billing for webhook-deleted rental"
+                );
+            } else {
+                tracing::info!(
+                    rental_id = %rental_id,
+                    "Finalized billing for webhook-deleted rental"
+                );
+            }
+        }
+
+        if let Err(e) = archive_secure_cloud_rental(
+            &state.db,
+            &rental_id,
+            Some("Webhook: VM deleted externally"),
+            Some("deleted"),
+        )
+        .await
+        {
+            tracing::error!(
+                error = %e,
+                rental_id = %rental_id,
+                "Failed to archive rental after webhook delete"
+            );
+        }
+
+        return (StatusCode::OK, Json(json!({ "status": "archived" })));
+    }
 
     // Handle based on new status
     match new_status {

--- a/crates/basilica-api/src/server.rs
+++ b/crates/basilica-api/src/server.rs
@@ -560,6 +560,74 @@ async fn process_secure_cloud_health_check(
     }
 }
 
+/// Cleanup deleted Hyperstack rentals that were missed before webhook-based finalization.
+async fn cleanup_deleted_hyperstack_rental(
+    rental_id: &str,
+    db: &PgPool,
+    billing_client: Option<&BillingClient>,
+) {
+    tracing::info!(
+        rental_id = %rental_id,
+        "Secure Cloud health check: finalizing and archiving deleted Hyperstack rental"
+    );
+
+    if let Some(billing_client) = billing_client {
+        use basilica_protocol::billing::{FinalizeRentalRequest, RentalStatus};
+        use prost_types::Timestamp;
+
+        let now = chrono::Utc::now();
+        let end_timestamp = Timestamp {
+            seconds: now.timestamp(),
+            nanos: now.timestamp_subsec_nanos() as i32,
+        };
+
+        let finalize_request = FinalizeRentalRequest {
+            rental_id: rental_id.to_string(),
+            end_time: Some(end_timestamp),
+            termination_reason: "vm_deleted_externally".to_string(),
+            target_status: RentalStatus::Stopped.into(),
+        };
+
+        if let Err(e) = billing_client.finalize_rental(finalize_request).await {
+            tracing::error!(
+                rental_id = %rental_id,
+                error = %e,
+                "Failed to finalize billing for deleted Hyperstack rental"
+            );
+        } else {
+            tracing::info!(
+                rental_id = %rental_id,
+                "Finalized billing for deleted Hyperstack rental"
+            );
+        }
+    } else {
+        tracing::warn!(
+            rental_id = %rental_id,
+            "Billing client unavailable; skipping finalize for deleted Hyperstack rental"
+        );
+    }
+
+    if let Err(e) = crate::api::extractors::ownership::archive_secure_cloud_rental(
+        db,
+        rental_id,
+        Some("Health check: Hyperstack rental already deleted"),
+        Some("deleted"),
+    )
+    .await
+    {
+        tracing::error!(
+            rental_id = %rental_id,
+            error = %e,
+            "Failed to archive deleted Hyperstack rental"
+        );
+    } else {
+        tracing::info!(
+            rental_id = %rental_id,
+            "Archived deleted Hyperstack rental"
+        );
+    }
+}
+
 impl Server {
     /// Create a new server instance
     pub async fn new(config: Config) -> Result<Self> {
@@ -1141,10 +1209,11 @@ impl Server {
                 interval.tick().await;
 
                 // Query all active secure cloud rentals from the database (excluding VIP rentals
-                // which don't need health checks - they're manually managed and assumed always up,
-                // and excluding Hyperstack rentals which use webhook callbacks instead of polling)
-                match sqlx::query_as::<_, (String,)>(
-                    "SELECT id FROM secure_cloud_rentals WHERE is_vip = FALSE AND provider != 'hyperstack'",
+                // which don't need health checks - they're manually managed and assumed always up),
+                // and include Hyperstack rentals only if already marked deleted for cleanup.
+                match sqlx::query_as::<_, (String, String, String)>(
+                    "SELECT id, provider, status FROM secure_cloud_rentals \
+                     WHERE is_vip = FALSE AND (provider != 'hyperstack' OR status = 'deleted')",
                 )
                 .fetch_all(&health_check_db)
                 .await
@@ -1153,6 +1222,19 @@ impl Server {
                         // Process rentals sequentially to avoid overwhelming provider APIs
                         for record in &rental_records {
                             let rental_id = &record.0;
+                            let provider = &record.1;
+                            let status = &record.2;
+
+                            if provider == "hyperstack" && status == "deleted" {
+                                cleanup_deleted_hyperstack_rental(
+                                    rental_id,
+                                    &health_check_db,
+                                    health_check_billing_client.as_ref().map(|c| c.as_ref()),
+                                )
+                                .await;
+                                continue;
+                            }
+
                             process_secure_cloud_health_check(
                                 rental_id,
                                 &health_check_aggregator_service,


### PR DESCRIPTION
When Hyperstack deletes a VM externally (or we receive a webhook indicating deletion), billing was not being finalized, leaving rentals in an inconsistent state.

This adds:
- Billing finalization in the webhook handler for terminal delete events
- A cleanup path in the health check loop for Hyperstack rentals already marked as deleted

Both paths call `finalize_rental()` with the proper termination reason and then archive the rental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of externally deleted virtual machines with automatic billing finalization and resource archiving.
  * Enhanced health-check monitoring to properly detect and process deleted resources.

* **Improvements**
  * Automated cleanup workflow for deleted instances, ensuring proper status transitions and billing closure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->