### PR TITLE
feat(cli): display country code in GPU selection prompts

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
@@ -1,6 +1,6 @@
 //! Common helper functions for GPU rental operations
 
-use crate::cli::handlers::region_mapping::region_matches_country;
+use crate::cli::handlers::region_mapping::{extract_country_code, region_matches_country};
 use crate::error::CliError;
 use crate::progress::{complete_spinner_and_clear, complete_spinner_error, create_spinner};
 use basilica_common::types::ComputeCategory;
@@ -117,6 +117,7 @@ struct UnifiedRentalItem {
     rental_id: String,
     compute_type: ComputeCategory,
     provider_or_node: String,
+    location: String,
     gpu_info: String,
     status: String,
     created_at: String,
@@ -211,10 +212,19 @@ pub async fn resolve_target_rental_unified(
                 format!("{}x {}", rental.gpu_specs.len(), rental.gpu_specs[0].name)
             };
 
+            // Extract country code from location
+            let location_code = rental
+                .location
+                .as_ref()
+                .and_then(|loc| extract_country_code(loc))
+                .unwrap_or("--")
+                .to_string();
+
             unified_items.push(UnifiedRentalItem {
                 rental_id: rental.rental_id.clone(),
                 compute_type: ComputeCategory::CommunityCloud,
                 provider_or_node: rental.node_id.clone(),
+                location: location_code,
                 gpu_info,
                 status: format!("{:?}", rental.state),
                 created_at: rental.created_at.clone(),
@@ -241,10 +251,19 @@ pub async fn resolve_target_rental_unified(
                 rental.gpu_type.to_uppercase()
             };
 
+            // Extract country code from location_code
+            let location_code = rental
+                .location_code
+                .as_ref()
+                .and_then(|loc| extract_country_code(loc))
+                .unwrap_or("--")
+                .to_string();
+
             unified_items.push(UnifiedRentalItem {
                 rental_id: rental.rental_id.clone(),
                 compute_type: ComputeCategory::SecureCloud,
                 provider_or_node: rental.provider.clone(),
+                location: location_code,
                 gpu_info,
                 status: rental.status.clone(),
                 created_at: rental.created_at.to_rfc3339(),
@@ -277,10 +296,19 @@ pub async fn resolve_target_rental_unified(
                 (None, None) => "CPU-only".to_string(),
             };
 
+            // Extract country code from location_code
+            let location_code = rental
+                .location_code
+                .as_ref()
+                .and_then(|loc| extract_country_code(loc))
+                .unwrap_or("--")
+                .to_string();
+
             unified_items.push(UnifiedRentalItem {
                 rental_id: rental.rental_id.clone(),
                 compute_type: ComputeCategory::SecureCloud,
                 provider_or_node: rental.provider.clone(),
+                location: location_code,
                 gpu_info: cpu_info,
                 status: rental.status.clone(),
                 created_at: rental.created_at.to_rfc3339(),
@@ -290,6 +318,17 @@ pub async fn resolve_target_rental_unified(
 
     if unified_items.is_empty() {
         return Err(eyre!("No active rentals found"));
+    }
+
+    // Helper to truncate strings for column width
+    fn truncate(s: &str, max_len: usize) -> String {
+        let char_count = s.chars().count();
+        if char_count <= max_len {
+            s.to_string()
+        } else {
+            let truncated: String = s.chars().take(max_len - 1).collect();
+            format!("{}…", truncated)
+        }
     }
 
     // Format items for selection
@@ -302,15 +341,22 @@ pub async fn resolve_target_rental_unified(
             };
 
             format!(
-                "{} | {:<20} | {:<25} | {:<12} | {}",
+                "{} | {:<15} | {:<4} | {:<25} | {:<12} | {}",
                 style(type_label).cyan(),
-                item.provider_or_node,
-                item.gpu_info,
+                truncate(&item.provider_or_node, 15),
+                item.location,
+                truncate(&item.gpu_info, 25),
                 item.status,
-                item.created_at
+                truncate(&item.created_at, 19)
             )
         })
         .collect();
+
+    // Show header hint
+    println!(
+        "{}",
+        style("  Type      | Provider        | Loc  | GPU                       | Status       | Created").dim()
+    );
 
     // Use dialoguer to select
     let theme = dialoguer::theme::ColorfulTheme::default();
@@ -326,9 +372,9 @@ pub async fn resolve_target_rental_unified(
         None => return Err(eyre!("Selection cancelled")),
     };
 
-    // Clear the selection prompt line
+    // Clear the header and selection prompt lines
     let term = Term::stdout();
-    let _ = term.clear_last_lines(1);
+    let _ = term.clear_last_lines(2);
 
     let selected = &unified_items[selection];
     Ok((selected.rental_id.clone(), selected.compute_type))
@@ -358,6 +404,7 @@ struct UnifiedOfferingItem {
     offering_type: OfferingType,
     display_gpu: String,
     display_provider: String,
+    display_country: String,
     display_memory: String,
     display_price: String,
     // Original data for creating the offering
@@ -507,6 +554,9 @@ pub async fn resolve_offering_unified(
                     )
                 },
                 display_provider: format!("{}", offering.provider),
+                display_country: extract_country_code(&offering.region)
+                    .unwrap_or("--")
+                    .to_string(),
                 display_memory: memory_str,
                 display_price: format!("${:.2}/hr", total_price),
                 secure_offering: Some(offering),
@@ -550,6 +600,9 @@ pub async fn resolve_offering_unified(
                     offering_type: OfferingType::SecureCpu,
                     display_gpu: format!("{} vCPU", offering.vcpu_count),
                     display_provider: offering.provider.to_string(),
+                    display_country: extract_country_code(&offering.region)
+                        .unwrap_or("--")
+                        .to_string(),
                     display_memory: format!("{}GB RAM", offering.system_memory_gb),
                     display_price: format!("${:.2}/hr", hourly_rate),
                     secure_offering: None,
@@ -606,10 +659,14 @@ pub async fn resolve_offering_unified(
                 .clone()
                 .unwrap_or_else(|| "Unknown".to_string());
 
+            // Extract country code from location
+            let country_code = extract_country_code(&location).unwrap_or("--").to_string();
+
             unified_items.push(UnifiedOfferingItem {
                 offering_type: OfferingType::Community,
                 display_gpu: gpu_info,
                 display_provider: location,
+                display_country: country_code,
                 display_memory: memory_str,
                 display_price: price_str,
                 secure_offering: None,
@@ -647,10 +704,11 @@ pub async fn resolve_offering_unified(
             };
 
             format!(
-                "{} │ {:<20} │ {:<20} │ {:<8} │ {}",
+                "{} │ {:<20} │ {:<15} │ {:<4} │ {:<8} │ {}",
                 style(type_label).cyan(),
                 truncate(&item.display_gpu, 20),
-                truncate(&item.display_provider, 20),
+                truncate(&item.display_provider, 15),
+                item.display_country,
                 item.display_memory,
                 style(&item.display_price).green()
             )
@@ -660,7 +718,8 @@ pub async fn resolve_offering_unified(
     // Show header hint
     println!(
         "{}",
-        style("  Type      │ GPU/CPU              │ Provider/Location    │ Memory   │ Price").dim()
+        style("  Type      │ GPU/CPU              │ Provider        │ Loc  │ Memory   │ Price")
+            .dim()
     );
 
     // Use dialoguer to select

--- a/crates/basilica-cli/src/cli/handlers/region_mapping.rs
+++ b/crates/basilica-cli/src/cli/handlers/region_mapping.rs
@@ -98,7 +98,67 @@ pub fn region_to_country(region: &str) -> Option<&'static str> {
         return Some("ZA");
     }
 
+    // Norway
+    if region_upper.contains("NORWAY") || region_upper.starts_with("NO-") {
+        return Some("NO");
+    }
+
     None
+}
+
+/// Extract country code from various location formats
+///
+/// Handles multiple formats:
+/// - Region codes: "US-EAST-1" → "US"
+/// - Full location: "San Francisco/California/US" → "US"
+/// - Direct country: "US" → "US"
+pub fn extract_country_code(location: &str) -> Option<&'static str> {
+    // First try region_to_country for region codes
+    if let Some(country) = region_to_country(location) {
+        return Some(country);
+    }
+
+    // Try parsing as LocationProfile (City/Region/Country format)
+    // Format is typically: "City/State/Country" or just "Country"
+    let parts: Vec<&str> = location.split('/').collect();
+    if let Some(last_part) = parts.last() {
+        let trimmed = last_part.trim();
+        // Map common country names/codes to ISO codes
+        return map_country_string(trimmed);
+    }
+
+    None
+}
+
+/// Map country name or code strings to standard ISO codes
+fn map_country_string(country: &str) -> Option<&'static str> {
+    let upper = country.to_uppercase();
+    match upper.as_str() {
+        // Direct ISO codes
+        "US" | "USA" | "UNITED STATES" => Some("US"),
+        "CA" | "CANADA" => Some("CA"),
+        "GB" | "UK" | "UNITED KINGDOM" => Some("GB"),
+        "DE" | "GERMANY" => Some("DE"),
+        "FR" | "FRANCE" => Some("FR"),
+        "IT" | "ITALY" => Some("IT"),
+        "ES" | "SPAIN" => Some("ES"),
+        "NL" | "NETHERLANDS" => Some("NL"),
+        "SE" | "SWEDEN" => Some("SE"),
+        "IE" | "IRELAND" => Some("IE"),
+        "JP" | "JAPAN" => Some("JP"),
+        "SG" | "SINGAPORE" => Some("SG"),
+        "AU" | "AUSTRALIA" => Some("AU"),
+        "IN" | "INDIA" => Some("IN"),
+        "KR" | "KOREA" | "SOUTH KOREA" => Some("KR"),
+        "HK" | "HONG KONG" => Some("HK"),
+        "BR" | "BRAZIL" => Some("BR"),
+        "BH" | "BAHRAIN" => Some("BH"),
+        "AE" | "UAE" | "UNITED ARAB EMIRATES" => Some("AE"),
+        "ZA" | "SOUTH AFRICA" => Some("ZA"),
+        "NO" | "NORWAY" => Some("NO"),
+        "EU" | "EUROPE" => Some("EU"),
+        _ => None,
+    }
 }
 
 /// Check if a region matches a country filter (case-insensitive)
@@ -171,5 +231,46 @@ mod tests {
         assert_eq!(region_to_country("unknown-region"), None);
         // Unknown regions should still work with direct matching
         assert!(region_matches_country("custom-us-region", "US"));
+    }
+
+    #[test]
+    fn test_extract_country_code_region_codes() {
+        // Region codes should be handled via region_to_country
+        assert_eq!(extract_country_code("US-EAST-1"), Some("US"));
+        assert_eq!(extract_country_code("EU-WEST-1"), Some("EU"));
+        assert_eq!(extract_country_code("EU-Frankfurt"), Some("DE"));
+        assert_eq!(extract_country_code("AP-TOKYO-1"), Some("JP"));
+    }
+
+    #[test]
+    fn test_extract_country_code_location_profiles() {
+        // City/Region/Country format (community cloud)
+        assert_eq!(
+            extract_country_code("San Francisco/California/US"),
+            Some("US")
+        );
+        assert_eq!(extract_country_code("London/UK"), Some("GB"));
+        assert_eq!(extract_country_code("Tokyo/Japan"), Some("JP"));
+    }
+
+    #[test]
+    fn test_extract_country_code_direct() {
+        // Direct country codes or names
+        assert_eq!(extract_country_code("US"), Some("US"));
+        assert_eq!(extract_country_code("Germany"), Some("DE"));
+        assert_eq!(extract_country_code("Japan"), Some("JP"));
+    }
+
+    #[test]
+    fn test_extract_country_code_unknown() {
+        assert_eq!(extract_country_code("unknown-location"), None);
+        assert_eq!(extract_country_code("Some City/Some State/Unknown"), None);
+    }
+
+    #[test]
+    fn test_extract_country_code_norway() {
+        assert_eq!(extract_country_code("NORWAY"), Some("NO"));
+        assert_eq!(extract_country_code("NO-1"), Some("NO"));
+        assert_eq!(extract_country_code("Norway"), Some("NO"));
     }
 }


### PR DESCRIPTION
Adds a "Loc" column to the interactive rental and offering selection tables, showing ISO country codes (e.g., US, DE, JP) for better at-a-glance location visibility.

- Extracts country codes from region strings (`US-EAST-1` → `US`) and location paths (`San Francisco/California/US` → `US`)
- Works across community cloud, secure cloud GPU, and secure cloud CPU offerings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location and country information display to rental and offering listings.
  * Expanded location format recognition for improved country identification.

* **Bug Fixes**
  * Reduced visual flicker when updating selection prompts.

* **User Interface**
  * Updated layout with new location columns.
  * Improved text formatting and field truncation for better alignment and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->