### PR TITLE
fix(validator): handle already-stopped rentals gracefully in status/stop endpoints

### DIFF
--- a/crates/basilica-validator/src/rental/mod.rs
+++ b/crates/basilica-validator/src/rental/mod.rs
@@ -896,6 +896,31 @@ impl RentalManager {
             .await?
             .ok_or_else(|| anyhow::anyhow!("Rental not found"))?;
 
+        // For terminal states, return DB state without Docker queries
+        if matches!(
+            rental_info.state,
+            RentalState::Stopped | RentalState::Failed
+        ) {
+            return Ok(RentalStatus {
+                rental_id: rental_id.to_string(),
+                state: rental_info.state.clone(),
+                container_status: ContainerStatus {
+                    container_id: rental_info.container_id.clone(),
+                    state: if rental_info.state == RentalState::Stopped {
+                        "stopped".to_string()
+                    } else {
+                        "exited".to_string()
+                    },
+                    exit_code: None,
+                    health: "none".to_string(),
+                    started_at: None,
+                    finished_at: None,
+                },
+                created_at: rental_info.created_at,
+                resource_usage: ResourceUsage::default(),
+            });
+        }
+
         // Get container status using validator SSH credentials
         let container_client = self.create_container_client(&rental_info.ssh_credentials)?;
 
@@ -924,6 +949,14 @@ impl RentalManager {
             .load_rental(rental_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Rental not found"))?;
+
+        // Already in terminal state — nothing to do
+        if matches!(
+            rental_info.state,
+            RentalState::Stopped | RentalState::Failed
+        ) {
+            return Ok(());
+        }
 
         // Stop container using validator SSH credentials
         let container_client = self.create_container_client(&rental_info.ssh_credentials)?;

--- a/crates/basilica-validator/src/rental/types.rs
+++ b/crates/basilica-validator/src/rental/types.rs
@@ -155,7 +155,7 @@ pub struct ContainerStatus {
 }
 
 /// Resource usage statistics
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ResourceUsage {
     pub cpu_percent: f64,
     pub memory_mb: i64,
@@ -167,7 +167,7 @@ pub struct ResourceUsage {
 }
 
 /// GPU usage statistics
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GpuUsage {
     pub gpu_index: u32,
     pub utilization_percent: f64,


### PR DESCRIPTION
Querying status or stopping a rental that's already in a terminal state (Stopped/Failed) would attempt SSH + Docker calls to a node that may no longer be reachable, causing unnecessary errors. Now both paths short-circuit: `get_rental_status` returns synthetic container status from the DB, and `stop_rental` returns `Ok(())` immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized rental status checks and stop operations to skip unnecessary processing for completed rentals, improving response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->