### PR TITLE
feat(hyperstack): update rate limit defaults for production usage

### DIFF
--- a/crates/basilica-aggregator/src/config.rs
+++ b/crates/basilica-aggregator/src/config.rs
@@ -59,20 +59,20 @@ pub struct HyperstackConfig {
     pub webhook_secret: String,
     /// Base URL for webhooks, e.g., "https://api.basilica.ai"
     pub callback_base_url: String,
-    /// Rate limit: maximum requests per second to Hyperstack API (default: 5)
+    /// Rate limit: maximum requests per second to Hyperstack API (default: 400)
     #[serde(default = "default_rate_limit_rps")]
     pub rate_limit_rps: u32,
-    /// Timeout in seconds waiting for a rate limit token (default: 5)
+    /// Timeout in seconds waiting for a rate limit token (default: 30)
     #[serde(default = "default_token_timeout_secs")]
     pub token_timeout_secs: u64,
 }
 
 fn default_rate_limit_rps() -> u32 {
-    5
+    400
 }
 
 fn default_token_timeout_secs() -> u64 {
-    5
+    30
 }
 
 impl HyperstackConfig {

--- a/scripts/cloud/variables.tf
+++ b/scripts/cloud/variables.tf
@@ -179,14 +179,14 @@ variable "hyperstack_callback_base_url" {
 
 variable "hyperstack_rate_limit_rps" {
   type        = number
-  description = "Rate limit for Hyperstack API requests per second (default: 10)"
-  default     = 10
+  description = "Rate limit for Hyperstack API requests per second (default: 400)"
+  default     = 400
 }
 
 variable "hyperstack_token_timeout_secs" {
   type        = number
-  description = "Timeout in seconds waiting for a rate limit token (default: 300)"
-  default     = 300
+  description = "Timeout in seconds waiting for a rate limit token (default: 30)"
+  default     = 30
 }
 
 # WireGuard VPN Configuration


### PR DESCRIPTION
Increases rate limit RPS from 5/10 to 400 and standardizes token timeout to 30 seconds across both Rust config and Terraform variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration parameters: rate limit threshold increased to 400 requests per second and token timeout adjusted to 30 seconds for improved performance handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->