### PR TITLE
feat(cli): enable WebSocket by default for OpenClaw template

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/deploy/templates/openclaw.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/templates/openclaw.rs
@@ -9,7 +9,7 @@ use crate::output::print_success;
 use crate::progress::{complete_spinner_and_clear, create_spinner};
 use basilica_sdk::types::{
     CreateDeploymentRequest, HealthCheckConfig, PersistentStorageSpec, ProbeConfig,
-    ResourceRequirements, StorageBackend, StorageSpec,
+    ResourceRequirements, StorageBackend, StorageSpec, WebSocketConfig,
 };
 use basilica_sdk::BasilicaClient;
 use regex::Regex;
@@ -144,7 +144,7 @@ pub async fn handle_openclaw_deploy(
         suspended: false,
         priority: None,
         topology_spread: None,
-        websocket: None,
+        websocket: Some(WebSocketConfig::default()),
         public_metadata: false,
     };
 


### PR DESCRIPTION
## Summary

- Enable WebSocket support by default in the OpenClaw deployment template
- OpenClaw is a chat gateway that requires WebSocket for real-time messaging
- Uses `WebSocketConfig::default()` (enabled=true, 1800s idle timeout)

## Test plan

- [x] `cargo check -p basilica-cli` compiles clean
- [x] `cargo nextest run -p basilica-cli` all 74 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw deployments now have WebSocket support enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->