### PR TITLE
feat(cli): add y/n confirmation prompt to `bs down` command

### DIFF
--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -179,8 +179,10 @@ impl Args {
                 target,
                 compute,
                 all,
+                yes,
             } => {
-                handlers::gpu_rental::handle_down(target.clone(), *compute, *all, config).await?;
+                handlers::gpu_rental::handle_down(target.clone(), *compute, *all, *yes, config)
+                    .await?;
             }
             Commands::Restart { target } => {
                 handlers::gpu_rental::handle_restart(target.clone(), config).await?;

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -106,6 +106,10 @@ pub enum Commands {
         /// Stop all active rentals
         #[arg(long, conflicts_with = "target")]
         all: bool,
+
+        /// Skip confirmation prompt
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 
     /// Restart instance container

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -2067,20 +2067,16 @@ pub async fn handle_down(
         }
 
         if !skip_confirm {
-            let confirmed = tokio::task::spawn_blocking(move || {
-                let theme = dialoguer::theme::ColorfulTheme::default();
-                Confirm::with_theme(&theme)
-                    .with_prompt(format!(
-                        "Are you sure you want to stop all {} active rental{}?",
-                        all_count,
-                        if all_count == 1 { "" } else { "s" }
-                    ))
-                    .default(false)
-                    .interact()
-            })
-            .await
-            .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
-            .map_err(|e| CliError::Internal(e.into()))?;
+            let theme = dialoguer::theme::ColorfulTheme::default();
+            let confirmed = Confirm::with_theme(&theme)
+                .with_prompt(format!(
+                    "Are you sure you want to stop all {} active rental{}?",
+                    all_count,
+                    if all_count == 1 { "" } else { "s" }
+                ))
+                .default(false)
+                .interact()
+                .map_err(|e| CliError::Internal(e.into()))?;
 
             if !confirmed {
                 println!("Cancelled.");
@@ -2215,17 +2211,12 @@ pub async fn handle_down(
             resolve_target_rental_unified(target, compute_filter, &api_client, true).await?;
 
         if !skip_confirm {
-            let confirm_id = rental_id.clone();
-            let confirmed = tokio::task::spawn_blocking(move || {
-                let theme = dialoguer::theme::ColorfulTheme::default();
-                Confirm::with_theme(&theme)
-                    .with_prompt(format!("Stop rental {}?", confirm_id))
-                    .default(false)
-                    .interact()
-            })
-            .await
-            .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
-            .map_err(|e| CliError::Internal(e.into()))?;
+            let theme = dialoguer::theme::ColorfulTheme::default();
+            let confirmed = Confirm::with_theme(&theme)
+                .with_prompt(format!("Stop rental {}?", rental_id))
+                .default(false)
+                .interact()
+                .map_err(|e| CliError::Internal(e.into()))?;
 
             if !confirmed {
                 println!("Cancelled.");

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -28,6 +28,7 @@ use basilica_sdk::ApiError;
 use color_eyre::eyre::eyre;
 use color_eyre::Section;
 use console::style;
+use dialoguer::Confirm;
 use reqwest::StatusCode;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -1994,6 +1995,7 @@ pub async fn handle_down(
     target: Option<String>,
     compute: Option<ComputeCategoryArg>,
     all: bool,
+    skip_confirm: bool,
     config: &CliConfig,
 ) -> Result<(), CliError> {
     use super::gpu_rental_helpers::resolve_target_rental_unified;
@@ -2044,6 +2046,47 @@ pub async fn handle_down(
         };
 
         complete_spinner_and_clear(spinner);
+
+        // Count total rentals to confirm
+        let all_count = community_rentals
+            .as_ref()
+            .map(|c| c.rentals.len())
+            .unwrap_or(0)
+            + secure_rentals
+                .as_ref()
+                .map(|s| s.rentals.iter().filter(|r| r.stopped_at.is_none()).count())
+                .unwrap_or(0)
+            + cpu_rentals
+                .as_ref()
+                .map(|c| c.rentals.iter().filter(|r| r.stopped_at.is_none()).count())
+                .unwrap_or(0);
+
+        if all_count == 0 {
+            println!("No active rentals found.");
+            return Ok(());
+        }
+
+        if !skip_confirm {
+            let confirmed = tokio::task::spawn_blocking(move || {
+                let theme = dialoguer::theme::ColorfulTheme::default();
+                Confirm::with_theme(&theme)
+                    .with_prompt(format!(
+                        "Are you sure you want to stop all {} active rental{}?",
+                        all_count,
+                        if all_count == 1 { "" } else { "s" }
+                    ))
+                    .default(false)
+                    .interact()
+            })
+            .await
+            .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
+            .map_err(|e| CliError::Internal(e.into()))?;
+
+            if !confirmed {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
 
         let mut total_count = 0;
         let mut success_count = 0;
@@ -2170,6 +2213,25 @@ pub async fn handle_down(
         // exclude_vip=true: VIP rentals cannot be stopped by users
         let (rental_id, compute_type) =
             resolve_target_rental_unified(target, compute_filter, &api_client, true).await?;
+
+        if !skip_confirm {
+            let confirm_id = rental_id.clone();
+            let confirmed = tokio::task::spawn_blocking(move || {
+                let theme = dialoguer::theme::ColorfulTheme::default();
+                Confirm::with_theme(&theme)
+                    .with_prompt(format!("Stop rental {}?", confirm_id))
+                    .default(false)
+                    .interact()
+            })
+            .await
+            .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
+            .map_err(|e| CliError::Internal(e.into()))?;
+
+            if !confirmed {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
 
         let spinner = create_spinner(&format!("Stopping rental: {}", rental_id));
 


### PR DESCRIPTION
## Summary

Add y/n confirmation prompt to `bs down` command to prevent accidental instance termination. Adds `--yes`/`-y` flag to skip confirmation for scripting.

## Related Issues

User (my) request from Discord — accidental double-enter on interactive selector killed a running instance.  

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

List the main changes in this PR:
  - Added `--yes`/`-y` flag to `Down` command definition
  - Added confirmation prompt before stopping a single rental: `Stop rental <id>? [y/N]`
  - Added confirmation prompt before `--all`: `Are you sure you want to stop all N active rental(s)? [y/N]`                                                                                                                                                                                                                            
  - Uses `spawn_blocking` + `dialoguer::Confirm` with `default(false)`, matching existing patterns in `volumes.rs`, `ssh_keys.rs`, and `tokens.rs` 
  
## Testing

### How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [x] Manual testing completed

### Test Configuration

- OS: `macOS Darwin 25.3.0`
- Rust version: `rustc 1.93.1 (Homebrew)`


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` to format my code
- [x] I have run `cargo clippy` and addressed all warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Context

Manual testing proof : 

https://github.com/user-attachments/assets/e2b4446e-25b7-4f29-a607-7afd82d14b96


https://github.com/user-attachments/assets/2cb9a907-bfaf-40ae-adc2-78ffae805790


https://github.com/user-attachments/assets/3f746ff5-79e4-450d-97a8-e8a649f3113f


https://github.com/user-attachments/assets/a1333862-c0f8-423a-acac-23ea70c2e1e8


https://github.com/user-attachments/assets/9f5fb3a2-23e3-495d-898b-710eed2adba8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--yes` / `-y` to the terminate instance command to skip confirmation prompts.
  * When stopping all rentals, the CLI now reports if no active rentals exist and exits early.
  * For single or all terminations, interactive confirmation is presented unless `--yes` is used; cancelling prints "Cancelled." and aborts the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->