### PR TITLE
Force inject basilica branding on rentals SSH and update with new cli…

### DIFF
--- a/crates/basilica-validator/src/rental/deployment.rs
+++ b/crates/basilica-validator/src/rental/deployment.rs
@@ -10,6 +10,28 @@ use tracing::{debug, info, warn};
 use super::container_client::ContainerClient;
 use super::types::{ContainerInfo, ContainerSpec};
 
+const BASILICA_SSH_LOGIN_BANNER: &str = r#"             #######           
+ ######  #############        
+########################      
+   #######################    
+    ########        #######   
+   ##########         ######  
+   ###########         ###### 
+  #####  ######         ######
+  #####   #####          #####
+ #####    ######         #####
+ #####    ######         #####
+ #####    ######         #####
+ #####    ######         #####
+ #####    ######         #####
+ #####    ######         #####
+ #####     #####         #####
+ #####     #####         #####
+ #####      ##################
+ #####        ################
+  ####          ##############
+"#;
+
 /// Container deployment manager
 pub struct DeploymentManager {
     /// Deployment configuration
@@ -574,20 +596,92 @@ impl DeploymentManager {
 
         // Configure SSH to allow root login with key
         let config_ssh = format!(
-            "docker exec {container_id} bash -c 'echo \"PermitRootLogin prohibit-password\" >> /etc/ssh/sshd_config && \
+            "docker exec {container_id} sh -c 'echo \"PermitRootLogin prohibit-password\" >> /etc/ssh/sshd_config && \
              echo \"PubkeyAuthentication yes\" >> /etc/ssh/sshd_config && \
-             echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config'"
+             echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config && \
+             echo \"Banner /etc/issue.net\" >> /etc/ssh/sshd_config && \
+             echo \"PrintMotd no\" >> /etc/ssh/sshd_config'"
         );
-        let _ = client.execute_ssh_command(&config_ssh).await;
+        if let Err(e) = client.execute_ssh_command(&config_ssh).await {
+            debug!("Failed to configure sshd settings: {}", e);
+        }
+
+        // Install Basilica login branding at multiple layers:
+        // 1) SSH daemon banner (/etc/issue.net)
+        // 2) Traditional MOTD (/etc/motd)
+        // 3) Interactive shell startup script that clears provider output and prints Basilica logo
+        let set_login_banner = format!(
+            r#"docker exec {container_id} sh -c "cat > /etc/issue.net <<'BASILICA_EOF'
+{banner}
+BASILICA_EOF
+cat /etc/issue.net > /etc/motd
+touch /root/.hushlogin""#,
+            banner = BASILICA_SSH_LOGIN_BANNER
+        );
+        if let Err(e) = client.execute_ssh_command(&set_login_banner).await {
+            debug!("Failed to install Basilica SSH daemon banner: {}", e);
+        }
+
+        let install_shell_branding = format!(
+            r#"docker exec {container_id} sh -c "mkdir -p /etc/profile.d
+cat > /etc/profile.d/zz-basilica-branding.sh <<'BASILICA_PROFILE_EOF'
+# Basilica-managed login branding for interactive shells.
+case "$-" in
+  *i*) ;;
+  *) return 0 2>/dev/null || exit 0 ;;
+esac
+
+# Avoid duplicate logo prints when nested shells are opened.
+if [ -n "$BASILICA_LOGO_SHOWN" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+export BASILICA_LOGO_SHOWN=1
+
+# Force provider branding out of view, then show Basilica logo.
+clear 2>/dev/null || true
+cat <<'BASILICA_BANNER_EOF'
+{banner}
+BASILICA_BANNER_EOF
+BASILICA_PROFILE_EOF
+chmod 0644 /etc/profile.d/zz-basilica-branding.sh""#,
+            banner = BASILICA_SSH_LOGIN_BANNER
+        );
+        if let Err(e) = client.execute_ssh_command(&install_shell_branding).await {
+            debug!("Failed to install Basilica shell branding script: {}", e);
+        }
+
+        // Ensure common startup files source the Basilica branding script.
+        // Appending the source line at the end makes this run after image-specific startup hooks.
+        let enforce_shell_branding = format!(
+            r#"docker exec {container_id} sh -c "for f in /root/.bashrc /root/.profile /root/.bash_profile /root/.zshrc /etc/profile /etc/bash.bashrc /etc/zsh/zshrc; do
+  [ -f \"$f\" ] || continue
+  grep -q 'zz-basilica-branding.sh' \"$f\" 2>/dev/null || printf '\n[ -f /etc/profile.d/zz-basilica-branding.sh ] && . /etc/profile.d/zz-basilica-branding.sh\n' >> \"$f\"
+done
+
+# Disable PAM dynamic MOTD hooks when present (common Ubuntu provider branding path).
+if [ -f /etc/pam.d/sshd ]; then
+  sed -i '/pam_motd\\.so/s/^/# basilica-disabled: /' /etc/pam.d/sshd 2>/dev/null || true
+fi
+
+# Disable executable update-motd scripts when present.
+chmod -x /etc/update-motd.d/* 2>/dev/null || true""#
+        );
+        if let Err(e) = client.execute_ssh_command(&enforce_shell_branding).await {
+            debug!("Failed to enforce Basilica shell branding: {}", e);
+        }
 
         // Start SSH service (try multiple methods)
         info!("Starting SSH service in container {}", container_id);
 
         // Try systemctl first (for systemd-based systems)
-        let start_systemctl = format!("docker exec {container_id} systemctl start ssh 2>/dev/null || systemctl start sshd 2>/dev/null");
+        let start_systemctl = format!(
+            "docker exec {container_id} sh -c 'systemctl restart ssh 2>/dev/null || systemctl restart sshd 2>/dev/null || systemctl start ssh 2>/dev/null || systemctl start sshd 2>/dev/null'"
+        );
         if client.execute_ssh_command(&start_systemctl).await.is_err() {
             // Try service command
-            let start_service = format!("docker exec {container_id} service ssh start 2>/dev/null || service sshd start 2>/dev/null");
+            let start_service = format!(
+                "docker exec {container_id} sh -c 'service ssh restart 2>/dev/null || service sshd restart 2>/dev/null || service ssh start 2>/dev/null || service sshd start 2>/dev/null'"
+            );
             if client.execute_ssh_command(&start_service).await.is_err() {
                 // Try running sshd directly
                 let start_direct = format!("docker exec -d {container_id} /usr/sbin/sshd -D");

--- a/crates/basilica-validator/src/rental/deployment.rs
+++ b/crates/basilica-validator/src/rental/deployment.rs
@@ -605,21 +605,6 @@ BASILICA_EOF""#,
             debug!("Failed to install Basilica SSH daemon banner: {}", e);
         }
 
-        // Standard profile.d script for interactive shells.
-        let install_shell_branding = format!(
-            r#"docker exec {container_id} sh -c "mkdir -p /etc/profile.d
-cat > /etc/profile.d/basilica-branding.sh <<'BASILICA_PROFILE_EOF'
-case "\$-" in *i*) ;; *) return 0 2>/dev/null || exit 0 ;; esac
-[ -n "\$BASILICA_LOGO_SHOWN" ] && return 0 2>/dev/null
-export BASILICA_LOGO_SHOWN=1
-cat /etc/issue.net
-BASILICA_PROFILE_EOF
-chmod 0755 /etc/profile.d/basilica-branding.sh""#
-        );
-        if let Err(e) = client.execute_ssh_command(&install_shell_branding).await {
-            debug!("Failed to install Basilica shell branding script: {}", e);
-        }
-
         // Configure SSH access and enforce Basilica banner settings.
         // OpenSSH uses first-match-wins semantics, so comment existing directives first.
         let config_ssh = format!(

--- a/crates/basilica-validator/src/rental/deployment.rs
+++ b/crates/basilica-validator/src/rental/deployment.rs
@@ -594,80 +594,46 @@ impl DeploymentManager {
             client.execute_ssh_command(&add_key_alt).await?;
         }
 
-        // Configure SSH to allow root login with key
-        let config_ssh = format!(
-            "docker exec {container_id} sh -c 'echo \"PermitRootLogin prohibit-password\" >> /etc/ssh/sshd_config && \
-             echo \"PubkeyAuthentication yes\" >> /etc/ssh/sshd_config && \
-             echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config && \
-             echo \"Banner /etc/issue.net\" >> /etc/ssh/sshd_config && \
-             echo \"PrintMotd no\" >> /etc/ssh/sshd_config'"
-        );
-        if let Err(e) = client.execute_ssh_command(&config_ssh).await {
-            debug!("Failed to configure sshd settings: {}", e);
-        }
-
-        // Install Basilica login branding at multiple layers:
-        // 1) SSH daemon banner (/etc/issue.net)
-        // 2) Traditional MOTD (/etc/motd)
-        // 3) Interactive shell startup script that clears provider output and prints Basilica logo
+        // Install Basilica SSH banner content.
         let set_login_banner = format!(
             r#"docker exec {container_id} sh -c "cat > /etc/issue.net <<'BASILICA_EOF'
 {banner}
-BASILICA_EOF
-cat /etc/issue.net > /etc/motd
-touch /root/.hushlogin""#,
+BASILICA_EOF""#,
             banner = BASILICA_SSH_LOGIN_BANNER
         );
         if let Err(e) = client.execute_ssh_command(&set_login_banner).await {
             debug!("Failed to install Basilica SSH daemon banner: {}", e);
         }
 
+        // Standard profile.d script for interactive shells.
         let install_shell_branding = format!(
             r#"docker exec {container_id} sh -c "mkdir -p /etc/profile.d
-cat > /etc/profile.d/zz-basilica-branding.sh <<'BASILICA_PROFILE_EOF'
-# Basilica-managed login branding for interactive shells.
-case "$-" in
-  *i*) ;;
-  *) return 0 2>/dev/null || exit 0 ;;
-esac
-
-# Avoid duplicate logo prints when nested shells are opened.
-if [ -n "$BASILICA_LOGO_SHOWN" ]; then
-  return 0 2>/dev/null || exit 0
-fi
+cat > /etc/profile.d/basilica-branding.sh <<'BASILICA_PROFILE_EOF'
+case "$-" in *i*) ;; *) return 0 2>/dev/null || exit 0 ;; esac
+[ -n "$BASILICA_LOGO_SHOWN" ] && return 0 2>/dev/null
 export BASILICA_LOGO_SHOWN=1
-
-# Force provider branding out of view, then show Basilica logo.
-clear 2>/dev/null || true
-cat <<'BASILICA_BANNER_EOF'
-{banner}
-BASILICA_BANNER_EOF
+cat /etc/issue.net
 BASILICA_PROFILE_EOF
-chmod 0644 /etc/profile.d/zz-basilica-branding.sh""#,
-            banner = BASILICA_SSH_LOGIN_BANNER
+chmod 0755 /etc/profile.d/basilica-branding.sh""#
         );
         if let Err(e) = client.execute_ssh_command(&install_shell_branding).await {
             debug!("Failed to install Basilica shell branding script: {}", e);
         }
 
-        // Ensure common startup files source the Basilica branding script.
-        // Appending the source line at the end makes this run after image-specific startup hooks.
-        let enforce_shell_branding = format!(
-            r#"docker exec {container_id} sh -c "for f in /root/.bashrc /root/.profile /root/.bash_profile /root/.zshrc /etc/profile /etc/bash.bashrc /etc/zsh/zshrc; do
-  [ -f \"$f\" ] || continue
-  grep -q 'zz-basilica-branding.sh' \"$f\" 2>/dev/null || printf '\n[ -f /etc/profile.d/zz-basilica-branding.sh ] && . /etc/profile.d/zz-basilica-branding.sh\n' >> \"$f\"
-done
-
-# Disable PAM dynamic MOTD hooks when present (common Ubuntu provider branding path).
-if [ -f /etc/pam.d/sshd ]; then
-  sed -i '/pam_motd\\.so/s/^/# basilica-disabled: /' /etc/pam.d/sshd 2>/dev/null || true
-fi
-
-# Disable executable update-motd scripts when present.
-chmod -x /etc/update-motd.d/* 2>/dev/null || true""#
+        // Configure SSH access and enforce Basilica banner settings.
+        // OpenSSH uses first-match-wins semantics, so comment existing directives first.
+        let config_ssh = format!(
+            r#"docker exec {container_id} sh -c "sed -i 's/^[[:space:]]*Banner[[:space:]].*/# basilica-override: &/; s/^[[:space:]]*PrintMotd[[:space:]].*/# basilica-override: &/' /etc/ssh/sshd_config 2>/dev/null || true
+cat >> /etc/ssh/sshd_config <<'BASILICA_SSHD_EOF'
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+PasswordAuthentication no
+Banner /etc/issue.net
+PrintMotd no
+BASILICA_SSHD_EOF""#
         );
-        if let Err(e) = client.execute_ssh_command(&enforce_shell_branding).await {
-            debug!("Failed to enforce Basilica shell branding: {}", e);
+        if let Err(e) = client.execute_ssh_command(&config_ssh).await {
+            debug!("Failed to configure sshd settings: {}", e);
         }
 
         // Start SSH service (try multiple methods)

--- a/crates/basilica-validator/src/rental/deployment.rs
+++ b/crates/basilica-validator/src/rental/deployment.rs
@@ -609,8 +609,8 @@ BASILICA_EOF""#,
         let install_shell_branding = format!(
             r#"docker exec {container_id} sh -c "mkdir -p /etc/profile.d
 cat > /etc/profile.d/basilica-branding.sh <<'BASILICA_PROFILE_EOF'
-case "$-" in *i*) ;; *) return 0 2>/dev/null || exit 0 ;; esac
-[ -n "$BASILICA_LOGO_SHOWN" ] && return 0 2>/dev/null
+case "\$-" in *i*) ;; *) return 0 2>/dev/null || exit 0 ;; esac
+[ -n "\$BASILICA_LOGO_SHOWN" ] && return 0 2>/dev/null
 export BASILICA_LOGO_SHOWN=1
 cat /etc/issue.net
 BASILICA_PROFILE_EOF
