### PR TITLE
feat(cli): introduce openclaw summon and add kimi examples

### DIFF
--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -897,6 +897,16 @@ pub enum DeployAction {
         #[command(flatten)]
         sglang: SglangOptions,
     },
+
+    /// Deploy OpenClaw gateway
+    #[command(name = "openclaw")]
+    Openclaw {
+        #[command(flatten)]
+        common: TemplateCommonOptions,
+
+        #[command(flatten)]
+        openclaw: OpenclawOptions,
+    },
 }
 
 /// Share token management actions
@@ -1034,4 +1044,42 @@ pub struct SglangOptions {
     /// Trust remote code from HuggingFace
     #[arg(long)]
     pub trust_remote_code: bool,
+}
+
+/// OpenClaw-specific deployment options
+#[derive(clap::Args, Debug, Clone)]
+pub struct OpenclawOptions {
+    /// Provider preset (openai, anthropic)
+    #[arg(long, value_name = "PROVIDER", default_value = "openai")]
+    pub provider: OpenclawProvider,
+
+    /// Backend URL for OpenClaw (OpenAI-compatible API base URL)
+    #[arg(long, value_name = "URL")]
+    pub backend_url: Option<String>,
+
+    /// Model ID to use (e.g., Qwen/Qwen2.5-7B-Instruct)
+    #[arg(long, value_name = "MODEL_ID")]
+    pub model_id: Option<String>,
+
+    /// Provider ID (default: openai)
+    #[arg(long, value_name = "PROVIDER_ID")]
+    pub provider_id: Option<String>,
+
+    /// Provider API type (default: openai-completions)
+    #[arg(long, value_name = "API")]
+    pub provider_api: Option<String>,
+
+    /// Context window size (default: 32768)
+    #[arg(long, value_name = "TOKENS")]
+    pub context_window: Option<u32>,
+
+    /// Max tokens (default: 8192)
+    #[arg(long, value_name = "TOKENS")]
+    pub max_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OpenclawProvider {
+    Openai,
+    Anthropic,
 }

--- a/crates/basilica-cli/src/cli/handlers/deploy/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/mod.rs
@@ -60,6 +60,9 @@ pub async fn handle_deploy(cmd: DeployCommand, config: &CliConfig) -> Result<(),
             common,
             sglang,
         }) => templates::handle_sglang_deploy(&client, model, common, sglang).await,
