### PR TITLE
chore(config): lower min_gpu_count from 8 to 4

### DIFF
--- a/config/validator.toml.example
+++ b/config/validator.toml.example
@@ -124,8 +124,8 @@ weight_version_key = 0
 # are distributed across GPU categories
 # Must sum to exactly 100.0
 [emission.gpu_allocations]
-A100 = { weight = 45.0, min_gpu_count = 8, min_gpu_vram = 1 }
-H100 = { weight = 55.0, min_gpu_count = 8, min_gpu_vram = 1 }
+A100 = { weight = 45.0, min_gpu_count = 4, min_gpu_vram = 1 }
+H100 = { weight = 55.0, min_gpu_count = 4, min_gpu_vram = 1 }
 
 [bid_grpc]
 listen_address = "0.0.0.0:50052"


### PR DESCRIPTION
## Summary
- Lower `min_gpu_count` from 8 to 4 for both A100 and H100 GPU allocations in the example validator config

## Test plan
- [x] Verified only the two expected lines changed in `config/validator.toml.example`
- No tests needed — example config file only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU allocation configuration for A100 and H100 GPUs, reducing minimum GPU count requirement from 8 to 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->