@@ -623,7 +623,7 @@ chmod 0755 /etc/profile.d/basilica-branding.sh""#
         // Configure SSH access and enforce Basilica banner settings.
         // OpenSSH uses first-match-wins semantics, so comment existing directives first.
         let config_ssh = format!(
-            r#"docker exec {container_id} sh -c "sed -i 's/^[[:space:]]*Banner[[:space:]].*/# basilica-override: &/; s/^[[:space:]]*PrintMotd[[:space:]].*/# basilica-override: &/' /etc/ssh/sshd_config 2>/dev/null || true
+            r#"docker exec {container_id} sh -c "sed -i 's/^[[:space:]]*\(Banner\|PrintMotd\|PermitRootLogin\|PubkeyAuthentication\|PasswordAuthentication\)[[:space:]].*/# basilica-override: &/' /etc/ssh/sshd_config 2>/dev/null || true
 cat >> /etc/ssh/sshd_config <<'BASILICA_SSHD_EOF'
 PermitRootLogin prohibit-password
 PubkeyAuthentication yes
@@ -633,7 +633,7 @@ PrintMotd no
 BASILICA_SSHD_EOF""#
         );
         if let Err(e) = client.execute_ssh_command(&config_ssh).await {
-            debug!("Failed to configure sshd settings: {}", e);
+            warn!("Failed to configure sshd settings: {}", e);
         }
 
         // Start SSH service (try multiple methods)


