### PR TITLE
fix(docker): replace abandoned watchtower with maintained fork

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -1037,7 +1037,7 @@ services:
       start_period: 40s
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.14.0
     container_name: basilica-watchtower
     restart: unless-stopped
     volumes:

--- a/scripts/miner/compose.prod.yml
+++ b/scripts/miner/compose.prod.yml
@@ -39,7 +39,7 @@ services:
       start_period: 30s
 
   watchtower:
-    image: containrrr/watchtower
+    image: nickfedor/watchtower:1.14.0
     container_name: basilica-watchtower
     restart: unless-stopped
     volumes:

--- a/scripts/validator/compose.prod.yml
+++ b/scripts/validator/compose.prod.yml
@@ -50,7 +50,7 @@ services:
               capabilities: [gpu]
 
   watchtower:
-    image: containrrr/watchtower
+    image: nickfedor/watchtower:1.14.0
     container_name: basilica-watchtower
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary

The `containrrr/watchtower` project was archived on December 17, 2025 and its Docker client uses API v1.25, which is incompatible with Docker 29+ (requires v1.44 minimum).

This PR replaces it with `nickfedor/watchtower:1.14.0`, an actively maintained fork that resolves this compatibility issue.

## References

- https://github.com/containrrr/watchtower/issues/2124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version in production deployment configurations to ensure consistency and compatibility across all production services and environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->