### PR TITLE
feat(incentive): use integer cents instead of string decimals for price fields

### DIFF
--- a/crates/basilica-protocol/proto/incentive.proto
+++ b/crates/basilica-protocol/proto/incentive.proto
@@ -17,8 +17,8 @@ message GetConfigRequest {}
 message GpuCategoryConfig {
   // Number of nodes to target. Each node = 8 GPUs, so target_count=1 means 8 GPUs.
   uint32 target_count = 1;
-  // Price per individual GPU per hour in USD.
-  string price_per_gpu_usd = 2;
+  // Price per individual GPU per hour in cents.
+  uint32 price_per_gpu_cents = 2;
 }
 
 message GetConfigResponse {
@@ -43,7 +43,7 @@ message CuLedgerRow {
   bool is_rented = 7;
   string gpu_category = 8;
   uint32 window_hours = 9;
-  string price_usd = 10;
+  uint32 price_per_gpu_cents = 10;
   string idempotency_key = 11;
   bool is_slashed = 12;
   optional string slash_audit_id = 13;
@@ -89,7 +89,7 @@ message NewCuLedgerRow {
   bool is_rented = 6;
   string gpu_category = 7;
   uint32 window_hours = 8;
-  string price_usd = 9;
+  uint32 price_per_gpu_cents = 9;
   string idempotency_key = 10;
 }
 

--- a/crates/basilica-protocol/src/gen/basilica.incentive.v1.rs
+++ b/crates/basilica-protocol/src/gen/basilica.incentive.v1.rs
@@ -8,9 +8,9 @@ pub struct GpuCategoryConfig {
     /// Number of nodes to target. Each node = 8 GPUs, so target_count=1 means 8 GPUs.
     #[prost(uint32, tag = "1")]
     pub target_count: u32,
-    /// Price per individual GPU per hour in USD.
-    #[prost(string, tag = "2")]
-    pub price_per_gpu_usd: ::prost::alloc::string::String,
+    /// Price per individual GPU per hour in cents.
+    #[prost(uint32, tag = "2")]
+    pub price_per_gpu_cents: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -56,8 +56,8 @@ pub struct CuLedgerRow {
     pub gpu_category: ::prost::alloc::string::String,
     #[prost(uint32, tag = "9")]
     pub window_hours: u32,
-    #[prost(string, tag = "10")]
-    pub price_usd: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "10")]
+    pub price_per_gpu_cents: u32,
     #[prost(string, tag = "11")]
     pub idempotency_key: ::prost::alloc::string::String,
     #[prost(bool, tag = "12")]
@@ -138,8 +138,8 @@ pub struct NewCuLedgerRow {
     pub gpu_category: ::prost::alloc::string::String,
     #[prost(uint32, tag = "8")]
     pub window_hours: u32,
-    #[prost(string, tag = "9")]
-    pub price_usd: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "9")]
+    pub price_per_gpu_cents: u32,
     #[prost(string, tag = "10")]
     pub idempotency_key: ::prost::alloc::string::String,
 }

--- a/crates/basilica-protocol/src/gen/mod.rs
+++ b/crates/basilica-protocol/src/gen/mod.rs
@@ -27,6 +27,11 @@ pub mod basilica {
             include!("basilica.billing.v1.rs");
         }
     }
