### PR TITLE
fix(validator): set is_validated from validation result instead of hardcoded true

### DIFF
--- a/crates/basilica-validator/src/miner_prover/verification.rs
+++ b/crates/basilica-validator/src/miner_prover/verification.rs
@@ -545,7 +545,7 @@ impl VerificationEngine {
                 node_id: node_result.node_id.to_string(),
                 is_available: success,
                 is_rented: Some(is_rented),
-                is_validated: true,
+                is_validated: success,
                 source: AvailabilitySource::Validation,
                 source_metadata: Some(format!("validation_type={:?}", node_result.validation_type)),
                 observed_at: Utc::now(),
@@ -2183,6 +2183,7 @@ mod node_profile_wiring_tests {
         );
         assert!(!history[0].is_current);
         assert!(!history[1].is_available);
+        assert!(!history[1].is_validated);
         assert!(history[1].is_current);
 
         Ok(())


### PR DESCRIPTION
`is_validated` was hardcoded to `true` when recording availability events after validation, regardless of whether the validation actually passed. A node that failed Full validation would still show `is_validated = 1` in the availability log until a later cleanup task corrected it.

Now uses the `success` variable so `is_validated` reflects the actual validation outcome. The `source` column already distinguishes validator-sourced rows from cleanup/health-check rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected availability log validation state tracking to accurately reflect individual node validation outcomes instead of defaulting to success for all validation-sourced events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->