+        Some(DeployAction::Openclaw { common, openclaw }) => {
+            templates::handle_openclaw_deploy(&client, common, openclaw).await
+        }
         None => {
             if let Some(source) = cmd.source.clone() {
                 create::handle_create(&client, &source, cmd).await

--- a/crates/basilica-cli/src/cli/handlers/deploy/templates/common.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/templates/common.rs
@@ -126,19 +126,35 @@ pub async fn wait_for_ready(
 
         let status = client.get_deployment(name).await.map_err(CliError::Api)?;
 
-        if let Some(ref phase) = status.phase {
-            if last_phase.as_ref() != Some(phase) {
-                complete_spinner_and_clear(spinner);
+        match status.phase.as_ref() {
+            Some(phase) if !phase.trim().is_empty() => {
+                if last_phase.as_ref() != Some(phase) {
+                    complete_spinner_and_clear(spinner);
 
-                let phase_msg = format_phase_message(phase, service_name);
-                print_info(&phase_msg);
-
-                spinner = create_spinner(&format!(
-                    "Phase: {} ({}/{})",
-                    phase, status.replicas.ready, status.replicas.desired
-                ));
-
-                last_phase = Some(phase.clone());
+                    let phase_trimmed = phase.trim();
+                    let phase_msg = format_phase_message(phase_trimmed, service_name);
+                    print_info(&phase_msg);
+                    spinner = create_spinner(&format!(
+                        "Phase: {} ({}/{})",
+                        phase_trimmed, status.replicas.ready, status.replicas.desired
+                    ));
+                    last_phase = Some(phase.clone());
+                }
+            }
+            _ => {
+                if last_phase.is_none() {
+                    complete_spinner_and_clear(spinner);
+                    let state_msg = format!(
+                        "{} state: {} ({}/{})",
+                        service_name, status.state, status.replicas.ready, status.replicas.desired
+                    );
+                    print_info(&state_msg);
+                    spinner = create_spinner(&format!(
+                        "State: {} ({}/{})",
+                        status.state, status.replicas.ready, status.replicas.desired
+                    ));
+                    last_phase = Some(String::new());
+                }
             }
         }
 
@@ -147,7 +163,7 @@ pub async fn wait_for_ready(
             return Ok(WaitResult::Ready(Box::new(status)));
         }
 
-        if status.state == "Failed" {
+        if status.state == "Failed" || status.phase.as_deref() == Some("failed") {
             complete_spinner_and_clear(spinner);
             let reason = status
                 .message

--- a/crates/basilica-cli/src/cli/handlers/deploy/templates/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/templates/mod.rs
@@ -3,12 +3,15 @@
 //! This module provides pre-configured deployment shortcuts for:
 //! - vLLM: OpenAI-compatible LLM inference server
 //! - SGLang: Fast LLM inference with RadixAttention
+//! - OpenClaw: OpenClaw gateway
 
 pub mod common;
 pub mod model_size;
+pub mod openclaw;
 pub mod sglang;
 pub mod vllm;
 
 pub use model_size::{estimate_gpu_requirements, GpuRequirements};
+pub use openclaw::handle_openclaw_deploy;
 pub use sglang::handle_sglang_deploy;
 pub use vllm::handle_vllm_deploy;

--- a/crates/basilica-cli/src/cli/handlers/deploy/templates/openclaw.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/templates/openclaw.rs
@@ -1,0 +1,416 @@
+//! OpenClaw deployment template
+//!
+//! Provides a pre-configured deployment for OpenClaw.
+//! Handles backend URL wiring, environment configuration, and UI token extraction.
+
+use crate::cli::commands::{OpenclawOptions, OpenclawProvider, TemplateCommonOptions};
+use crate::error::{CliError, DeployError};
+use crate::output::print_success;
+use crate::progress::{complete_spinner_and_clear, create_spinner};
+use basilica_sdk::types::{
+    CreateDeploymentRequest, HealthCheckConfig, PersistentStorageSpec, ProbeConfig,
+    ResourceRequirements, StorageBackend, StorageSpec,
+};
+use basilica_sdk::BasilicaClient;
+use regex::Regex;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::env as std_env;
+use std::time::{Duration, Instant};
+
+use super::common::{create_with_retry, parse_env_vars, wait_for_ready, WaitResult};
+
+/// Default OpenClaw Docker image
+const OPENCLAW_IMAGE: &str = "ghcr.io/one-covenant/basilica-openclaw:latest";
+
+/// Default port for OpenClaw gateway
+const OPENCLAW_PORT: u32 = 18789;
+
+/// Handle OpenClaw deployment
+pub async fn handle_openclaw_deploy(
+    client: &BasilicaClient,
+    common: TemplateCommonOptions,
+    openclaw: OpenclawOptions,
+) -> Result<(), CliError> {
+    let name = common
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("openclaw-{}", &uuid::Uuid::new_v4().to_string()[..8]));
+
+    let mut env = parse_env_vars(&common.env)?;
+    let preset = provider_preset(openclaw.provider);
+
+    let backend_url = openclaw
+        .backend_url
+        .clone()
+        .unwrap_or_else(|| preset.base_url.to_string());
+    let backend_url = normalize_backend_url(&backend_url);
+    inject_backend_env(&mut env, &backend_url);
+
+    let provider_id = openclaw
+        .provider_id
+        .clone()
+        .unwrap_or_else(|| preset.provider_id.to_string());
+    let provider_api = openclaw
+        .provider_api
+        .clone()
+        .unwrap_or_else(|| preset.provider_api.to_string());
+    let context_window = openclaw.context_window.unwrap_or(preset.context_window);
+    let max_tokens = openclaw.max_tokens.unwrap_or(preset.max_tokens);
+
+    let model_id = match openclaw
+        .model_id
+        .clone()
+        .or_else(|| preset.model_id.map(str::to_string))
+    {
+        Some(id) => id,
+        None => {
+            if provider_id != "openai" {
+                return Err(CliError::Deploy(DeployError::Validation {
+                    message: "Model ID is required for this provider. Use --model-id.".to_string(),
+                }));
+            }
+            detect_model_id(&backend_url, &env).await?
+        }
+    };
+
+    env.insert("OPENCLAW_MODEL_ID".to_string(), model_id);
+    env.insert("OPENCLAW_PROVIDER_ID".to_string(), provider_id);
+    env.insert("OPENCLAW_PROVIDER_API".to_string(), provider_api);
+    env.insert(
+        "OPENCLAW_CONTEXT_WINDOW".to_string(),
+        context_window.to_string(),
+    );
+    env.insert("OPENCLAW_MAX_TOKENS".to_string(), max_tokens.to_string());
+
+    // Pass through provider API keys from local env if not explicitly set via --env.
+    if !env.contains_key("OPENAI_API_KEY") {
+        if let Ok(val) = std_env::var("OPENAI_API_KEY") {
+            if !val.trim().is_empty() {
+                env.insert("OPENAI_API_KEY".to_string(), val);
+            }
+        }
+    }
+    if !env.contains_key("ANTHROPIC_API_KEY") {
+        if let Ok(val) = std_env::var("ANTHROPIC_API_KEY") {
+            if !val.trim().is_empty() {
+                env.insert("ANTHROPIC_API_KEY".to_string(), val);
+            }
+        }
+    }
+
+    match env.get("OPENCLAW_PROVIDER_ID").map(|s| s.as_str()) {
+        Some("anthropic") => {
+            if !env.contains_key("ANTHROPIC_API_KEY") {
+                return Err(CliError::Deploy(DeployError::Validation {
+                    message: "ANTHROPIC_API_KEY is required for provider=anthropic. Set it in your environment or pass --env ANTHROPIC_API_KEY=...".to_string(),
+                }));
+            }
+        }
+        _ => {
+            if !env.contains_key("OPENAI_API_KEY") {
+                return Err(CliError::Deploy(DeployError::Validation {
+                    message: "OPENAI_API_KEY is required for provider=openai. Set it in your environment or pass --env OPENAI_API_KEY=...".to_string(),
+                }));
+            }
+        }
+    }
+
+    let resources = build_openclaw_resources(&common);
+
+    let storage = if common.no_storage {
+        None
+    } else {
+        Some(build_openclaw_storage())
+    };
+
+    let health_check = Some(build_openclaw_health_check());
+
+    let request = CreateDeploymentRequest {
+        instance_name: name.clone(),
+        image: OPENCLAW_IMAGE.to_string(),
+        replicas: 1,
+        port: OPENCLAW_PORT,
+        command: Some(vec!["/usr/local/bin/basilica-entrypoint.sh".to_string()]),
+        args: None,
+        env: Some(env),
+        resources: Some(resources),
+        ttl_seconds: common.ttl,
+        public: true,
+        storage,
+        health_check,
+        enable_billing: true,
+        queue_name: None,
+        suspended: false,
+        priority: None,
+        topology_spread: None,
+    };
+
+    let spinner = create_spinner(&format!("Creating OpenClaw summons '{}'...", name));
+    let response = create_with_retry(client, request).await?;
+    complete_spinner_and_clear(spinner);
+
+    let actual_name = response.instance_name.clone();
+
+    if !common.detach {
+        let result = wait_for_ready(client, &actual_name, common.timeout, "OpenClaw").await?;
+
+        match result {
+            WaitResult::Ready(deployment) => {
+                if common.json {
+                    crate::output::json_output(&deployment)?;
+                } else {
+                    let token = wait_for_gateway_token(client, &actual_name).await?;
+                    wait_for_public_url_ready(&deployment.url, 90).await?;
+                    print_openclaw_success(&deployment, &actual_name, &token);
+                }
+            }
+            WaitResult::Failed(reason) => {
+                return Err(CliError::Deploy(DeployError::DeploymentFailed {
+                    name: actual_name,
+                    reason,
+                }));
+            }
+            WaitResult::Timeout => {
+                return Err(CliError::Deploy(DeployError::Timeout {
+                    name: actual_name,
+                    timeout_secs: common.timeout,
+                }));
+            }
+        }
+    } else if common.json {
+        crate::output::json_output(&response)?;
+    } else {
+        print_success(&format!(
+            "OpenClaw summons '{}' created (detached mode)",
+            actual_name
+        ));
+        println!("  Check status: basilica summon status {}", actual_name);
+    }
+
+    Ok(())
+}
+
+fn inject_backend_env(env: &mut HashMap<String, String>, backend_url: &str) {
+    env.entry("OPENCLAW_BASE_URL".to_string())
+        .or_insert_with(|| backend_url.to_string());
+    env.entry("OPENAI_BASE_URL".to_string())
+        .or_insert_with(|| backend_url.to_string());
+}
+
+fn normalize_backend_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{}/v1", trimmed)
+    }
+}
+
+struct ProviderPreset {
+    base_url: &'static str,
+    provider_id: &'static str,
+    provider_api: &'static str,
+    model_id: Option<&'static str>,
+    context_window: u32,
+    max_tokens: u32,
+}
+
+fn provider_preset(provider: OpenclawProvider) -> ProviderPreset {
+    match provider {
+        OpenclawProvider::Openai => ProviderPreset {
+            base_url: "https://api.openai.com/v1",
+            provider_id: "openai",
+            provider_api: "openai-responses",
+            model_id: Some("gpt-5.2-pro"),
+            context_window: 400_000,
+            max_tokens: 128_000,
+        },
+        OpenclawProvider::Anthropic => ProviderPreset {
+            base_url: "https://api.anthropic.com/v1",
+            provider_id: "anthropic",
+            provider_api: "anthropic-messages",
+            model_id: Some("claude-opus-4-1-20250805"),
+            context_window: 200_000,
+            max_tokens: 32_000,
+        },
+    }
+}
+
+async fn detect_model_id(
+    backend_url: &str,
+    env: &HashMap<String, String>,
+) -> Result<String, CliError> {
+    let models_url = format!("{}/models", backend_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let mut request = client.get(&models_url);
+
+    if let Some(key) = env.get("OPENAI_API_KEY") {
+        request = request.bearer_auth(key);
+    }
+
+    let response = request.send().await.map_err(|e| {
+        CliError::Deploy(DeployError::Validation {
+            message: format!("Failed to fetch models from {}: {}", models_url, e),
+        })
+    })?;
+
+    if !response.status().is_success() {
+        return Err(CliError::Deploy(DeployError::Validation {
+            message: format!(
+                "Failed to fetch models from {}: HTTP {}. Provide --model-id.",
+                models_url,
+                response.status()
+            ),
+        }));
+    }
+
+    let body: Value = response.json().await.map_err(|e| {
+        CliError::Deploy(DeployError::Validation {
+            message: format!("Failed to parse models response: {}", e),
+        })
+    })?;
+
+    if let Some(id) = body
+        .get("data")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.iter().find_map(|item| item.get("id")))
+        .and_then(|id| id.as_str())
+    {
+        return Ok(id.to_string());
+    }
+
+    if let Some(id) = body
+        .get("models")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.iter().find_map(|item| item.get("id")))
+        .and_then(|id| id.as_str())
+    {
+        return Ok(id.to_string());
+    }
+
+    Err(CliError::Deploy(DeployError::Validation {
+        message: "No model ID found in /v1/models response. Provide --model-id.".to_string(),
+    }))
+}
+
+fn build_openclaw_resources(common: &TemplateCommonOptions) -> ResourceRequirements {
+    ResourceRequirements {
+        cpu: "2".to_string(),
+        memory: common.memory.clone(),
+        cpu_request: Some("1".to_string()),
+        memory_request: Some("4Gi".to_string()),
+        gpus: None,
+    }
+}
+
+fn build_openclaw_storage() -> StorageSpec {
+    StorageSpec {
+        persistent: Some(PersistentStorageSpec {
+            enabled: true,
+            backend: StorageBackend::R2,
+            bucket: String::new(),
+            region: Some("auto".to_string()),
+            endpoint: None,
+            credentials_secret: Some("basilica-r2-credentials".to_string()),
+            sync_interval_ms: 1000,
+            cache_size_mb: 2048,
+            mount_path: "/data".to_string(),
+        }),
+    }
+}
+
+fn build_openclaw_health_check() -> HealthCheckConfig {
+    let probe = ProbeConfig {
+        path: "/".to_string(),
+        port: Some(OPENCLAW_PORT as u16),
+        initial_delay_seconds: 30,
+        period_seconds: 10,
+        timeout_seconds: 5,
+        failure_threshold: 3,
+    };
+
+    HealthCheckConfig {
+        liveness: Some(probe.clone()),
+        readiness: Some(probe),
+        startup: None,
+    }
+}
+
+fn print_openclaw_success(
+    deployment: &basilica_sdk::types::DeploymentResponse,
+    name: &str,
+    token: &str,
+) {
+    print_success(&format!("OpenClaw summons '{}' is ready!", name));
+    println!("  URL: {}", deployment.url);
+    println!(
+        "  Control UI: {}/chat?session=main&token={}",
+        deployment.url, token
+    );
+}
+
+async fn wait_for_public_url_ready(url: &str, timeout_secs: u64) -> Result<(), CliError> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let client = reqwest::Client::new();
+    let url = url.trim_end_matches('/');
+    let probe_url = format!("{}/", url);
+
+    while Instant::now() < deadline {
+        match client.get(&probe_url).send().await {
+            Ok(resp) if resp.status().is_success() => return Ok(()),
+            _ => {
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+        }
+    }
+
+    Err(CliError::Deploy(DeployError::Timeout {
+        name: url.to_string(),
+        timeout_secs: timeout_secs as u32,
+    }))
+}
+
+async fn wait_for_gateway_token(client: &BasilicaClient, name: &str) -> Result<String, CliError> {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    let re = Regex::new(r"(?:CLAWDBOT|OPENCLAW)_GATEWAY_TOKEN=([a-fA-F0-9]{64})")
+        .map_err(|e| CliError::Internal(color_eyre::eyre::eyre!(e)))?;
+
+    let mut last_error: Option<String> = None;
+
+    while Instant::now() < deadline {
+        match client.get_deployment_logs(name, false, Some(200)).await {
+            Ok(response) => match response.text().await {
+                Ok(body) => {
+                    if let Some(caps) = re.captures(&body) {
+                        let token = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+                        if !token.is_empty() {
+                            return Ok(token.to_string());
+                        }
+                    }
+                }
+                Err(err) => {
+                    last_error = Some(format!("Failed to read logs response: {}", err));
+                }
+            },
+            Err(err) => {
+                last_error = Some(format!("Failed to fetch logs: {}", err));
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    let reason = match last_error {
+        Some(err) => format!(
+            "Gateway token not found in logs within timeout. Last error: {}",
+            err
+        ),
+        None => "Gateway token not found in logs within timeout.".to_string(),
+    };
+
+    Err(CliError::Deploy(DeployError::DeploymentFailed {
+        name: name.to_string(),
+        reason,
+    }))
+}

--- a/examples/27_clawdbot_kimi_k2_5.py
+++ b/examples/27_clawdbot_kimi_k2_5.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Deploy Clawdbot with Kimi-K2.5 inference on Basilica.
+
+Connects Clawdbot to a running Kimi-K2.5 vLLM deployment on Basilica,
+giving the agent platform access to K2.5's reasoning capabilities.
+
+Prerequisites:
+    - A running Kimi-K2.5 deployment on Basilica (see 26_kimi_k2_5_multimodal.py)
+
+Usage:
+    export BASILICA_API_TOKEN="your-token"
+    export KIMI_K2_5_DEPLOYMENT_URL="https://<id>.deployments.basilica.ai"
+    python3 27_clawdbot_kimi_k2_5.py
+
+See: https://github.com/clawdbot/clawdbot
+"""
+import os
+import re
+import sys
+
+from basilica import BasilicaClient
+
+k2_5_url = os.getenv("KIMI_K2_5_DEPLOYMENT_URL")
+if not k2_5_url:
+    sys.exit(
+        "Set KIMI_K2_5_DEPLOYMENT_URL to your Kimi-K2.5 deployment URL.\n"
+        "Example: export KIMI_K2_5_DEPLOYMENT_URL=https://<id>.deployments.basilica.ai"
+    )
+
+# Ensure the base URL ends with /v1 for OpenAI-compatible API
+base_url = k2_5_url.rstrip("/")
+if not base_url.endswith("/v1"):
+    base_url = f"{base_url}/v1"
+
+print("Deploying Clawdbot with Kimi-K2.5 backend...")
+print(f"  K2.5 endpoint: {base_url}")
+print()
+
+client = BasilicaClient()
+
+deployment = client.deploy(
+    name="clawdbot-kimi-k2-5",
+    image="ghcr.io/one-covenant/basilica-clawdbot:kimi-k2.5",
+    port=18789,
+    env={
+        "KIMI_K2_5_BASE_URL": base_url,
+    },
+    cpu="2",
+    memory="4Gi",
+    timeout=600,
+)
+
+print(f"Clawdbot deployed: {deployment.url}")
+print()
+
+# Extract gateway token from logs
+match = re.search(r"CLAWDBOT_GATEWAY_TOKEN=([a-f0-9]{64})", deployment.logs(tail=200))
+if match:
+    token = match.group(1)
+    print(f"Control UI: {deployment.url}/chat?session=main&token={token}")
+    print()
+    print(f"Gateway token: {token}")
+else:
+    print(f"Get token: basilica deploy logs {deployment.name} | grep CLAWDBOT_GATEWAY_TOKEN")

--- a/examples/28_openclaw.py
+++ b/examples/28_openclaw.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Deploy OpenClaw gateway on Basilica.
+
+Usage:
+    export OPENCLAW_BASE_URL="https://your-openai-compatible-backend/v1"
+    export OPENAI_API_KEY="your-key"  # optional if backend requires
+    python3 28_openclaw.py
+
+See: https://github.com/openclaw/openclaw
+"""
+import os
+import re
+import sys
+
+from basilica import BasilicaClient
+
+backend_url = os.getenv("OPENCLAW_BASE_URL") or os.getenv("OPENAI_BASE_URL")
+if not backend_url:
+    sys.exit("Set OPENCLAW_BASE_URL or OPENAI_BASE_URL")
+
+client = BasilicaClient()
+
+env = {
+    "OPENCLAW_BASE_URL": backend_url,
+    "OPENAI_BASE_URL": backend_url,
+}
+if os.getenv("OPENAI_API_KEY"):
+    env["OPENAI_API_KEY"] = os.environ["OPENAI_API_KEY"]
+
+deployment = client.deploy(
+    name="openclaw",
+    image="ghcr.io/one-covenant/basilica-openclaw:latest",
+    port=18789,
+    env=env,
+    cpu="2",
+    memory="4Gi",
+    timeout=600,
+)
+
+print(f"OpenClaw deployed: {deployment.url}")
+
+match = re.search(
+    r"(?:CLAWDBOT|OPENCLAW)_GATEWAY_TOKEN=([a-f0-9]{64})",
+    deployment.logs(tail=200),
+)
+if match:
+    print(f"Control UI: {deployment.url}/chat?session=main&token={match.group(1)}")
+else:
+    print(f"Get token: basilica deploy logs {deployment.name} | grep GATEWAY_TOKEN")

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,7 @@ Using `@basilica.deployment` decorator:
 | `23_vllm_llama_with_embeddings.py` | Llama-3.1-8B + E5 Embeddings (RAG stack) | `python3 23_vllm_llama_with_embeddings.py` |
 | `24_clawdbot.py` | Clawdbot AI agent platform | `python3 24_clawdbot.py` |
 | `25_kimi_k2_5.py` | Kimi-K2-Instruct 1T MoE (8x H200) | `python3 25_kimi_k2_5.py` |
+| `28_openclaw.py` | OpenClaw gateway | `python3 28_openclaw.py` |
 
 ## Large Model Deployment Notes
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw gateway deployment support to the CLI with configurable provider options (OpenAI, Anthropic).
  * Added example scripts for deploying OpenClaw gateways and Clawdbot with Kimi K2.5 backends.

* **Improvements**
  * Enhanced deployment phase tracking and status reporting for more robust readiness detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->