### PR TITLE
fix(validator): capture time once to prevent timestamp race conditions

### DIFF
--- a/crates/basilica-validator/src/billing/converter.rs
+++ b/crates/basilica-validator/src/billing/converter.rs
@@ -33,12 +33,14 @@ pub fn resource_usage_to_telemetry(
         gpu_usage,
     };
 
+    let now = Utc::now();
+
     Ok(TelemetryData {
         rental_id,
         node_id,
         timestamp: Some(prost_types::Timestamp {
-            seconds: Utc::now().timestamp(),
-            nanos: Utc::now().timestamp_subsec_nanos() as i32,
+            seconds: now.timestamp(),
+            nanos: now.timestamp_subsec_nanos() as i32,
         }),
         resource_usage: Some(resource_usage),
         custom_metrics: std::collections::HashMap::new(),

--- a/crates/basilica-validator/src/ssh/mod.rs
+++ b/crates/basilica-validator/src/ssh/mod.rs
@@ -206,21 +206,23 @@ impl ValidatorSshClient {
             }
         };
 
+        let now = Instant::now();
+
         // Clean up expired entries if pool is getting large
         if pool.len() >= self.max_pool_size {
-            let cutoff = Instant::now() - self.pool_timeout;
+            let cutoff = now - self.pool_timeout;
             pool.retain(|_, entry| entry.last_used > cutoff);
         }
 
         let entry = pool.entry(key).or_insert_with(|| ConnectionPoolEntry {
             details: details.clone(),
-            last_used: Instant::now(),
+            last_used: now,
             connection_count: 0,
             success_count: 0,
             failure_count: 0,
         });
 
-        entry.last_used = Instant::now();
+        entry.last_used = now;
         entry.connection_count += 1;
 
         if success {


### PR DESCRIPTION
Two separate `Utc::now()` calls were used to construct a single `prost_types::Timestamp` in billing telemetry, producing timestamps up to ~1s wrong if a second boundary is crossed between calls. Also consolidated three redundant `Instant::now()` calls in SSH connection pool tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timestamp handling consistency in validator billing and SSH connection management by consolidating time reference calls within their respective functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->