### PR TITLE
ci: add aarch64 Linux and multi-Python macOS wheels to SDK release

### DIFF
--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64]
+        target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
 
@@ -63,8 +63,13 @@ jobs:
           manylinux: auto
           before-script-linux: |
             # Install protoc inside the manylinux container
-            curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip
-            unzip protoc-25.1-linux-x86_64.zip -d /usr/local
+            if [ "$(uname -m)" = "x86_64" ]; then
+              PROTOC_ARCH="linux-x86_64"
+            else
+              PROTOC_ARCH="linux-aarch_64"
+            fi
+            curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-${PROTOC_ARCH}.zip"
+            unzip "protoc-25.1-${PROTOC_ARCH}.zip" -d /usr/local
             chmod +x /usr/local/bin/protoc
             protoc --version
 
@@ -75,19 +80,20 @@ jobs:
           path: dist/*.whl
 
   build-wheels-macos:
-    name: Build wheels on macOS (${{ matrix.target }})
+    name: Build wheels on macOS (${{ matrix.target }}, py${{ matrix.python-version }})
     needs: extract-version
     runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '${{ matrix.python-version }}'
 
       - name: Install protoc
         run: brew install protobuf
@@ -96,13 +102,13 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --manifest-path crates/basilica-sdk-python/Cargo.toml
+          args: --release --out dist -i python${{ matrix.python-version }} --manifest-path crates/basilica-sdk-python/Cargo.toml
           sccache: 'true'
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}
+          name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist/*.whl
 
   build-sdist:
@@ -246,7 +252,7 @@ jobs:
 
             ## Supported Platforms
 
-            - Linux: x86_64
+            - Linux: x86_64, aarch64 (ARM64)
             - macOS: x86_64 (Intel), aarch64 (Apple Silicon)
             - Python: 3.10, 3.11, 3.12, 3.13
 


### PR DESCRIPTION
## Summary
- Add Linux `aarch64` target to the Python SDK release workflow with architecture-aware protoc installation
- Add Python 3.10-3.13 matrix for macOS builds (previously only built for 3.10)
- Update release notes to reflect new platform support

This fixes users having to recompile the SDK from source when installing on Linux ARM64 or macOS with Python != 3.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended build support to include aarch64/ARM64 architecture for Linux and macOS installations.
  * Added Python version-specific wheel distributions for macOS (Python 3.10, 3.11, 3.12, 3.13).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->