### PR TITLE
feat(cli): display IP address in interactive rental selector

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
@@ -121,6 +121,7 @@ struct UnifiedRentalItem {
     gpu_info: String,
     status: String,
     created_at: String,
+    ip_address: Option<String>,
 }
 
 /// Resolve target rental ID with unified selection across compute types
@@ -228,6 +229,7 @@ pub async fn resolve_target_rental_unified(
                 gpu_info,
                 status: format!("{:?}", rental.state),
                 created_at: rental.created_at.clone(),
+                ip_address: None, // IP not available in community cloud list response
             });
         }
     }
@@ -267,6 +269,7 @@ pub async fn resolve_target_rental_unified(
                 gpu_info,
                 status: rental.status.clone(),
                 created_at: rental.created_at.to_rfc3339(),
+                ip_address: rental.ip_address.clone(),
             });
         }
     }
@@ -312,6 +315,7 @@ pub async fn resolve_target_rental_unified(
                 gpu_info: cpu_info,
                 status: rental.status.clone(),
                 created_at: rental.created_at.to_rfc3339(),
+                ip_address: rental.ip_address.clone(),
             });
         }
     }
@@ -340,10 +344,17 @@ pub async fn resolve_target_rental_unified(
                 ComputeCategory::SecureCloud => "Secure   ",
             };
 
+            let ip_display = item
+                .ip_address
+                .as_ref()
+                .map(|ip| truncate(ip, 15))
+                .unwrap_or_else(|| "--".to_string());
+
             format!(
-                "{} | {:<15} | {:<4} | {:<25} | {:<12} | {}",
+                "{} | {:<15} | {:<15} | {:<4} | {:<25} | {:<12} | {}",
                 style(type_label).cyan(),
                 truncate(&item.provider_or_node, 15),
+                ip_display,
                 item.location,
                 truncate(&item.gpu_info, 25),
                 item.status,
@@ -355,7 +366,7 @@ pub async fn resolve_target_rental_unified(
     // Show header hint
     println!(
         "{}",
-        style("  Type      | Provider        | Loc  | GPU                       | Status       | Created").dim()
+        style("  Type      | Provider        | IP              | Loc  | GPU                       | Status       | Created").dim()
     );
 
     // Use dialoguer to select


### PR DESCRIPTION
Adds IP address column to the interactive rental selection UI, making it easier to identify rentals when multiple are active.

Shows IP for secure cloud and CPU cloud rentals; community cloud rentals display `--` since IP is not available in the list response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU rental list now displays IP addresses for each rental item, providing quick access to connection information. IP addresses appear in a dedicated table column with "--" displayed for rentals where addresses are unavailable, such as community cloud instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->