### PR TITLE
fix(cli): set CWD to binary directory before self-update

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `bs upgrade` no longer fails when run from a working directory different from the binary's location
 - Deployment list table now uses `Style::modern()` borders, properly cased column headers, formatted timestamps, and full URLs to match `ls`/`ps` table styling
 
 ## [0.18.3] - 2026-02-11

--- a/crates/basilica-cli/src/cli/handlers/upgrade.rs
+++ b/crates/basilica-cli/src/cli/handlers/upgrade.rs
@@ -90,6 +90,12 @@ pub fn handle_upgrade(version: Option<String>, dry_run: bool) -> Result<(), CliE
         .no_confirm(true)
         .target_version_tag(&target_tag);
 
+    // Change CWD to the binary's directory so that self_replace's
+    // read_link() → relative path resolves correctly
+    if let Some(bin_dir) = resolved_exe.parent() {
+        std::env::set_current_dir(bin_dir).expect("failed to set CWD to binary's parent directory");
+    }
+
     // Build and execute the update
     let status = update_builder
         .build()


### PR DESCRIPTION
## Summary

- Fixes CLI self-upgrade failing when the user's CWD differs from the binary's directory
- `self_replace`'s internal `read_link()` can return a relative path that fails to resolve against the wrong CWD
- Sets CWD to the binary's parent directory before invoking the update