### PR TITLE
feat(validator): send X-Validator-Hotkey header in API requests

### DIFF
--- a/crates/basilica-validator/src/basilica_api/mod.rs
+++ b/crates/basilica-validator/src/basilica_api/mod.rs
@@ -351,6 +351,7 @@ impl BasilicaApiClient {
         let response = self
             .http_client
             .get(url)
+            .header("X-Validator-Hotkey", self.signer.hotkey())
             .header("X-Validator-Signature", signature)
             .header("X-Timestamp", timestamp)
             .query(query)


### PR DESCRIPTION
Add validator hotkey to API requests via `X-Validator-Hotkey` header in `signed_get()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API request authentication by adding a new validation header to signed requests, strengthening security measures for server-side authentication and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->