+    pub mod incentive {
+        pub mod v1 {
+            include!("basilica.incentive.v1.rs");
+        }
+    }
     pub mod payments {
         pub mod v1 {
             include!("basilica.payments.v1.rs");

--- a/crates/basilica-validator/src/basilica_api/mod.rs
+++ b/crates/basilica-validator/src/basilica_api/mod.rs
@@ -583,8 +583,8 @@ pub struct IncentiveGpuCategoryConfig {
     /// Number of nodes to target. Each node is assumed to have 8 GPUs,
     /// so target_count=1 means 8 GPUs.
     pub target_count: u32,
-    /// Price per individual GPU per hour in USD.
-    pub price_per_gpu_usd: Decimal,
+    /// Price per individual GPU per hour in cents.
+    pub price_per_gpu_cents: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -598,7 +598,7 @@ pub struct CuLedgerRowResponse {
     pub is_rented: bool,
     pub gpu_category: String,
     pub window_hours: u32,
-    pub price_usd: Decimal,
+    pub price_per_gpu_cents: u32,
     pub idempotency_key: String,
     pub is_slashed: bool,
     pub slash_audit_id: Option<uuid::Uuid>,
@@ -643,7 +643,7 @@ pub struct NewCuLedgerRowRequest {
     pub is_rented: bool,
     pub gpu_category: String,
     pub window_hours: u32,
-    pub price_usd: Decimal,
+    pub price_per_gpu_cents: u32,
     pub idempotency_key: String,
 }
 
@@ -889,7 +889,7 @@ mod tests {
         let json = r#"
         {
             "gpu_categories": {
-                "H100": { "target_count": 2, "price_per_gpu_usd": "3.00" }
+                "H100": { "target_count": 2, "price_per_gpu_cents": 300 }
             },
             "window_hours": 72,
             "revenue_share_pct": 30,
@@ -899,10 +899,7 @@ mod tests {
 
         let parsed: IncentiveConfigResponse = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.gpu_categories["H100"].target_count, 2);
-        assert_eq!(
-            parsed.gpu_categories["H100"].price_per_gpu_usd,
-            Decimal::from_str_exact("3.00").unwrap()
-        );
+        assert_eq!(parsed.gpu_categories["H100"].price_per_gpu_cents, 300);
         assert_eq!(parsed.window_hours, 72);
     }
 
@@ -919,7 +916,7 @@ mod tests {
             "is_rented": false,
             "gpu_category": "H100",
             "window_hours": 72,
-            "price_usd": "3.00",
+            "price_per_gpu_cents": 300,
             "idempotency_key": "node-abc:1710496800",
             "is_slashed": false,
             "slash_audit_id": "33333333-3333-3333-3333-333333333333",
@@ -994,7 +991,7 @@ mod tests {
                     "is_rented": false,
                     "gpu_category": "H100",
                     "window_hours": 72,
-                    "price_usd": "3.00",
+                    "price_per_gpu_cents": 300,
                     "idempotency_key": "node-abc:1710496800",
                     "is_slashed": false,
                     "slash_audit_id": "33333333-3333-3333-3333-333333333333",
@@ -1053,7 +1050,7 @@ mod tests {
                     "is_rented": false,
                     "gpu_category": "H100",
                     "window_hours": 72,
-                    "price_usd": "3.00",
+                    "price_per_gpu_cents": 300,
                     "idempotency_key": "node-abc:1710496800"
                 }
             ]
@@ -1186,7 +1183,7 @@ mod tests {
             .and(path("/v1/incentive/config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "gpu_categories": {
-                    "H100": { "target_count": 2, "price_per_gpu_usd": "3.00" }
+                    "H100": { "target_count": 2, "price_per_gpu_cents": 300 }
                 },
                 "window_hours": 72,
                 "revenue_share_pct": 30,
@@ -1289,7 +1286,7 @@ mod tests {
                     "is_rented": false,
                     "gpu_category": "H100",
                     "window_hours": 72,
-                    "price_usd": "3.00",
+                    "price_per_gpu_cents": 300,
                     "idempotency_key": "node-abc:1710496800",
                     "is_slashed": false,
                     "slash_audit_id": null,
@@ -1365,7 +1362,7 @@ mod tests {
                 is_rented: false,
                 gpu_category: "H100".to_string(),
                 window_hours: 72,
-                price_usd: Decimal::from_str_exact("3.00").unwrap(),
+                price_per_gpu_cents: 300,
                 idempotency_key: "node-abc:1710496800".to_string(),
             }],
         };
@@ -1385,7 +1382,7 @@ mod tests {
                     "is_rented": false,
                     "gpu_category": "H100",
                     "window_hours": 72,
-                    "price_usd": "3.00",
+                    "price_per_gpu_cents": 300,
                     "idempotency_key": "node-abc:1710496800"
                 }]
             })))

--- a/crates/basilica-validator/src/incentive/cu_generator.rs
+++ b/crates/basilica-validator/src/incentive/cu_generator.rs
@@ -344,7 +344,7 @@ pub fn generate_hourly_cu_windows(
                 is_rented: aggregate.is_rented,
                 gpu_category: metadata.gpu_category.clone(),
                 window_hours: config.window_hours,
-                price_usd: category_config.price_per_gpu_usd,
+                price_per_gpu_cents: category_config.price_per_gpu_cents,
                 idempotency_key: format!("{}:{}", aggregate.node_id_for_key, next_ms / 1000),
             });
         }