### PR DESCRIPTION
## Summary

Force-inject Basilica branding into rental SSH login so users consistently see Basilica ASCII branding instead of base-image/provider MOTD branding.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Added a new `BASILICA_SSH_LOGIN_BANNER` constant and used it for SSH login branding.
- Configured SSH daemon to show Basilica banner:
  - `Banner /etc/issue.net`
  - `PrintMotd no`
- Wrote Basilica branding to `/etc/issue.net` and `/etc/motd`.
- Added `/etc/profile.d/zz-basilica-branding.sh` to:
  - run only for interactive shells,
  - clear terminal output,
  - print Basilica ASCII logo once per session.
- Appended sourcing hook to common startup files (`/root/.bashrc`, `/root/.profile`, `/root/.bash_profile`, `/root/.zshrc`, `/etc/profile`, `/etc/bash.bashrc`, `/etc/zsh/zshrc`) when present.
- Disabled common Ubuntu/provider MOTD paths by:
  - commenting `pam_motd.so` entries in `/etc/pam.d/sshd` (best effort),
  - disabling `/etc/update-motd.d/*` executables (best effort).
- Scope of code change: `crates/basilica-validator/src/rental/deployment.rs`

## Testing

### How Has This Been Tested?

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing completed

Commands run:
- `cargo fmt --all -- --check` ✅

### Test Configuration

- OS: Darwin 25.3.0 arm64
- Rust version: `rustc 1.85.0-nightly (d117b7f21 2024-12-31)`
- Cargo version: `cargo 1.85.0-nightly (c86f4b3a1 2024-12-24)`
- Bittensor version (if applicable): `bittensor-rs 0.1.1` (git `one-covenant/bittensor-rs`, commit `bd344ba6`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` to format my code
- [ ] I have run `cargo clippy` and addressed all warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Context

- Branding enforcement is intentionally best-effort and non-fatal; failures in branding steps are logged and do not fail rental provisioning.
- Existing SSH/rental provisioning flow is preserved; this change is focused on SSH login presentation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH login branding displayed in login banners and interactive shells.
  * Added default deployment configuration, resource limits, and network policy defaults.
  * Improved SSH access setup to reliably create SSH home keys and install shell branding during deployment.

* **Bug Fixes**
  * Improved SSH configuration error handling and startup orchestration with multiple fallback start methods and clearer logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->