### PR TITLE
fix(cli): align deployment list table styling with ls/ps

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Deployment list table now uses `Style::modern()` borders, properly cased column headers, formatted timestamps, and full URLs to match `ls`/`ps` table styling
+
 ## [0.18.3] - 2026-02-11
 
 ### Fixed

--- a/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
@@ -145,15 +145,21 @@ pub fn print_deployments_table(deployments: &[DeploymentSummary]) {
         return;
     }
 
-    use tabled::{Table, Tabled};
+    use tabled::{settings::Style, Table, Tabled};
 
     #[derive(Tabled)]
     struct Row {
+        #[tabled(rename = "Name")]
         name: String,
+        #[tabled(rename = "State")]
         state: String,
+        #[tabled(rename = "Access")]
         access: String,
+        #[tabled(rename = "Replicas")]
         replicas: String,
+        #[tabled(rename = "URL")]
         url: String,
+        #[tabled(rename = "Created")]
         created: String,
     }
 
@@ -163,18 +169,19 @@ pub fn print_deployments_table(deployments: &[DeploymentSummary]) {
             name: d.instance_name.clone(),
             state: d.state.clone(),
             access: if d.public {
-                style("Public").green().to_string()
+                "Public".to_string()
             } else {
-                style("Token").yellow().to_string()
+                "Token".to_string()
             },
             replicas: format!("{}/{}", d.replicas.ready, d.replicas.desired),
-            url: truncate_url(&d.url, 45),
-            created: d.created_at.clone(),
+            url: d.url.clone(),
+            created: crate::output::table_output::format_timestamp(&d.created_at),
         })
         .collect();
 
-    let table = Table::new(rows).to_string();
-    println!("{}", table);
+    let mut table = Table::new(rows);
+    table.with(Style::modern());
+    println!("{table}");
 }
 
 /// Print summons details
@@ -336,15 +343,6 @@ pub async fn stream_logs_to_stdout(
     }
 
     Ok(())
-}
-
-/// Truncate URL for table display
-fn truncate_url(url: &str, max_len: usize) -> String {
-    if url.len() <= max_len {
-        url.to_string()
-    } else {
-        format!("{}...", &url[..max_len - 3])
-    }
 }
 
 /// Truncate string for display (unicode-safe)

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, str::FromStr};
 use tabled::{builder::Builder, settings::Style, Table, Tabled};
 
 /// Format RFC3339 timestamp to YY-MM-DD HH:MM:SS format
-fn format_timestamp(timestamp: &str) -> String {
+pub fn format_timestamp(timestamp: &str) -> String {
     DateTime::parse_from_rfc3339(timestamp)
         .ok()
         .map(|dt| {


### PR DESCRIPTION
Deployment list table now uses consistent styling with the existing `ls`/`ps` tables — modern borders, title-cased headers, formatted timestamps, and full URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment list table styling with modern borders and properly cased column headers
  * Added formatted timestamps in the Created column for better readability
  * Deployment URLs now display in full instead of being truncated for easier access
  * Simplified visual styling for deployment access types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->