### PR TITLE
feat(validator): add H200 GPU support for community cloud verification and emissions

### DIFF
--- a/crates/basilica-common/src/types.rs
+++ b/crates/basilica-common/src/types.rs
@@ -113,6 +113,8 @@ pub enum GpuCategory {
     A100,
     /// NVIDIA H100 - Flagship AI training & inference
     H100,
+    /// NVIDIA H200 - High-memory AI training & inference
+    H200,
     /// NVIDIA B200 - Next-gen AI acceleration
     B200,
     /// Other GPU models - General GPU compute
@@ -131,10 +133,15 @@ impl GpuCategory {
     /// use basilica_common::types::GpuCategory;
     ///
     /// let supported = GpuCategory::supported_models();
-    /// assert_eq!(supported, vec!["A100", "H100", "B200"]);
+    /// assert_eq!(supported, vec!["A100", "H100", "H200", "B200"]);
     /// ```
     pub fn supported_models() -> Vec<String> {
-        vec!["A100".to_string(), "H100".to_string(), "B200".to_string()]
+        vec![
+            "A100".to_string(),
+            "H100".to_string(),
+            "H200".to_string(),
+            "B200".to_string(),
+        ]
     }
 
     /// Get the use case description for this GPU category
@@ -142,6 +149,7 @@ impl GpuCategory {
         match self {
             GpuCategory::A100 => "High-end training & inference",
             GpuCategory::H100 => "Flagship AI training & inference",
+            GpuCategory::H200 => "High-memory AI training & inference",
             GpuCategory::B200 => "Next-gen AI acceleration",
             GpuCategory::Other(_) => "General GPU compute",
         }
@@ -152,6 +160,7 @@ impl GpuCategory {
         match self {
             GpuCategory::A100 => "A100".to_string(),
             GpuCategory::H100 => "H100".to_string(),
+            GpuCategory::H200 => "H200".to_string(),
             GpuCategory::B200 => "B200".to_string(),
             GpuCategory::Other(_) => "OTHER".to_string(),
         }
@@ -183,6 +192,8 @@ impl FromStr for GpuCategory {
             Ok(GpuCategory::A100)
         } else if cleaned.contains("H100") {
             Ok(GpuCategory::H100)
+        } else if cleaned.contains("H200") {
+            Ok(GpuCategory::H200)
         } else if cleaned.contains("B200") {
             Ok(GpuCategory::B200)
         } else {

--- a/crates/basilica-miner/src/main.rs
+++ b/crates/basilica-miner/src/main.rs
@@ -366,6 +366,7 @@ fn minimum_usd_per_gpu(gpu_category: &GpuCategory) -> f64 {
     match gpu_category {
         GpuCategory::H100 => 50.0,
         GpuCategory::A100 => 25.0,
+        GpuCategory::H200 => 75.0,
         GpuCategory::B200 => 75.0,
         GpuCategory::Other(_) => 10.0,
     }
@@ -552,6 +553,7 @@ mod tests {
     fn test_minimum_usd_per_gpu_defaults() {
         assert_eq!(minimum_usd_per_gpu(&GpuCategory::H100), 50.0);
         assert_eq!(minimum_usd_per_gpu(&GpuCategory::A100), 25.0);
+        assert_eq!(minimum_usd_per_gpu(&GpuCategory::H200), 75.0);
         assert_eq!(minimum_usd_per_gpu(&GpuCategory::B200), 75.0);
         assert_eq!(
             minimum_usd_per_gpu(&GpuCategory::Other("unknown".to_string())),

--- a/crates/basilica-validator/src/bittensor_core/weight_allocation.rs
+++ b/crates/basilica-validator/src/bittensor_core/weight_allocation.rs
@@ -390,8 +390,12 @@ mod tests {
             crate::config::emission::GpuAllocation::new(12.0),
         );
         gpu_allocations.insert(
+            "H200".to_string(),
+            crate::config::emission::GpuAllocation::new(20.0),
+        );
+        gpu_allocations.insert(
             "B200".to_string(),
-            crate::config::emission::GpuAllocation::new(80.0),
+            crate::config::emission::GpuAllocation::new(60.0),
         );
 
         EmissionConfig {
@@ -419,6 +423,11 @@ mod tests {
         miners.insert(
             "H100".to_string(),
             vec![(MinerUid::new(4), 0.9), (MinerUid::new(5), 0.7)],
+        );
+
+        miners.insert(
+            "H200".to_string(),
+            vec![(MinerUid::new(8), 0.95), (MinerUid::new(9), 0.85)],
         );
 
         miners.insert(
@@ -495,14 +504,15 @@ mod tests {
         assert!((burn.percentage - 10.0).abs() < 0.1);
 
         // Should have category allocations
-        assert_eq!(distribution.category_allocations.len(), 3);
+        assert_eq!(distribution.category_allocations.len(), 4);
         assert!(distribution.category_allocations.contains_key("A100"));
         assert!(distribution.category_allocations.contains_key("H100"));
+        assert!(distribution.category_allocations.contains_key("H200"));
         assert!(distribution.category_allocations.contains_key("B200"));
 
         // Should have weights for miners + burn
-        assert_eq!(distribution.weights.len(), 8); // 7 miners + 1 burn
-        assert_eq!(distribution.miners_served, 7);
+        assert_eq!(distribution.weights.len(), 10); // 9 miners + 1 burn
+        assert_eq!(distribution.miners_served, 9);
 
         // Verify weight conservation
         let total_weight: u64 = distribution.weights.iter().map(|w| w.weight as u64).sum();
@@ -518,7 +528,7 @@ mod tests {
         let distribution = engine.calculate_weight_distribution(miners).unwrap();
 
         // With threshold removed, all miners should be included
-        assert_eq!(distribution.miners_served, 7);
+        assert_eq!(distribution.miners_served, 9);
     }
 
     #[test]
@@ -595,8 +605,11 @@ mod tests {
         let a100_allocation = distribution.category_allocations.get("A100").unwrap();
         let h100_allocation = distribution.category_allocations.get("H100").unwrap();
 
+        let h200_allocation = distribution.category_allocations.get("H200").unwrap();
+
         assert!((a100_allocation.allocation_percentage - 8.0).abs() < 0.1);
         assert!((h100_allocation.allocation_percentage - 12.0).abs() < 0.1);
+        assert!((h200_allocation.allocation_percentage - 20.0).abs() < 0.1);
     }
 
     #[test]
@@ -608,17 +621,20 @@ mod tests {
         let pools = engine.calculate_all_category_pools(total_weight).unwrap();
 
         // Should have pools for all configured categories
-        assert_eq!(pools.len(), 3);
+        assert_eq!(pools.len(), 4);
         assert!(pools.contains_key("A100"));
         assert!(pools.contains_key("H100"));
+        assert!(pools.contains_key("H200"));
         assert!(pools.contains_key("B200"));
 
         // A100 should get 8% of total
         assert_eq!(pools.get("A100"), Some(&800));
         // H100 should get 12% of total
         assert_eq!(pools.get("H100"), Some(&1200));
-        // B200 should get 80% of total
-        assert_eq!(pools.get("B200"), Some(&8000));
+        // H200 should get 20% of total
+        assert_eq!(pools.get("H200"), Some(&2000));
+        // B200 should get 60% of total
+        assert_eq!(pools.get("B200"), Some(&6000));
 
         // Total should equal input
         let total: u64 = pools.values().sum();

--- a/crates/basilica-validator/src/config/collateral.rs
+++ b/crates/basilica-validator/src/config/collateral.rs
@@ -224,6 +224,7 @@ fn default_minimum_usd_per_gpu() -> HashMap<String, Decimal> {
     let mut map = HashMap::new();
     map.insert("H100".to_string(), Decimal::from(50));
     map.insert("A100".to_string(), Decimal::from(25));
+    map.insert("H200".to_string(), Decimal::from(75));
     map.insert("B200".to_string(), Decimal::from(75));
     map.insert("DEFAULT".to_string(), Decimal::from(10));
     map

--- a/crates/basilica-validator/src/config/emission.rs
+++ b/crates/basilica-validator/src/config/emission.rs
@@ -209,7 +209,8 @@ impl EmissionConfig {
         let mut gpu_allocations = HashMap::new();
         gpu_allocations.insert("A100".to_string(), GpuAllocation::new(8.0));
         gpu_allocations.insert("H100".to_string(), GpuAllocation::new(12.0));
-        gpu_allocations.insert("B200".to_string(), GpuAllocation::new(80.0));
+        gpu_allocations.insert("H200".to_string(), GpuAllocation::new(20.0));
+        gpu_allocations.insert("B200".to_string(), GpuAllocation::new(60.0));
 
         Self {
             burn_percentage: 10.0,

--- a/crates/basilica-validator/src/config/emission_tests.rs
+++ b/crates/basilica-validator/src/config/emission_tests.rs
@@ -263,13 +263,15 @@ H100 = 30.0
         // Test has_gpu_model
         assert!(config.has_gpu_model("A100"));
         assert!(config.has_gpu_model("H100"));
+        assert!(config.has_gpu_model("H200"));
         assert!(config.has_gpu_model("B200"));
         assert!(!config.has_gpu_model("RTX4090"));
 
         // Test get_gpu_allocation
         assert_eq!(config.get_gpu_allocation_weight("A100"), Some(8.0));
         assert_eq!(config.get_gpu_allocation_weight("H100"), Some(12.0));
-        assert_eq!(config.get_gpu_allocation_weight("B200"), Some(80.0));
+        assert_eq!(config.get_gpu_allocation_weight("H200"), Some(20.0));
+        assert_eq!(config.get_gpu_allocation_weight("B200"), Some(60.0));
         assert_eq!(config.get_gpu_allocation_weight("RTX4090"), None);
 
         // Test set_gpu_allocation with valid values
@@ -342,7 +344,7 @@ H100 = 30.0
         assert_eq!(config.burn_percentage, 10.0);
         assert_eq!(config.burn_uid, 999);
         assert_eq!(config.weight_set_interval_blocks, 360);
-        assert_eq!(config.gpu_allocations.len(), 3);
+        assert_eq!(config.gpu_allocations.len(), 4);
 
         let total: f64 = config.gpu_allocations.values().map(|a| a.weight).sum();
         assert!((total - 100.0).abs() < 0.01);

--- a/crates/basilica-validator/src/gpu/categorization_tests.rs
+++ b/crates/basilica-validator/src/gpu/categorization_tests.rs
@@ -42,6 +42,21 @@ mod tests {
             "H100"
         );
 
+        // Test H200 variants
+        assert_eq!(
+            GpuCategory::from_str("NVIDIA H200").unwrap().to_string(),
+            "H200"
+        );
+        assert_eq!(
+            GpuCategory::from_str("H200 SXM").unwrap().to_string(),
+            "H200"
+        );
+        assert_eq!(GpuCategory::from_str("h200").unwrap().to_string(), "H200");
+        assert_eq!(
+            GpuCategory::from_str("HGX H200").unwrap().to_string(),
+            "H200"
+        );
+
         // Test B200 variants
         assert_eq!(
             GpuCategory::from_str("HGX B200").unwrap().to_string(),
@@ -135,6 +150,7 @@ mod tests {
         // Test all known categories
         assert_eq!(GpuCategorizer::model_to_category("A100"), GpuCategory::A100);
         assert_eq!(GpuCategorizer::model_to_category("H100"), GpuCategory::H100);
+        assert_eq!(GpuCategorizer::model_to_category("H200"), GpuCategory::H200);
         assert_eq!(GpuCategorizer::model_to_category("B200"), GpuCategory::B200);
         // These should return Other now
         match GpuCategorizer::model_to_category("RTX4090") {
@@ -145,6 +161,7 @@ mod tests {
         // Test case sensitivity
         assert_eq!(GpuCategorizer::model_to_category("a100"), GpuCategory::A100);
         assert_eq!(GpuCategorizer::model_to_category("h100"), GpuCategory::H100);
+        assert_eq!(GpuCategorizer::model_to_category("h200"), GpuCategory::H200);
         assert_eq!(GpuCategorizer::model_to_category("b200"), GpuCategory::B200);
 
         // Test unknown models
@@ -417,13 +434,16 @@ mod tests {
         // Test enum variants
         let a100 = GpuCategory::A100;
         let h100 = GpuCategory::H100;
+        let h200 = GpuCategory::H200;
         let b200 = GpuCategory::B200;
         let other = GpuCategory::Other("CustomGPU".to_string());
 
         assert_eq!(a100, GpuCategory::A100);
         assert_ne!(h100, a100);
+        assert_eq!(h200, GpuCategory::H200);
+        assert_ne!(h200, h100);
         assert_eq!(b200, GpuCategory::B200);
-        assert_ne!(b200, h100);
+        assert_ne!(b200, h200);
 
         match other {
             GpuCategory::Other(name) => assert_eq!(name, "CustomGPU"),


### PR DESCRIPTION
Adds NVIDIA H200 as a recognized GPU category across the validator and miner crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added H200 GPU model support with 20% weight allocation.
  * Set H200 minimum collateral value at $75 USD.
  * Rebalanced B200 weight allocation from 80% to 60%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->