@@ -512,7 +512,7 @@ mod tests {
             "H100".to_string(),
             IncentiveGpuCategoryConfig {
                 target_count: 2,
-                price_per_gpu_usd: Decimal::from_str("3.00").unwrap(),
+                price_per_gpu_cents: 300,
             },
         );
 
@@ -1234,7 +1234,7 @@ mod tests {
 
         let cu_row = &windows[0].rows[0];
         assert_eq!(cu_row.window_hours, 72);
-        assert_eq!(cu_row.price_usd, Decimal::from_str("3.00").unwrap());
+        assert_eq!(cu_row.price_per_gpu_cents, 300);
         assert_eq!(cu_row.gpu_category, "H100");
         Ok(())
     }

--- a/crates/basilica-validator/src/incentive/incentive_pool.rs
+++ b/crates/basilica-validator/src/incentive/incentive_pool.rs
@@ -113,9 +113,10 @@ pub fn compute_incentive_pool(
         }
 
         let target_gpus = Decimal::from(category_config.target_count) * Decimal::from(8u32);
-        let row_capacity_budget = target_gpus * Decimal::from(row.window_hours) * row.price_usd;
+        let row_price_usd = cents_to_usd(row.price_per_gpu_cents);
+        let row_capacity_budget = target_gpus * Decimal::from(row.window_hours) * row_price_usd;
         let per_cu_budget = row_capacity_budget / category_supply;
-        let effective_price = min_decimal(row.price_usd, per_cu_budget);
+        let effective_price = min_decimal(row_price_usd, per_cu_budget);
         let row_payout = vested_fraction * row.cu_amount * effective_price;
         if row_payout <= Decimal::ZERO {
             continue;
@@ -461,6 +462,10 @@ fn min_decimal(left: Decimal, right: Decimal) -> Decimal {
     }
 }
 
+fn cents_to_usd(cents: u32) -> Decimal {
+    Decimal::from(cents) / Decimal::from(100u32)
+}
+
 #[derive(Debug, Clone)]
 struct WeightCandidate {
     uid: u16,
@@ -511,7 +516,7 @@ mod tests {
                 name.to_string(),
                 IncentiveGpuCategoryConfig {
                     target_count: *target_count,
-                    price_per_gpu_usd: d(price_per_gpu_usd),
+                    price_per_gpu_cents: dollars_to_cents(price_per_gpu_usd),
                 },
             );
         }
@@ -529,14 +534,14 @@ mod tests {
             "H100".to_string(),
             IncentiveGpuCategoryConfig {
                 target_count: 1,
-                price_per_gpu_usd: d("10"),
+                price_per_gpu_cents: dollars_to_cents("10"),
             },
         );
         gpu_categories.insert(
             "A100".to_string(),
             IncentiveGpuCategoryConfig {
                 target_count: 2,
-                price_per_gpu_usd: d("8"),
+                price_per_gpu_cents: dollars_to_cents("8"),
             },
         );
 
@@ -581,12 +586,17 @@ mod tests {
             is_rented: false,
             gpu_category: gpu_category.to_string(),
             window_hours,
-            price_usd: d(price_usd),
+            price_per_gpu_cents: dollars_to_cents(price_usd),
             idempotency_key: format!("{hotkey}-{node_id}"),
             is_slashed: false,
             slash_audit_id: None,
             created_at: earned_at,
         }
+    }
+
+    fn dollars_to_cents(value: &str) -> u32 {
+        let usd = Decimal::from_str(value).unwrap();
+        (usd * Decimal::from(100u32)).round().to_u32().unwrap()
     }
 
     type RuRowArgs<'a> = (


### PR DESCRIPTION
## Summary

- Converts price fields in the incentive protocol from `string` (decimal) to `uint32` (cents), eliminating string-based decimal parsing at the protocol boundary
- Renames `price_per_gpu_usd` → `price_per_gpu_cents` and `price_usd` → `price_per_gpu_cents` across proto, generated code, and validator types
- Adds `cents_to_usd()` helper in incentive pool for calculations that still need USD decimals
- Registers `basilica.incentive.v1` module in `gen/mod.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated pricing calculations to use cent-denominated integer representation instead of USD decimal values across incentive operations and protocol definitions.

* **Tests**
  * Updated test fixtures and assertions to align with new pricing format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->