### PR TITLE
feat(validator): add detailed shadow weights logging for weight verification

### DIFF
--- a/crates/basilica-validator/src/bittensor_core/weight_setter.rs
+++ b/crates/basilica-validator/src/bittensor_core/weight_setter.rs
@@ -566,8 +566,8 @@ impl WeightSetter {
             if vested <= Decimal::ZERO {
                 continue;
             }
-            let ru_usd =
-                vested * row.ru_amount * Decimal::from(row.revenue_share_pct) / Decimal::from(100u32);
+            let ru_usd = vested * row.ru_amount * Decimal::from(row.revenue_share_pct)
+                / Decimal::from(100u32);
             if ru_usd <= Decimal::ZERO {
                 continue;
             }
@@ -575,10 +575,8 @@ impl WeightSetter {
         }
 
         // Merge into Vec<ShadowMinerPayout>
-        let all_hotkeys: std::collections::HashSet<&String> = cu_accum
-            .keys()
-            .chain(ru_accum.keys())
-            .collect();
+        let all_hotkeys: std::collections::HashSet<&String> =
+            cu_accum.keys().chain(ru_accum.keys()).collect();
 
         let mut payouts: Vec<ShadowMinerPayout> = all_hotkeys
             .into_iter()


### PR DESCRIPTION
## Summary

- Expands `[SHADOW_WEIGHTS]` logging from a single summary line to 6 structured log groups: emission parameters, incentive config, pool summary, per-miner CU/RU payout breakdown, per-category weight allocation, and final weight vector
- Adds `compute_shadow_miner_breakdown` to replicate the incentive pool payout math while keeping CU (per-category) and RU (total) separate per miner
- Only touches the shadow path — no changes to `compute_incentive_pool`, `IncentivePoolResult`, or the active weight-setting flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal tracking of validator incentive-pool computations: richer payout breakdowns (per-category and per-miner), inclusion of emission parameters and payout summaries, and expanded structured shadow logging across multiple stages for better observability and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->