### PR TITLE
chore(localnet): support compose override files

### DIFF
--- a/scripts/localnet/start.sh
+++ b/scripts/localnet/start.sh
@@ -48,6 +48,11 @@ show_help() {
 # Parse arguments
 PROFILE="${1:-all}"
 BUILD_FLAG=""
+COMPOSE_ARGS=()
+
+if [ -n "${MG_COMPOSE_OVERRIDE_FILE:-}" ]; then
+    COMPOSE_ARGS+=(-f "${MG_COMPOSE_OVERRIDE_FILE}")
+fi
 
 for arg in "$@"; do
     case $arg in
@@ -223,7 +228,7 @@ docker network create basilica-localnet --subnet 172.28.0.0/16 2>/dev/null && \
 # This prevents race conditions where validator starts before wallets exist
 
 echo "[1/4] Starting subtensor (network profile)..."
-docker compose --profile network up -d ${BUILD_FLAG}
+docker compose "${COMPOSE_ARGS[@]}" --profile network up -d ${BUILD_FLAG}
 
 echo ""
 echo "[2/4] Waiting for Subtensor..."
@@ -241,7 +246,7 @@ else
     echo ""
     echo "[4/4] Starting remaining services for profile: ${PROFILE}..."
 
-    docker compose --profile "${PROFILE}" up -d ${BUILD_FLAG}
+    docker compose "${COMPOSE_ARGS[@]}" --profile "${PROFILE}" up -d ${BUILD_FLAG}
 
     echo ""
     echo "Waiting for services..."
@@ -266,7 +271,7 @@ echo ""
 
 # Display running services
 echo "Running services:"
-docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | head -20
+docker compose "${COMPOSE_ARGS[@]}" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | head -20
 
 echo ""
 echo "Endpoints:"

--- a/scripts/localnet/stop.sh
+++ b/scripts/localnet/stop.sh
@@ -13,6 +13,11 @@ cd "${SCRIPT_DIR}"
 
 # Parse arguments
 CLEAN=false
+COMPOSE_ARGS=()
+
+if [ -n "${MG_COMPOSE_OVERRIDE_FILE:-}" ]; then
+    COMPOSE_ARGS+=(-f "${MG_COMPOSE_OVERRIDE_FILE}")
+fi
 
 for arg in "$@"; do
     case $arg in
@@ -47,7 +52,7 @@ echo ""
 # Stop containers (include all profiles so compose sees every service)
 if [ "$CLEAN" = true ]; then
     echo "[1/3] Stopping containers and removing volumes..."
-    docker compose --profile network --profile validator --profile miner down -v 2>/dev/null || true
+    docker compose "${COMPOSE_ARGS[@]}" --profile network --profile validator --profile miner down -v 2>/dev/null || true
 
     echo ""
     echo "[2/3] Removing orphaned volumes..."
@@ -61,7 +66,7 @@ if [ "$CLEAN" = true ]; then
     docker network rm basilica-localnet 2>/dev/null || true
 else
     echo "[1/3] Stopping containers..."
-    docker compose --profile network --profile validator --profile miner down 2>/dev/null || true
+    docker compose "${COMPOSE_ARGS[@]}" --profile network --profile validator --profile miner down 2>/dev/null || true
 
     echo ""
     echo "[2/3] Skipping volume removal (use --clean to remove)"
@@ -75,10 +80,10 @@ echo "========================================"
 echo ""
 
 # Show status
-RUNNING=$(docker compose ps -q 2>/dev/null | wc -l | tr -d ' ')
+RUNNING=$(docker compose "${COMPOSE_ARGS[@]}" ps -q 2>/dev/null | wc -l | tr -d ' ')
 if [ "$RUNNING" -gt 0 ]; then
     echo "Warning: Some containers may still be running:"
-    docker compose ps 2>/dev/null
+    docker compose "${COMPOSE_ARGS[@]}" ps 2>/dev/null
 else
     echo "All containers stopped."
 fi


### PR DESCRIPTION
Allow machine-god verification runs to inject compose override files so ephemeral localnet stacks can use isolated ports and cleanup behavior without rewriting the base scripts.

Made-with: Cursor

## Summary

Brief description of what this PR does.

## Related Issues

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

List the main changes in this PR:

- 
- 
- 

## Testing

### How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing completed

### Test Configuration

- OS: 
- Rust version: 
- Bittensor version (if applicable): 

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format my code
- [ ] I have run `cargo clippy` and addressed all warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Context

Add any other context about the PR here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local network setup and teardown scripts to support custom Docker Compose configuration via environment variable overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->