### PR TITLE
fix(config): expose bidding gRPC port in all compose files

### DIFF
--- a/scripts/localnet/docker-compose.yml
+++ b/scripts/localnet/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     ports:
       - "8080:8080"   # API
       - "9090:9090"   # Metrics
+      - "50052:50052" # Bidding gRPC
     networks:
       basilica-localnet:
         ipv4_address: 172.28.0.20

--- a/scripts/validator/compose.dev.yml
+++ b/scripts/validator/compose.dev.yml
@@ -22,6 +22,7 @@ services:
     ports:
       - "8080:8080"     # Server/API port
       - "9090:9090"     # Metrics port
+      - "50052:50052"   # Bidding gRPC
 
     networks:
       - basilica_network_dev

--- a/scripts/validator/compose.local.yml
+++ b/scripts/validator/compose.local.yml
@@ -33,6 +33,7 @@ services:
     ports:
       - "8080:8080"     # Server/API port
       - "9090:9090"     # Metrics port
+      - "50052:50052"   # Bidding gRPC
 
     networks:
       - basilica_network_local

--- a/scripts/validator/compose.prod.yml
+++ b/scripts/validator/compose.prod.yml
@@ -24,6 +24,7 @@ services:
     ports:
       - "8080:8080"     # Server/API port
       - "9090:9090"     # Metrics port
+      - "50052:50052"   # Bidding gRPC
 
     dns:
       - 1.1.1.1


### PR DESCRIPTION
## Summary
- Adds port `50052:50052` (bidding gRPC) to all Docker Compose files for the validator service
- Covers `compose.prod.yml`, `compose.dev.yml`, `compose.local.yml`, and localnet `docker-compose.yml`
- The bidding gRPC port was added in `ada3db45` but the compose files were never updated to expose it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validator service configurations across development, local, and production environments to expose the Bidding gRPC port, enabling network communication for bidding services in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->