### PR TITLE
docs(scoring): update weight model docs from uptime-based to delivery-based

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -103,7 +103,7 @@ docker compose logs -f miner
 11. [Monitoring](#monitoring)
 12. [Troubleshooting](#troubleshooting)
 13. [Advanced Topics](#advanced-topics)
-    - [Time-Based Incentive Ramp-Up](#time-based-incentive-ramp-up)
+    - [Delivery-Based Emissions](#delivery-based-emissions)
     - [Miners & the Ban System](#miners--the-ban-system)
 
 ---
@@ -1637,9 +1637,9 @@ chmod +x /opt/basilica/scripts/monitor-gpus.sh
 - **Error rates**: Failed authentications, SSH failures
 - **Database performance**: Query times, connection pool usage
 
-### Time-Based Incentive Ramp-Up
+### Delivery-Based Emissions
 
-Validators apply a linear uptime multiplier that reaches 1.0 after roughly 14 days of uninterrupted service and resets when downtime exceeds the validator tolerance window. For detailed formulas, examples, and operational guidance, see [Node Uptime Ramp-up (Incentives Ramp-up)](scoring-and-weights.md#node-uptime-ramp-up-incentives-ramp-up).
+Miners earn emissions based on **rental revenue**, not uptime or validation scores. When your GPU nodes are actively rented and generating revenue, the billing system records delivery records that the validator uses to set weights. Your share of emissions within each GPU category is proportional to the `revenue_usd` your nodes generate relative to other miners in the same category. For the full weight calculation details, see [Scoring and Weight Setting](scoring-and-weights.md).
 
 ### Miners & the Ban System
 

--- a/docs/scoring-and-weights.md
+++ b/docs/scoring-and-weights.md
@@ -4,88 +4,92 @@ This document explains how the Basilica validator scores miners and sets weights
 
 ## Overview
 
-The validator uses a GPU-based scoring system that evaluates miners based on their hardware capabilities and validation success rates. Only H100 and H200 GPUs are eligible for rewards, while other GPU types are excluded from weight distribution.
+The validator uses a **delivery-based weight model**: miners only receive emissions when their GPU nodes generate rental revenue. Weights are proportional to the `revenue_usd` recorded in delivery records from the billing API. GPUs that are not actively rented do not earn emissions.
 
 ## GPU Categories
 
-The system recognizes three GPU categories, but only two are eligible for rewards:
+The system recognizes the following GPU categories:
 
+- **A100** - NVIDIA A100 GPUs
 - **H100** - NVIDIA H100 GPUs
 - **H200** - NVIDIA H200 GPUs
-- **OTHER** - All other GPU types
+- **B200** - NVIDIA B200 GPUs
+- **Other** - All other GPU types (not eligible for weight allocation)
 
-**NOTE**: The "OTHER" category is not rewarded. Only miners with H100 or H200 GPUs are considered for weight allocation.
+**NOTE**: Only GPUs with a configured allocation in the validator's emission config receive weight. The "Other" category is never rewarded.
 
 **NOTE**: Currently we only validate GPUs with CUDA version 12.8 or higher.
 
-### Current Allocation
+### Current Default Allocation
 
-Based on the emission configuration, the weight pool is distributed as follows:
+Based on `validator.toml.example`, the default weight pool distribution is:
 
-- **Burn**: 95% of the total weight allocation is sent to a burn address to maintain network economics.
-- **H100**: 40% of total **available** weight allocation
-- **H200**: 60% of total **available** weight allocation
+- **Burn**: 95% of total weight allocation is sent to a burn address
+- **A100**: 45% of remaining (post-burn) weight allocation
+- **H100**: 55% of remaining (post-burn) weight allocation
 
-## Scoring Formula
+These values are configurable per validator. Additional GPU categories (H200, B200) can be added to the `[emission.gpu_allocations]` config as needed.
 
-### For Each Miner
+## Delivery-Based Weight Model
 
-The base score is calculated as:
+### How It Works
 
-```text
-validation_ratio = successful_validations / total_validations
-```
+1. **Rental Revenue Tracking**: When a miner's GPU node is rented, the billing system records a delivery with the `revenue_usd` generated during the rental period.
+2. **Delivery Sync**: At each weight-setting epoch, the validator fetches delivery records from the billing API for the current period.
+3. **Category Grouping**: Deliveries are grouped by GPU category. Each delivery contributes its `revenue_usd` to the miner's total within that category.
+4. **Weight Allocation**: Within each category, weights are distributed proportionally to each miner's share of total revenue in that category.
 
-This ratio represents the miner's availability and reliability. High availability makes miners rank higher.
+### Weight Calculation
 
-### For Each Miner in a Category
+#### Step 1: Fetch Deliveries
 
-Within each GPU category, the miner's score is weighted by their effective (uptime-adjusted) GPU count:
-
-```text
-category_score = validation_ratio × effective_gpu_count
-```
-
-Where:
-- `validation_ratio` = successful_validations / total_validations across all nodes in this category
-- `effective_gpu_count` = SUM(gpu_count_n × uptime_multiplier_n) for all nodes n in this category
-
-For a single node, the contribution to effective GPU count is:
-```text
-effective_gpu_count_n = gpu_count_n × uptime_multiplier_n
-```
-
-Where:
-- `gpu_count_n` = raw number of GPUs on node n
-- `uptime_multiplier_n` = node uptime factor (0.0 to 1.0, based on continuous uptime - see [Node Uptime Ramp-up](#node-uptime-ramp-up-incentives-ramp-up))
-
-The effective GPU count is aggregated across all machines the miner operates within that category, with each node's GPU count multiplied by its individual uptime multiplier.
-
-### Category Competition
-
-For each category C, the total score is calculated using effective (uptime-adjusted) GPU counts:
+The weight setter syncs delivery records from the billing API for the current epoch window:
 
 ```text
-total_category_score = SUM(validation_ratio_i × effective_gpu_count_i) for all miners i in C
+deliveries = billing_api.get_miner_delivery(period_start, period_end)
 ```
 
-Where `effective_gpu_count_i` is the sum of all uptime-adjusted GPU counts across all nodes that miner i operates in category C:
+Each delivery contains:
+- `miner_hotkey` — the miner's identity
+- `node_id` — the specific GPU node
+- `gpu_category` — the GPU type (e.g., "H100")
+- `revenue_usd` — rental revenue generated
+
+#### Step 2: Group by Category
+
+Deliveries are grouped by GPU category. Only deliveries with `revenue_usd > 0` and a recognized GPU category contribute to weight allocation:
 
 ```text
-effective_gpu_count_i = SUM(gpu_count_n × uptime_multiplier_n) for all nodes n of miner i in C
+For each delivery:
+  category = delivery.gpu_category
+  miners_by_category[category].push(miner_uid, revenue_usd)
 ```
 
-Miners compete locally within their category. The more populated a category is (measured by total effective GPU count), the more competition exists for that category's weight pool.
+#### Step 3: Allocate Category Weights
 
-### Weight Distribution Within Category
-
-Each miner's weight within their category is proportional to their contribution:
+Each configured GPU category receives a share of the post-burn emission pool:
 
 ```text
-miner_weight_in_category = (category_score / total_category_score) × category_weight_pool
+burn_weight = total_emissions × burn_percentage
+remaining = total_emissions - burn_weight
+
+category_pool = remaining × (category_weight / 100.0)
 ```
 
-### Final Miner Weight
+If a category has no deliveries (no active rentals), its allocation is added to the burn.
+
+#### Step 4: Distribute Within Category
+
+Within each category, miner weight is proportional to their revenue share:
+
+```text
+miner_revenue = SUM(revenue_usd) for all deliveries of this miner in this category
+total_category_revenue = SUM(revenue_usd) for all miners in this category
+
+miner_weight = (miner_revenue / total_category_revenue) × category_pool
+```
+
+#### Step 5: Final Weight
 
 The final weight for each miner is the sum of their weights across all categories:
 
@@ -93,291 +97,61 @@ The final weight for each miner is the sum of their weights across all categorie
 final_weight = SUM(miner_weight_in_category) across all categories
 ```
 
-## Node Uptime Ramp-up (Incentives Ramp-up)
-
-### Overview
-
-The Node Uptime Ramp-up mechanism rewards miner loyalty and stability by gradually increasing reward allocation based on continuous node availability. This system incentivizes miners to maintain consistent uptime and penalizes nodes that go offline or fail validations.
-
-**Key Principles:**
-- Rewards scale linearly from 0% to 100% over 14 days of continuous uptime
-- Any validation failure resets the uptime counter to zero
-- Ramp-up is tracked **per GPU node**, not per miner UID
-
-### How It Works
-
-Each GPU node maintains an independent uptime multiplier that affects how its GPU count contributes to the miner's category score. When a node first comes online or after any failure, it starts with a 0% multiplier (effectively 0 GPUs for scoring). This multiplier increases linearly each day the node remains online and passes validations.
-
-**Timeline:**
-```
-Day 0 ─────────────────────> Day 14
-0%     7.14%    50%           100%
-│      │        │             │
-New    1 day    7 days        Full rewards
-node   online   online        (14+ days online)
-```
-
-### Mathematical Formula
-
-The uptime multiplier for each node is calculated as:
-
-```text
-uptime_multiplier = min(continuous_uptime_minutes / 20160, 1.0)
-```
-
-Where:
-- `continuous_uptime_minutes` = minutes since last failure (or node registration)
-- `20160` = 14 days in minutes (14 × 24 × 60)
-- `1.0` = maximum multiplier (100% rewards)
-
-This multiplier is then applied to the node's GPU count:
-
-```text
-effective_gpu_count = gpu_count × uptime_multiplier
-```
-
-### Reset Conditions
-
-The uptime counter resets to **zero** when:
-
-1. **Any validation failure occurs** (`success = 0` in verification logs)
-2. **Node goes offline** for extended period (no successful validations)
-3. **Validation attestation fails** (binary validation failure)
-
-**Important:** Only "full validations" (those with binary attestation: `last_binary_validation IS NOT NULL`) count toward uptime. Partial validations do not affect the uptime calculation.
-
-After a reset, the node must build up its uptime multiplier again from 0%, starting from the timestamp of the next successful validation.
-
-### Uptime Progression Timeline
-
-Here's how rewards scale over time for a single H100 GPU node:
+### Example
 
 ```
-Timeline (Days)    Uptime Multiplier    Effective GPU Count    Reward %
-─────────────────────────────────────────────────────────────────────────
-Day 0  (0 hours)         0.000                 0.000           0.00%
-Day 1  (24 hours)        0.071                 0.071           7.14%
-Day 2  (48 hours)        0.143                 0.143          14.29%
-Day 3  (72 hours)        0.214                 0.214          21.43%
-Day 7  (168 hours)       0.500                 0.500          50.00%
-Day 10 (240 hours)       0.714                 0.714          71.43%
-Day 14 (336 hours)       1.000                 1.000         100.00%
-Day 30 (720+ hours)      1.000                 1.000         100.00% (capped)
+Configuration:
+  burn_percentage = 95%
+  A100 allocation = 45%
+  H100 allocation = 55%
+
+Total emissions: 65535 (u16::MAX)
+Burn (95%): 62258 → burn_uid
+Remaining: 3277
+
+A100 pool (45% of remaining): 1475
+  Miner 1: $500 revenue → 500/800 = 62.5% → weight 922
+  Miner 2: $300 revenue → 300/800 = 37.5% → weight 553
+
+H100 pool (55% of remaining): 1802
+  Miner 3: $1000 revenue → 1000/1000 = 100% → weight 1802
+
+If no miners had H100 rentals, the H100 pool (1802) would be added to burn.
 ```
-
-### Example Scenarios
-
-#### Scenario 1: New Miner Joins H100 Category
-
-**Setup:**
-- GPU Category: H100
-- Category weight pool: 40% of available emissions
-- Existing miner: 1 H100 node, 14 days uptime (multiplier = 1.0), 100% validation success
-- New miner: 1 H100 node, just joined (multiplier = 0.0), 100% validation success
-
-**Calculations (Day 0):**
-
-```
-Existing miner:
-  effective_gpu_count = 1 GPU × 1.0 = 1.0
-  category_score = 1.0 (validation_ratio) × 1.0 (effective_gpu_count) = 1.0
-
-New miner:
-  effective_gpu_count = 1 GPU × 0.0 = 0.0
-  category_score = 1.0 (validation_ratio) × 0.0 (effective_gpu_count) = 0.0
-
-total_category_score = 1.0 + 0.0 = 1.0
-
-Existing miner share = 1.0 / 1.0 = 100% of H100 pool
-New miner share      = 0.0 / 1.0 = 0% of H100 pool
-```
-
-**Result:** The new miner receives 0% of H100 emissions until their uptime builds up.
-
-**After 7 days:**
-```
-Existing miner:
-  effective_gpu_count = 1 GPU × 1.0 = 1.0
-  category_score = 1.0 × 1.0 = 1.0
-
-New miner:
-  effective_gpu_count = 1 GPU × 0.5 = 0.5
-  category_score = 1.0 × 0.5 = 0.5
-
-total_category_score = 1.0 + 0.5 = 1.5
-
-Existing miner share = 1.0 / 1.5 = 66.7% of H100 pool
-New miner share      = 0.5 / 1.5 = 33.3% of H100 pool
-```
-
-**After 14 days:**
-```
-Existing miner:
-  effective_gpu_count = 1 GPU × 1.0 = 1.0
-  category_score = 1.0 × 1.0 = 1.0
-
-New miner:
-  effective_gpu_count = 1 GPU × 1.0 = 1.0
-  category_score = 1.0 × 1.0 = 1.0
-
-total_category_score = 1.0 + 1.0 = 2.0
-
-Existing miner share = 1.0 / 2.0 = 50% of H100 pool
-New miner share      = 1.0 / 2.0 = 50% of H100 pool
-```
-
-#### Scenario 2: Impact of Downtime
-
-**Setup:**
-- Miner with 1 H100 node
-- Node has been online for 7 days (multiplier = 0.5, receiving 50% rewards)
-- Node goes offline or fails validation
-- Assume 100% validation success rate when online
-
-**Before failure:**
-```
-effective_gpu_count = 1 × 0.5 = 0.5
-category_score = 1.0 (validation_ratio) × 0.5 (effective_gpu_count) = 0.5
-Reward share = 0.5 / total_category_score
-```
-
-**Immediately after failure:**
-```
-effective_gpu_count = 1 × 0.0 = 0.0 (RESET!)
-category_score = 1.0 × 0.0 = 0.0
-Reward share = 0.0 / total_category_score = 0%
-```
-
-**Impact:** The 7 days of built-up uptime is lost. The miner must start over from 0% and build back up over another 14 days.
-
-#### Scenario 3: Multiple Nodes with Different Uptimes
-
-**Setup:**
-- Miner with 3 H100 nodes (100% validation success):
-  - Node A: 1 GPU, 14 days uptime (multiplier = 1.0)
-  - Node B: 1 GPU, 7 days uptime (multiplier = 0.5)
-  - Node C: 1 GPU, 3 days uptime (multiplier = 0.214)
-
-**Calculation:**
-```
-Node A: effective_gpu_count = 1 × 1.000 = 1.000
-Node B: effective_gpu_count = 1 × 0.500 = 0.500
-Node C: effective_gpu_count = 1 × 0.214 = 0.214
-────────────────────────────────────────────────
-Miner's total effective_gpu_count = 2.714 GPUs
-
-category_score = 1.0 (validation_ratio) × 2.714 (effective_gpu_count) = 2.714
-
-vs. theoretical maximum:
-  effective_gpu_count = 3.000 GPUs (all at 100%)
-  category_score = 1.0 × 3.000 = 3.000
-```
-
-**Current efficiency:** 2.714 / 3.0 = 90.47% of maximum possible rewards
-
-### Visual: Rewards Distribution Comparison
-
-Here's how the H100 category rewards are split between an established miner and a new entrant:
-
-```
-Time: Day 0 (New miner just joined)
-─────────────────────────────────────────────────────────────
-Miner A (1 H100, 14d uptime)  ████████████████████████ 100%
-Miner B (1 H100, 0d uptime)   (no rewards)              0%
-
-Time: Day 7 (New miner has 7 days uptime)
-─────────────────────────────────────────────────────────────
-Miner A (1 H100, 14d uptime)  ████████████████ 66.7%
-Miner B (1 H100, 7d uptime)   ████████ 33.3%
-
-Time: Day 14 (Both at maximum)
-─────────────────────────────────────────────────────────────
-Miner A (1 H100, 14d uptime)  ████████████ 50%
-Miner B (1 H100, 14d uptime)  ████████████ 50%
-```
-
-### Monitoring Your Uptime Status
-
-Validators expose Prometheus metrics that miners can monitor to track their uptime status:
-
-**Key Metrics:**
-
-1. **`basilica_node_uptime_minutes{miner_uid="X", node_id="Y"}`**
-   - Shows continuous uptime in minutes for each node
-   - Resets to 0 on any validation failure
-
-2. **`basilica_node_uptime_multiplier{miner_uid="X", node_id="Y"}`**
-   - Shows current uptime multiplier (0.0 to 1.0)
-   - Directly correlates to reward percentage (0% to 100%)
-
-### Best Practices for Maximizing Rewards
-
-1. **Maintain Continuous Uptime**
-   - Set up monitoring and alerting for node health
-   - Use systemd or supervisor for automatic service restarts
-   - Implement redundant power and network connections
-
-2. **Monitor Validation Success**
-   - Check validator logs regularly for failed validations
-   - Ensure all validations include binary attestation
-   - Fix any issues immediately to prevent uptime resets
-
-3. **Plan Maintenance Windows Carefully**
-   - Any downtime resets your uptime to zero
-   - If you must take a node offline, understand you'll lose 14 days of ramp-up progress
-   - Consider the trade-off: is the maintenance worth restarting the 14-day clock?
-
-4. **Per-Node vs. Per-Miner**
-   - Uptime is tracked per GPU node, not per miner UID
-   - Adding a new node to an existing miner starts that node at 0% multiplier
-   - Existing nodes maintain their independent uptime multipliers
-   - If you have multiple nodes, they can be at different uptime levels simultaneously
-
-5. **Recovery Strategy After Failure**
-   - After a validation failure or outage, uptime resets to zero
-   - The next successful validation starts a new uptime period
-   - It takes 14 days of continuous success to return to 100% rewards
-   - No shortcuts—you must rebuild trust through proven uptime
-
-## Implementation Details
-
-### Validation Process
-
-1. **Miner Discovery**: Validators discover miners from the Bittensor metagraph
-2. **SSH Endpoint Discovery**: Validators query miners via gRPC for GPU node SSH endpoints
-3. **Direct SSH Verification**: Validators SSH directly to GPU nodes for hardware verification
-4. **Score Calculation**: Based on validation success and GPU specifications
-
-### GPU Profile Updates
-
-The system maintains GPU profiles for each miner that track:
-
-- Primary GPU model
-- GPU count distribution across models (raw counts)
-- Node uptime multipliers (per-node basis)
-- Total validation score (calculated using effective GPU counts)
-- Verification count
-- Last update timestamp
-
-### Weight Setting Frequency
-
-Weights are set periodically based on the configured `blocks_per_weight_set` parameter. The weight setter:
-
-- Sets weights when 360 blocks have passed
-- Only includes miners with active axons on the chain and GPU nodes that passed verification
-
-### Filtering Criteria
-
-Miners must meet several criteria to receive weights:
-
-- Have GPU nodes that passed validation within the cutoff time (default: 3 hours)
-- Have active axons on the Bittensor network (non-zero IP and port)
-- Own H100 or H200 GPUs (OTHER category GPUs are excluded)
 
 ## Multi-Category Support
 
 A single miner can appear in multiple categories if they operate different GPU types:
 
-- Miners with both H100 and H200 GPUs compete in both categories
-- Scores are calculated proportionally based on effective GPU count distribution (uptime-adjusted)
+- Miners with both A100 and H100 rentals earn weight in both categories
+- Revenue is attributed to the specific GPU category of each rental
 - Final weight is the sum of weights earned in each category
+
+## Implementation Details
+
+### Delivery Flow
+
+```text
+Billing API → WeightSetter.sync_deliveries_for_epoch()
+  → Store deliveries locally
+  → Group by GPU category
+  → WeightAllocationEngine.allocate_weights()
+  → Submit to Bittensor chain
+```
+
+### Weight Setting Frequency
+
+Weights are set periodically based on the configured `blocks_per_weight_set` parameter. The weight setter:
+
+- Checks the blockchain block every 12 seconds
+- Sets weights when the configured number of blocks have passed (default: 360 blocks ≈ 72 minutes)
+- Only includes miners whose hotkeys are active on the Bittensor metagraph
+
+### Filtering Criteria
+
+Deliveries are excluded from weight calculation when:
+
+- The miner's hotkey is no longer in the metagraph (deregistered)
+- The GPU category is unrecognized (maps to `Other`)
+- The `revenue_usd` is zero, negative, or non-finite
+- The node is excluded due to collateral requirements

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -114,8 +114,8 @@ The Basilica validator performs critical network functions that ensure GPU provi
 
 1. **Miner Discovery**: Query Bittensor metagraph to discover all miners on the subnet
 2. **Node Verification**: SSH directly to GPU nodes for cryptographic verification
-3. **Performance Scoring**: Calculate miner scores based on GPU capabilities and reliability
-4. **Weight Setting**: Distribute emissions based on GPU categories and performance
+3. **Delivery-Based Scoring**: Set miner weights based on rental revenue from the billing API
+4. **Weight Setting**: Distribute emissions proportionally to revenue within each GPU category
 5. **API Service**: Provide external access for rentals and network queries
 
 ---
@@ -228,10 +228,11 @@ The validator employs a **two-tier verification strategy** that optimizes for bo
 
 1. Checks current blockchain block every 12 seconds
 2. Every N blocks (default: 360), triggers weight setting
-3. Queries GPU scoring engine for miner scores by category
-4. Allocates weights based on emission configuration
-5. Applies burn percentage to burn_uid
-6. Submits weights to Bittensor chain
+3. Syncs delivery records from the billing API for the current epoch
+4. Groups deliveries by GPU category, using `revenue_usd` as the scoring metric
+5. Allocates weights proportionally to revenue within each category
+6. Burns allocation for empty categories (no active rentals) plus configured burn percentage
+7. Submits weights to Bittensor chain
 
 #### ApiHandler
 
@@ -619,110 +620,69 @@ let results = futures::stream::iter(tasks)
 - `max_concurrent_full_validations`: 1024 (binary validation requests)
 - `max_miners_per_round`: 20 (miners verified per cycle)
 
-### GPU Scoring and Categorization
+### Delivery-Based Scoring
 
-**Scoring Engine** (code: `scoring/gpu_scoring_engine.rs`):
+**Weight Setter** (code: `bittensor_core/weight_setter.rs`):
 
-1. **GPU Profile Aggregation**:
+Miners are scored based on rental revenue, not validation ratios or GPU counts. The weight setter fetches delivery records from the billing API and distributes weights proportionally to `revenue_usd` within each GPU category.
 
-   ```sql
-   SELECT miner_uid, gpu_counts_json, total_score
-   FROM miner_gpu_profiles
-   WHERE last_successful_validation > NOW() - INTERVAL '6 hours';
-   ```
+1. **Delivery Sync**: At each epoch, the weight setter calls the billing API to fetch delivery records for the period window.
 
-2. **GPU Count Extraction**:
+2. **Category Grouping**: Deliveries are grouped by GPU category. Only deliveries with positive `revenue_usd` and a recognized GPU category contribute.
 
-   ```json
-   {
-     "H100": 8,
-     "A100": 16,
-     "B200": 4
-   }
-   ```
-
-3. **Category Scoring**:
+3. **Revenue-Based Scoring**: Within each category, a miner's weight share equals their share of total revenue:
 
    ```rust
-   // For each GPU category (e.g., "H100")
-   let category_score = verification_score * gpu_count;
-
-   // Example: 0.95 validation score * 8 GPUs = 7.6 category score
-   ```
-
-4. **Normalization**:
-
-   ```rust
-   // Within each category, normalize scores to 0.0-1.0
-   let normalized_score = miner_score / category_total_score;
+   // For each miner in a category
+   let miner_share = miner_revenue / total_category_revenue;
+   let miner_weight = category_pool * miner_share;
    ```
 
 **Multi-GPU Miners**:
 
-- Miners with multiple GPU categories score in each category
+- Miners with multiple GPU categories earn weight in each category based on rental revenue
 - Each category has independent weight allocation
-- Example: Miner with 8x H100 + 16x A100 scores in both categories
+- Example: Miner with H100 and A100 rentals earns weight in both categories proportional to revenue
 
 ### Weight Allocation Algorithm
 
-**Emission Distribution** (code: `config/emission.rs`):
+**Emission Distribution** (code: `bittensor_core/weight_allocation.rs`):
 
 **Configuration**:
 
 ```toml
 [emission]
-burn_percentage = 5.0  # Burn 5% of emissions
-burn_uid = 204         # Send burn weight to UID 204
+burn_percentage = 95.0  # Burn 95% of emissions
+burn_uid = 204          # Send burn weight to UID 204
 
 [emission.gpu_allocations]
-H100 = { weight = 50.0, min_gpu_count = 4 }
-A100 = { weight = 30.0, min_gpu_count = 2 }
-B200 = { weight = 20.0, min_gpu_count = 1 }
+A100 = { weight = 45.0, min_gpu_count = 8, min_gpu_vram = 1 }
+H100 = { weight = 55.0, min_gpu_count = 8, min_gpu_vram = 1 }
 ```
 
-**Weight Calculation** (code: `bittensor_core/weight_setter.rs:48-200`):
+**Weight Calculation**:
 
-1. **Burn Weight**:
+1. **Burn Weight**: Configured percentage of total emissions goes to the burn UID.
 
-   ```rust
-   let burn_weight = (u16::MAX as f64 * burn_percentage / 100.0) as u16;
-   weights[burn_uid] = burn_weight;
-   ```
+2. **Category Allocation**: Remaining emissions are split by configured category weights.
 
-2. **Category Allocation**:
+3. **Empty Category Burn**: If a category has no active rentals, its allocation is added to burn.
 
-   ```rust
-   // Remaining emissions after burn
-   let remaining_emissions = u16::MAX - burn_weight;
+4. **Miner Weights**: Within each active category, weight is proportional to `revenue_usd`.
 
-   // Per category
-   let category_allocation = remaining_emissions * (category_weight / 100.0);
-   ```
-
-3. **Miner Weights within Category**:
-
-   ```rust
-   // Proportional to normalized score
-   let miner_weight = category_allocation * normalized_score;
-   ```
-
-4. **Example**:
+5. **Example**:
 
    ```
    Total emissions: 65535 (u16::MAX)
-   Burn (5%): 3277 → UID 204
-   Remaining: 62258
+   Burn (95%): 62258 → UID 204
+   Remaining: 3277
 
-   H100 allocation (50%): 31129
-     - Miner 1 (score 0.6): 18677
-     - Miner 2 (score 0.4): 12452
+   A100 allocation (45%): 1475
+     - Miner 1 ($500 revenue, 62.5%): 922
+     - Miner 2 ($300 revenue, 37.5%): 553
 
-   A100 allocation (30%): 18677
-     - Miner 3 (score 1.0): 18677
-
-   B200 allocation (20%): 12452
-     - Miner 1 (score 0.5): 6226
-     - Miner 4 (score 0.5): 6226
+   H100 allocation (55%): 1802
+     - Miner 3 ($1000 revenue, 100%): 1802
    ```
 
 **Weight Setting Frequency**:
@@ -1225,10 +1185,8 @@ weight_version_key = 0
 
 # GPU model allocations with weights and minimum requirements
 [emission.gpu_allocations]
-H100 = { weight = 40.0, min_gpu_count = 4, min_gpu_vram = 80 }
-A100 = { weight = 30.0, min_gpu_count = 2, min_gpu_vram = 40 }
-B200 = { weight = 20.0, min_gpu_count = 1, min_gpu_vram = 192 }
-H200 = { weight = 10.0, min_gpu_count = 1, min_gpu_vram = 141 }
+A100 = { weight = 45.0, min_gpu_count = 8, min_gpu_vram = 1 }
+H100 = { weight = 55.0, min_gpu_count = 8, min_gpu_vram = 1 }
 
 # === Database Cleanup Configuration ===
 [cleanup]
@@ -2186,164 +2144,99 @@ let results = futures::stream::iter(tasks)
 
 ## Weight Setting and Emissions
 
-How validators distribute TAO emissions based on GPU performance and categories.
+How validators distribute TAO emissions based on rental revenue across GPU categories.
 
 ### Emission Algorithm Overview
 
-**Goal**: Fairly distribute subnet emissions across miners based on:
-
-1. GPU category (H100, A100, B200, etc.)
-2. GPU quantity per category
-3. Verification score (performance and reliability)
+**Goal**: Fairly distribute subnet emissions across miners based on rental revenue within each GPU category. Miners only receive weight when their nodes are actively rented and generating revenue.
 
 **Configuration-Driven Allocation**:
 
 ```toml
 [emission]
-burn_percentage = 5.0
+burn_percentage = 95.0
 burn_uid = 204
 
 [emission.gpu_allocations]
-H100 = { weight = 50.0, min_gpu_count = 4 }
-A100 = { weight = 30.0, min_gpu_count = 2 }
-B200 = { weight = 20.0, min_gpu_count = 1 }
+A100 = { weight = 45.0, min_gpu_count = 8, min_gpu_vram = 1 }
+H100 = { weight = 55.0, min_gpu_count = 8, min_gpu_vram = 1 }
 ```
 
 ### Weight Calculation Process
 
-#### Step 1: GPU Profile Aggregation
+#### Step 1: Sync Delivery Records
 
-**Query Miner Profiles** (`scoring/gpu_scoring_engine.rs`):
+At each weight-setting epoch, the validator fetches delivery records from the billing API:
 
-```sql
-SELECT
-    miner_uid,
-    gpu_counts_json,
-    total_score,
-    verification_count
-FROM miner_gpu_profiles
-WHERE last_successful_validation > NOW() - INTERVAL '6 hours'
-  AND total_score >= 0.1;  -- min_score_threshold
+```rust
+let deliveries = api_client.get_miner_delivery(epoch.period_start, epoch.period_end).await?;
 ```
 
-**Example Results**:
-
-```
-miner_uid | gpu_counts_json      | total_score
-5         | {"H100": 8}          | 0.95
-12        | {"H100": 4, "A100": 16} | 0.92
-23        | {"A100": 8}          | 0.88
-45        | {"B200": 2}          | 0.85
-```
+Each delivery contains `miner_hotkey`, `node_id`, `gpu_category`, and `revenue_usd`.
 
 ---
 
-#### Step 2: Category Scoring
+#### Step 2: Group Deliveries by Category
 
-**For each GPU category**, calculate scores:
+Deliveries are grouped by GPU category. Only deliveries with `revenue_usd > 0` and recognized GPU categories contribute:
 
-**H100 Category**:
-
-```rust
-// Miner 5: 8x H100, score 0.95
-let miner_5_h100_score = 0.95 * 8 = 7.6
-
-// Miner 12: 4x H100, score 0.92
-let miner_12_h100_score = 0.92 * 4 = 3.68
-
-// Category total
-let h100_total_score = 7.6 + 3.68 = 11.28
 ```
-
-**A100 Category**:
-
-```rust
-// Miner 12: 16x A100, score 0.92
-let miner_12_a100_score = 0.92 * 16 = 14.72
-
-// Miner 23: 8x A100, score 0.88
-let miner_23_a100_score = 0.88 * 8 = 7.04
-
-// Category total
-let a100_total_score = 14.72 + 7.04 = 21.76
-```
-
-**B200 Category**:
-
-```rust
-// Miner 45: 2x B200, score 0.85
-let miner_45_b200_score = 0.85 * 2 = 1.7
-
-// Category total
-let b200_total_score = 1.7
+Miner 5:  H100 rentals → $800 revenue
+Miner 12: H100 rentals → $400 revenue, A100 rentals → $600 revenue
+Miner 23: A100 rentals → $300 revenue
 ```
 
 ---
 
 #### Step 3: Burn Weight Calculation
 
-**Burn Allocation** (`bittensor_core/weight_setter.rs:48-200`):
-
 ```rust
-// Total weight available
 let total_weight = u16::MAX;  // 65535
 
-// Burn weight (5% of total)
-let burn_weight = (total_weight as f64 * 0.05) as u16;  // 3277
+// Burn weight (95% of total)
+let burn_weight = (total_weight as f64 * 0.95) as u16;  // 62258
 
-// Assign to burn UID
 weights[burn_uid] = burn_weight;
 
-// Remaining for miners
-let remaining_weight = total_weight - burn_weight;  // 62258
+let remaining_weight = total_weight - burn_weight;  // 3277
 ```
 
 ---
 
 #### Step 4: Category Weight Allocation
 
-**Distribute remaining weight across GPU categories**:
-
 ```rust
-// H100 allocation (50% of remaining)
-let h100_allocation = (remaining_weight as f64 * 0.50) as u16;  // 31129
+// A100 allocation (45% of remaining)
+let a100_allocation = (remaining_weight as f64 * 0.45) as u16;  // 1475
 
-// A100 allocation (30% of remaining)
-let a100_allocation = (remaining_weight as f64 * 0.30) as u16;  // 18677
-
-// B200 allocation (20% of remaining)
-let b200_allocation = (remaining_weight as f64 * 0.20) as u16;  // 12452
+// H100 allocation (55% of remaining)
+let h100_allocation = (remaining_weight as f64 * 0.55) as u16;  // 1802
 ```
+
+If a category has no active rentals, its allocation is added to burn.
 
 ---
 
 #### Step 5: Miner Weights within Category
 
-**H100 Category Distribution**:
+**H100 Category** (total revenue: $1200):
 
 ```rust
-// Miner 5: 7.6 / 11.28 = 0.674
-let miner_5_h100_weight = (h100_allocation as f64 * 0.674) as u16;  // 20987
+// Miner 5: $800 / $1200 = 0.667
+let miner_5_h100_weight = (h100_allocation as f64 * 0.667) as u16;  // 1202
 
-// Miner 12: 3.68 / 11.28 = 0.326
-let miner_12_h100_weight = (h100_allocation as f64 * 0.326) as u16;  // 10148
+// Miner 12: $400 / $1200 = 0.333
+let miner_12_h100_weight = (h100_allocation as f64 * 0.333) as u16;  // 600
 ```
 
-**A100 Category Distribution**:
+**A100 Category** (total revenue: $900):
 
 ```rust
-// Miner 12: 14.72 / 21.76 = 0.677
-let miner_12_a100_weight = (a100_allocation as f64 * 0.677) as u16;  // 12644
+// Miner 12: $600 / $900 = 0.667
+let miner_12_a100_weight = (a100_allocation as f64 * 0.667) as u16;  // 984
 
-// Miner 23: 7.04 / 21.76 = 0.323
-let miner_23_a100_weight = (a100_allocation as f64 * 0.323) as u16;  // 6033
-```
-
-**B200 Category Distribution**:
-
-```rust
-// Miner 45: 1.7 / 1.7 = 1.0
-let miner_45_b200_weight = b200_allocation;  // 12452
+// Miner 23: $300 / $900 = 0.333
+let miner_23_a100_weight = (a100_allocation as f64 * 0.333) as u16;  // 491
 ```
 
 ---
@@ -2354,31 +2247,27 @@ let miner_45_b200_weight = b200_allocation;  // 12452
 
 ```rust
 // Miner 5 (H100 only)
-weights[5] = 20987
+weights[5] = 1202
 
 // Miner 12 (H100 + A100)
-weights[12] = miner_12_h100_weight + miner_12_a100_weight  // 10148 + 12644 = 22792
+weights[12] = miner_12_h100_weight + miner_12_a100_weight  // 600 + 984 = 1584
 
 // Miner 23 (A100 only)
-weights[23] = 6033
-
-// Miner 45 (B200 only)
-weights[45] = 12452
+weights[23] = 491
 
 // Burn UID
-weights[204] = 3277
+weights[204] = 62258
 ```
 
 **Final Weight Vector**:
 
 ```
-UID   | Weight | Percentage | GPUs
+UID   | Weight | Percentage | Revenue Source
 ------|--------|------------|------------------
-5     | 20987  | 32.0%      | 8x H100
-12    | 22792  | 34.8%      | 4x H100 + 16x A100
-23    | 6033   | 9.2%       | 8x A100
-45    | 12452  | 19.0%      | 2x B200
-204   | 3277   | 5.0%       | BURN
+5     | 1202   | 1.8%       | H100 rentals
+12    | 1584   | 2.4%       | H100 + A100 rentals
+23    | 491    | 0.7%       | A100 rentals
+204   | 62258  | 95.0%      | BURN
 ------|--------|------------|------------------
 Total | 65535  | 100.0%     |
 ```


### PR DESCRIPTION
## Summary

- Replaced the old uptime ramp-up / GPU-count scoring model with the current **delivery-based weight model** where emissions are proportional to `revenue_usd` from the billing API
- Updated config defaults to match `validator.toml.example`: 95% burn, A100 45% / H100 55%
- Removed obsolete sections: Node Uptime Ramp-up, validation_ratio × gpu_count formulas, 14-day multiplier timelines
- Added new worked examples showing revenue-based weight distribution

Affects `docs/miner.md`, `docs/scoring-and-weights.md`, `docs/validator.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated emissions model**: Rewards now determined by delivery revenue and per-node weights rather than uptime-based incentives.
* **Enhanced GPU category support**: Added new classifications (A100, B200) with refined weight allocation logic.
* **Revenue-based weight allocation**: Miners now earn weights proportional to their rental revenue share within GPU categories.
* **Multi-category framework**: Miners can earn weights across multiple GPU categories simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->