### PR TITLE
fix: enable abi3 stable ABI for Python SDK wheels

### DIFF
--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -80,20 +80,19 @@ jobs:
           path: dist/*.whl
 
   build-wheels-macos:
-    name: Build wheels on macOS (${{ matrix.target }}, py${{ matrix.python-version }})
+    name: Build wheels on macOS (${{ matrix.target }})
     needs: extract-version
     runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '${{ matrix.python-version }}'
+          python-version: '3.10'
 
       - name: Install protoc
         run: brew install protobuf
@@ -102,13 +101,13 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist -i python${{ matrix.python-version }} --manifest-path crates/basilica-sdk-python/Cargo.toml
+          args: --release --out dist --manifest-path crates/basilica-sdk-python/Cargo.toml
           sccache: 'true'
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-macos-${{ matrix.target }}
           path: dist/*.whl
 
   build-sdist:

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -54,6 +54,6 @@ Issues = "https://github.com/one-covenant/basilica/issues"
 Changelog = "https://github.com/one-covenant/basilica/blob/main/crates/basilica-sdk-python/CHANGELOG.md"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "pyo3/abi3-py310"]
 python-source = "python"
 module-name = "basilica._basilica"


### PR DESCRIPTION
## Summary
- Add `pyo3/abi3-py310` to maturin features in `pyproject.toml` so all platforms produce `cp310-abi3` tagged wheels
- Revert per-Python-version macOS matrix (abi3 makes one wheel cover all Python 3.10+)

## Problem
The Linux wheel on PyPI was tagged `cp38-cp38` instead of `cp310-abi3`. Since `requires-python >= 3.10`, pip/uv refused the wheel and fell back to compiling from source, requiring a full Rust toolchain.

## Test plan
- [ ] Verify CI passes
- [ ] On next release, confirm PyPI wheels are tagged `cp310-abi3-manylinux_*` for Linux
- [ ] Verify `uv pip install basilica-sdk` installs without compilation on Linux x86_64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration to use Python 3.10
  * Added Python stable ABI compatibility for Python 3.10 in the Python SDK

<!-- end of auto-generated comment: release notes by coderabbit.ai -->