### PR TITLE
feat: add B300 GPU category

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "bittensor-rs"
 version = "0.1.1"
-source = "git+https://github.com/one-covenant/bittensor-rs?branch=main#bd344ba62fbedc686e3814096bbf93cf9d34f7c9"
+source = "git+https://github.com/one-covenant/bittensor-rs?rev=bd344ba62fbedc686e3814096bbf93cf9d34f7c9#bd344ba62fbedc686e3814096bbf93cf9d34f7c9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/basilica-common/src/types.rs
+++ b/crates/basilica-common/src/types.rs
@@ -120,6 +120,8 @@ pub enum GpuCategory {
     H200,
     /// NVIDIA B200 - Next-gen AI acceleration
     B200,
+    /// NVIDIA B300 - Ultra-class AI acceleration
+    B300,
     /// Other GPU models - General GPU compute
     Other(String),
 }
@@ -183,7 +185,7 @@ impl GpuCategory {
     /// use basilica_common::types::GpuCategory;
     ///
     /// let supported = GpuCategory::supported_models();
-    /// assert_eq!(supported, vec!["A100", "H100", "H200", "B200"]);
+    /// assert_eq!(supported, vec!["A100", "H100", "H200", "B200", "B300"]);
     /// ```
     pub fn supported_models() -> Vec<String> {
         vec![
@@ -191,6 +193,7 @@ impl GpuCategory {
             "H100".to_string(),
             "H200".to_string(),
             "B200".to_string(),
+            "B300".to_string(),
         ]
     }
 
@@ -201,6 +204,7 @@ impl GpuCategory {
             GpuCategory::H100 => "Flagship AI training & inference",
             GpuCategory::H200 => "High-memory AI training & inference",
             GpuCategory::B200 => "Next-gen AI acceleration",
+            GpuCategory::B300 => "Ultra-class AI acceleration",
             GpuCategory::Other(_) => "General GPU compute",
         }
     }
@@ -212,6 +216,7 @@ impl GpuCategory {
             GpuCategory::H100 => "H100".to_string(),
             GpuCategory::H200 => "H200".to_string(),
             GpuCategory::B200 => "B200".to_string(),
+            GpuCategory::B300 => "B300".to_string(),
             GpuCategory::Other(name) => name.to_uppercase(),
         }
     }
@@ -244,6 +249,8 @@ impl FromStr for GpuCategory {
             Ok(GpuCategory::H100)
         } else if cleaned.contains("H200") {
             Ok(GpuCategory::H200)
+        } else if cleaned.contains("B300") {
+            Ok(GpuCategory::B300)
         } else if cleaned.contains("B200") {
             Ok(GpuCategory::B200)
         } else {
@@ -270,6 +277,10 @@ mod gpu_category_serde_tests {
             serde_json::to_string(&GpuCategory::B200).unwrap(),
             "\"B200\""
         );
+        assert_eq!(
+            serde_json::to_string(&GpuCategory::B300).unwrap(),
+            "\"B300\""
+        );
     }
 
     #[test]
@@ -291,6 +302,10 @@ mod gpu_category_serde_tests {
         assert_eq!(
             serde_json::from_str::<GpuCategory>("\"B200\"").unwrap(),
             GpuCategory::B200
+        );
+        assert_eq!(
+            serde_json::from_str::<GpuCategory>("\"B300\"").unwrap(),
+            GpuCategory::B300
         );
     }
 

--- a/crates/basilica-miner/src/main.rs
+++ b/crates/basilica-miner/src/main.rs
@@ -369,6 +369,7 @@ fn minimum_usd_per_gpu(gpu_category: &GpuCategory) -> f64 {
         GpuCategory::A100 => 25.0,
         GpuCategory::H200 => 75.0,
         GpuCategory::B200 => 75.0,
+        GpuCategory::B300 => 100.0,
         GpuCategory::Other(_) => 10.0,
     }
 }


### PR DESCRIPTION
## Summary
- Add NVIDIA B300 as a supported GPU type in `GpuCategory` enum
- Include serde serialization/deserialization and `from_str` parsing for B300
- Set minimum USD/GPU price at $100 for B300 in miner collateral check
- Pin bittensor-rs to verified-clean commit

## Test plan
- [x] `cargo check` passes across full workspace
- [x] Existing B300 serde tests included in types.rs
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for the B300 GPU category with complete platform integration. The B300 is now available across all system components with pricing configuration and metadata handling capabilities. A minimum pricing threshold of $100 per GPU unit has been configured for proper resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->