### PR TITLE
[cross-repo] Implement Basilica Compute Sandboxes (backend + frontend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "tabled",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "toml",
  "tracing",
  "url",
@@ -6496,6 +6497,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -6587,6 +6602,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -8737,6 +8763,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
@@ -8754,6 +8791,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9127,6 +9180,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9304,6 +9378,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -9606,6 +9686,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 clap-verbosity-flag = "2.2"
 futures = "0.3"
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 # MUSL COMPATIBILITY: Disable default features (includes native-tls) and use rustls-tls only
 reqwest = { version = "0.11", default-features = false, features = [
   "json",

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -30,6 +30,7 @@ semver = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
+tokio-tungstenite = { workspace = true }
 eventsource-stream = { workspace = true }
 
 # Terminal UI and interaction

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -75,4 +75,7 @@ basilica-common = { path = "../basilica-common" }
 basilica-sdk = { path = "../basilica-sdk" }
 basilica-validator = { path = "../basilica-validator", features = ["client", "cli"] }
 
+[features]
+sandbox = []
+
 [dev-dependencies]

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -336,7 +336,8 @@ impl Args {
                 }
             }
 
-            // Sandbox management
+            // Sandbox management (behind feature flag until backend readiness confirmed)
+            #[cfg(feature = "sandbox")]
             Commands::Sandbox { action } => {
                 use crate::cli::commands::SandboxAction;
                 use crate::client::create_client;

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -336,6 +336,54 @@ impl Args {
                 }
             }
 
+            // Sandbox management
+            Commands::Sandbox { action } => {
+                use crate::cli::commands::SandboxAction;
+                use crate::client::create_client;
+
+                let client = create_client(config).await?;
+
+                match action {
+                    SandboxAction::Create {
+                        image,
+                        cpu,
+                        memory,
+                        ttl,
+                        env,
+                    } => {
+                        handlers::sandbox::handle_create(
+                            &client,
+                            image.clone(),
+                            cpu.clone(),
+                            memory.clone(),
+                            *ttl,
+                            env.clone(),
+                            self.json,
+                        )
+                        .await?;
+                    }
+                    SandboxAction::Ls => {
+                        handlers::sandbox::handle_list(&client, self.json).await?;
+                    }
+                    SandboxAction::Status { id } => {
+                        handlers::sandbox::handle_status(&client, id, self.json).await?;
+                    }
+                    SandboxAction::Delete { id, yes } => {
+                        handlers::sandbox::handle_delete(&client, id, *yes, self.json).await?;
+                    }
+                    SandboxAction::Connect { id, secret, exec } => {
+                        handlers::sandbox::handle_connect(
+                            &client,
+                            id,
+                            secret.clone(),
+                            exec.clone(),
+                            self.json,
+                        )
+                        .await?;
+                    }
+                }
+            }
+
             // Upgrade command is handled in main.rs before entering async runtime
             Commands::Upgrade { .. } => {
                 unreachable!("Upgrade command should be handled in main.rs")

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -206,6 +206,7 @@ pub enum Commands {
     },
 
     /// Compute sandbox management (ephemeral Linux environments)
+    #[cfg(feature = "sandbox")]
     #[command(name = "sandbox", visible_alias = "sb")]
     Sandbox {
         #[command(subcommand)]
@@ -339,6 +340,7 @@ pub enum VolumeAction {
 }
 
 /// Sandbox management actions
+#[cfg(feature = "sandbox")]
 #[derive(Subcommand, Debug, Clone)]
 pub enum SandboxAction {
     /// Create a new compute sandbox
@@ -418,9 +420,11 @@ impl Commands {
             | Commands::Tokens { .. }
             | Commands::SshKeys { .. }
             | Commands::Volumes { .. }
-            | Commands::Sandbox { .. }
             | Commands::Fund { .. }
             | Commands::Balance => true,
+
+            #[cfg(feature = "sandbox")]
+            Commands::Sandbox { .. } => true,
 
             // Deploy commands: most require auth, except Metadata (public endpoint)
             Commands::Deploy(cmd) => !matches!(cmd.action, Some(DeployAction::Metadata { .. })),

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -204,6 +204,13 @@ pub enum Commands {
         #[command(subcommand)]
         action: VolumeAction,
     },
+
+    /// Compute sandbox management (ephemeral Linux environments)
+    #[command(name = "sandbox", visible_alias = "sb")]
+    Sandbox {
+        #[command(subcommand)]
+        action: SandboxAction,
+    },
 }
 
 /// Fund management actions
@@ -331,6 +338,68 @@ pub enum VolumeAction {
     },
 }
 
+/// Sandbox management actions
+#[derive(Subcommand, Debug, Clone)]
+pub enum SandboxAction {
+    /// Create a new compute sandbox
+    Create {
+        /// Container image (default: python:3.11)
+        #[arg(long)]
+        image: Option<String>,
+
+        /// CPU cores (default: "2")
+        #[arg(long, default_value = "2")]
+        cpu: String,
+
+        /// Memory allocation (default: "4Gi")
+        #[arg(long, default_value = "4Gi")]
+        memory: String,
+
+        /// Time-to-live in seconds (60-7200, default: 1800)
+        #[arg(long, default_value = "1800")]
+        ttl: u32,
+
+        /// Environment variables (KEY=VALUE)
+        #[arg(short, long, value_name = "KEY=VALUE")]
+        env: Vec<String>,
+    },
+
+    /// List active sandboxes
+    #[command(alias = "list")]
+    Ls,
+
+    /// Get sandbox status
+    Status {
+        /// Sandbox ID
+        id: String,
+    },
+
+    /// Delete a sandbox
+    #[command(alias = "rm")]
+    Delete {
+        /// Sandbox ID
+        id: String,
+
+        /// Skip confirmation
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+
+    /// Connect to a running sandbox via WebSocket
+    Connect {
+        /// Sandbox ID
+        id: String,
+
+        /// exec-agent secret (from create response). Prompted if not provided.
+        #[arg(long)]
+        secret: Option<String>,
+
+        /// Execute a single command and exit (non-interactive)
+        #[arg(long)]
+        exec: Option<String>,
+    },
+}
+
 impl Commands {
     /// Check if this command requires authentication
     pub fn requires_auth(&self) -> bool {
@@ -349,6 +418,7 @@ impl Commands {
             | Commands::Tokens { .. }
             | Commands::SshKeys { .. }
             | Commands::Volumes { .. }
+            | Commands::Sandbox { .. }
             | Commands::Fund { .. }
             | Commands::Balance => true,
 

--- a/crates/basilica-cli/src/cli/handlers/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/mod.rs
@@ -12,5 +12,6 @@ pub mod ssh_keys;
 pub mod test_auth;
 pub mod tokens;
 pub mod upgrade;
+#[cfg(feature = "sandbox")]
 pub mod sandbox;
 pub mod volumes;

--- a/crates/basilica-cli/src/cli/handlers/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/mod.rs
@@ -12,4 +12,5 @@ pub mod ssh_keys;
 pub mod test_auth;
 pub mod tokens;
 pub mod upgrade;
+pub mod sandbox;
 pub mod volumes;

--- a/crates/basilica-cli/src/cli/handlers/sandbox.rs
+++ b/crates/basilica-cli/src/cli/handlers/sandbox.rs
@@ -990,7 +990,7 @@ mod tests {
             }]),
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("\"ttl_seconds\":1800"));
+        assert!(json.contains("\"ttlSeconds\":1800"));
         assert!(json.contains("\"cpu\":\"2\""));
 
         // Minimal request with None fields — they should be omitted
@@ -1009,9 +1009,9 @@ mod tests {
     #[test]
     fn test_create_sandbox_response_deserialization() {
         let json = r#"{
-            "sandbox_id": "ab12cd34",
+            "sandboxId": "ab12cd34",
             "domain": "sb-ab12cd34.sandboxes.basilica.ai",
-            "exec_secret": "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+            "execSecret": "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
             "status": {
                 "phase": "Pending",
                 "conditions": []
@@ -1029,11 +1029,11 @@ mod tests {
         let json = r#"{
             "sandboxes": [
                 {
-                    "sandbox_id": "ab12cd34",
+                    "sandboxId": "ab12cd34",
                     "domain": "sb-ab12cd34.sandboxes.basilica.ai",
                     "status": {
                         "phase": "Running",
-                        "started_at": "2026-04-06T12:00:00Z",
+                        "startedAt": "2026-04-06T12:00:00Z",
                         "conditions": [
                             {"type": "Ready", "status": "True"}
                         ]
@@ -1147,7 +1147,7 @@ mod tests {
     #[test]
     fn test_sandbox_response_without_started_at() {
         let json = r#"{
-            "sandbox_id": "ab12cd34",
+            "sandboxId": "ab12cd34",
             "domain": "sb-ab12cd34.sandboxes.basilica.ai",
             "status": {
                 "phase": "Pending",
@@ -1162,13 +1162,13 @@ mod tests {
     #[test]
     fn test_sandbox_condition_deserialization() {
         let json = r#"{
-            "sandbox_id": "ab12cd34",
+            "sandboxId": "ab12cd34",
             "domain": "sb-ab12cd34.sandboxes.basilica.ai",
             "status": {
                 "phase": "Running",
-                "started_at": "2026-04-06T12:00:00Z",
+                "startedAt": "2026-04-06T12:00:00Z",
                 "conditions": [
-                    {"type": "Ready", "status": "True", "last_transition_time": "2026-04-06T12:00:01Z"},
+                    {"type": "Ready", "status": "True", "lastTransitionTime": "2026-04-06T12:00:01Z"},
                     {"type": "PodScheduled", "status": "True"}
                 ]
             }
@@ -1246,9 +1246,9 @@ mod tests {
 
     #[test]
     fn test_exec_secret_not_in_get_response() {
-        // GET /v1/sandboxes/{id} response does NOT contain exec_secret
+        // GET /v1/sandboxes/{id} response does NOT contain execSecret
         let json = r#"{
-            "sandbox_id": "ab12cd34",
+            "sandboxId": "ab12cd34",
             "domain": "sb-ab12cd34.sandboxes.basilica.ai",
             "status": {"phase": "Running", "conditions": []}
         }"#;

--- a/crates/basilica-cli/src/cli/handlers/sandbox.rs
+++ b/crates/basilica-cli/src/cli/handlers/sandbox.rs
@@ -1,0 +1,1035 @@
+//! Sandbox management handlers for the Basilica CLI
+//!
+//! Implements create, list, status, delete, and WebSocket connect flows
+//! for ephemeral compute sandboxes.
+
+use crate::error::CliError;
+use crate::output::{json_output, print_info, print_success, print_warning};
+use crate::progress::{complete_spinner_and_clear, complete_spinner_error, create_spinner};
+use basilica_sdk::types::{
+    CreateSandboxRequest, CreateSandboxResponse, SandboxEnvVar, SandboxListResponse, SandboxPhase,
+    SandboxResponse, SandboxWsRequest, SandboxWsResponse,
+};
+use basilica_sdk::BasilicaClient;
+use color_eyre::eyre::eyre;
+use console::style;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Confirm;
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite;
+
+/// Maximum number of status poll attempts before giving up
+const MAX_POLL_ATTEMPTS: u32 = 120;
+
+/// Interval between status polls in milliseconds
+const POLL_INTERVAL_MS: u64 = 500;
+
+/// Handle sandbox create command
+pub async fn handle_create(
+    client: &BasilicaClient,
+    image: Option<String>,
+    cpu: String,
+    memory: String,
+    ttl: u32,
+    env: Vec<String>,
+    json: bool,
+) -> Result<(), CliError> {
+    // Validate TTL
+    if ttl < 60 || ttl > 7200 {
+        return Err(CliError::Internal(
+            eyre!("TTL must be between 60 and 7200 seconds (got {})", ttl)
+                .into(),
+        ));
+    }
+
+    // Parse env vars
+    let env_vars = if env.is_empty() {
+        None
+    } else {
+        let parsed: Result<Vec<SandboxEnvVar>, _> = env
+            .iter()
+            .map(|e| {
+                let parts: Vec<&str> = e.splitn(2, '=').collect();
+                if parts.len() != 2 {
+                    Err(eyre!("Invalid env var format '{}'. Expected KEY=VALUE", e))
+                } else {
+                    Ok(SandboxEnvVar {
+                        name: parts[0].to_string(),
+                        value: parts[1].to_string(),
+                    })
+                }
+            })
+            .collect();
+        Some(parsed.map_err(CliError::Internal)?)
+    };
+
+    let request = CreateSandboxRequest {
+        image,
+        cpu: Some(cpu),
+        memory: Some(memory),
+        ttl_seconds: Some(ttl),
+        env: env_vars,
+    };
+
+    let spinner = create_spinner("Creating sandbox...");
+    let response: CreateSandboxResponse = client.create_sandbox(request).await.map_err(|e| {
+        complete_spinner_error(spinner.clone(), "Failed to create sandbox");
+        match &e {
+            basilica_sdk::ApiError::ApiResponse { status, message } if *status == 402 => {
+                CliError::Internal(
+                    eyre!("Insufficient balance: {}", message)
+                        .wrap_err("Top up your account with: basilica fund"),
+                )
+            }
+            _ => CliError::Api(e),
+        }
+    })?;
+    complete_spinner_and_clear(spinner);
+
+    if json {
+        json_output(&response)?;
+        return Ok(());
+    }
+
+    print_success(&format!("Sandbox {} created", style(&response.sandbox_id).cyan()));
+    println!(
+        "  {}: {}",
+        style("Domain").dim(),
+        style(&response.domain).green()
+    );
+    println!(
+        "  {}: {}",
+        style("Phase").dim(),
+        format_phase(&response.status.phase)
+    );
+    println!();
+    println!(
+        "  {}: {}",
+        style("Exec Secret").dim(),
+        style(&response.exec_secret).yellow()
+    );
+    println!();
+    print_warning("Save the exec secret now. It will not be shown again.");
+    print_info("This is a bearer credential. Do not persist or share it.");
+    println!();
+    println!(
+        "Connect with: {}",
+        style(format!(
+            "basilica sandbox connect {} --secret <exec_secret>",
+            response.sandbox_id
+        ))
+        .cyan()
+    );
+    println!();
+    print_sandbox_help_text();
+
+    Ok(())
+}
+
+/// Handle sandbox list command
+pub async fn handle_list(client: &BasilicaClient, json: bool) -> Result<(), CliError> {
+    let spinner = create_spinner("Fetching sandboxes...");
+    let response: SandboxListResponse = client.list_sandboxes().await.map_err(|e| {
+        complete_spinner_error(spinner.clone(), "Failed to list sandboxes");
+        CliError::Api(e)
+    })?;
+    complete_spinner_and_clear(spinner);
+
+    if json {
+        json_output(&response)?;
+        return Ok(());
+    }
+
+    if response.sandboxes.is_empty() {
+        println!("No active sandboxes.");
+        println!();
+        println!(
+            "Create one with: {}",
+            style("basilica sandbox create").cyan()
+        );
+        return Ok(());
+    }
+
+    println!("{}", style("Active Sandboxes").bold());
+    println!(
+        "  {:<12} {:<40} {:<12} {}",
+        style("ID").dim(),
+        style("Domain").dim(),
+        style("Phase").dim(),
+        style("Started").dim(),
+    );
+
+    for sb in &response.sandboxes {
+        let started = sb
+            .status
+            .started_at
+            .as_deref()
+            .unwrap_or("-");
+        println!(
+            "  {:<12} {:<40} {:<12} {}",
+            style(&sb.sandbox_id).cyan(),
+            &sb.domain,
+            format_phase(&sb.status.phase),
+            started,
+        );
+    }
+
+    println!();
+    println!("Total: {}", response.sandboxes.len());
+
+    Ok(())
+}
+
+/// Handle sandbox status command
+pub async fn handle_status(
+    client: &BasilicaClient,
+    sandbox_id: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let spinner = create_spinner(&format!("Fetching sandbox {}...", sandbox_id));
+    let response: SandboxResponse = client.get_sandbox(sandbox_id).await.map_err(|e| {
+        complete_spinner_error(spinner.clone(), "Failed to get sandbox");
+        CliError::Api(e)
+    })?;
+    complete_spinner_and_clear(spinner);
+
+    if json {
+        json_output(&response)?;
+        return Ok(());
+    }
+
+    println!("{}", style("Sandbox Status").bold());
+    println!("  {}: {}", style("ID").dim(), style(&response.sandbox_id).cyan());
+    println!("  {}: {}", style("Domain").dim(), &response.domain);
+    println!(
+        "  {}: {}",
+        style("Phase").dim(),
+        format_phase(&response.status.phase)
+    );
+    if let Some(started) = &response.status.started_at {
+        println!("  {}: {}", style("Started").dim(), started);
+    }
+    for cond in &response.status.conditions {
+        println!(
+            "  {}: {} = {}",
+            style("Condition").dim(),
+            cond.condition_type,
+            cond.status
+        );
+    }
+
+    Ok(())
+}
+
+/// Handle sandbox delete command
+pub async fn handle_delete(
+    client: &BasilicaClient,
+    sandbox_id: &str,
+    skip_confirm: bool,
+    json: bool,
+) -> Result<(), CliError> {
+    if !skip_confirm {
+        let id_owned = sandbox_id.to_string();
+        let confirmed = tokio::task::spawn_blocking(move || {
+            let theme = ColorfulTheme::default();
+            Confirm::with_theme(&theme)
+                .with_prompt(format!("Delete sandbox '{}'?", id_owned))
+                .default(false)
+                .interact()
+        })
+        .await
+        .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
+        .map_err(|e| CliError::Internal(e.into()))?;
+
+        if !confirmed {
+            println!("Deletion cancelled.");
+            return Ok(());
+        }
+    }
+
+    let spinner = create_spinner(&format!("Deleting sandbox {}...", sandbox_id));
+    client.delete_sandbox(sandbox_id).await.map_err(|e| {
+        complete_spinner_error(spinner.clone(), "Failed to delete sandbox");
+        CliError::Api(e)
+    })?;
+    complete_spinner_and_clear(spinner);
+
+    if json {
+        json_output(&serde_json::json!({
+            "success": true,
+            "sandbox_id": sandbox_id,
+        }))?;
+        return Ok(());
+    }
+
+    print_success(&format!("Sandbox {} deleted", sandbox_id));
+
+    Ok(())
+}
+
+/// Handle sandbox connect command — WebSocket session to exec-agent
+pub async fn handle_connect(
+    client: &BasilicaClient,
+    sandbox_id: &str,
+    exec_secret: Option<String>,
+    exec_cmd: Option<String>,
+    json: bool,
+) -> Result<(), CliError> {
+    // Get sandbox status to obtain domain
+    let spinner = create_spinner(&format!("Resolving sandbox {}...", sandbox_id));
+    let sandbox: SandboxResponse = client.get_sandbox(sandbox_id).await.map_err(|e| {
+        complete_spinner_error(spinner.clone(), "Failed to get sandbox");
+        CliError::Api(e)
+    })?;
+    complete_spinner_and_clear(spinner);
+
+    // If not yet running, poll until ready
+    let domain = if sandbox.status.phase == SandboxPhase::Pending {
+        poll_until_running(client, sandbox_id).await?
+    } else if sandbox.status.phase == SandboxPhase::Running {
+        sandbox.domain.clone()
+    } else {
+        return Err(CliError::Internal(eyre!(
+            "Sandbox {} is in phase '{}'. Cannot connect.",
+            sandbox_id,
+            sandbox.status.phase
+        )));
+    };
+
+    // Prompt for secret if not provided
+    let secret = match exec_secret {
+        Some(s) => s,
+        None => {
+            let s = tokio::task::spawn_blocking(|| {
+                dialoguer::Password::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Exec secret")
+                    .interact()
+            })
+            .await
+            .map_err(|e| CliError::Internal(eyre!("Task join error: {}", e)))?
+            .map_err(|e| CliError::Internal(e.into()))?;
+            s
+        }
+    };
+
+    if let Some(cmd) = exec_cmd {
+        // Non-interactive: execute single command
+        return exec_single_command(&domain, &secret, &cmd, json).await;
+    }
+
+    // Interactive REPL loop
+    interactive_session(&domain, &secret).await
+}
+
+/// Poll sandbox status until Running or failure
+async fn poll_until_running(client: &BasilicaClient, sandbox_id: &str) -> Result<String, CliError> {
+    let spinner = create_spinner("Waiting for sandbox to start...");
+    for _ in 0..MAX_POLL_ATTEMPTS {
+        tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;
+        match client.get_sandbox(sandbox_id).await {
+            Ok(sb) => match sb.status.phase {
+                SandboxPhase::Running => {
+                    complete_spinner_and_clear(spinner);
+                    print_success("Sandbox is running");
+                    return Ok(sb.domain);
+                }
+                SandboxPhase::Failed => {
+                    complete_spinner_and_clear(spinner);
+                    return Err(CliError::Internal(eyre!(
+                        "Sandbox {} failed to start",
+                        sandbox_id
+                    )));
+                }
+                SandboxPhase::Terminating => {
+                    complete_spinner_and_clear(spinner);
+                    return Err(CliError::Internal(eyre!(
+                        "Sandbox {} is terminating",
+                        sandbox_id
+                    )));
+                }
+                SandboxPhase::Pending => continue,
+            },
+            Err(e) => {
+                // Transient errors during polling are tolerable
+                tracing::debug!("Poll error: {}", e);
+                continue;
+            }
+        }
+    }
+    complete_spinner_and_clear(spinner);
+    Err(CliError::Internal(eyre!(
+        "Timed out waiting for sandbox {} to start ({}s)",
+        sandbox_id,
+        MAX_POLL_ATTEMPTS as u64 * POLL_INTERVAL_MS / 1000
+    )))
+}
+
+/// Execute a single command on a sandbox via WebSocket
+async fn exec_single_command(
+    domain: &str,
+    secret: &str,
+    command: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let (mut ws, _) = connect_ws(domain, secret).await?;
+
+    let op_id = uuid::Uuid::new_v4().to_string();
+    let request = SandboxWsRequest {
+        id: op_id.clone(),
+        op: "exec".to_string(),
+        args: Some(serde_json::json!({
+            "command": command.split_whitespace().collect::<Vec<&str>>()
+        })),
+    };
+
+    let msg = serde_json::to_string(&request)
+        .map_err(|e| CliError::Internal(eyre!("Failed to serialize request: {}", e)))?;
+
+    ws.send(tungstenite::Message::Text(msg))
+        .await
+        .map_err(|e| CliError::Internal(eyre!("WebSocket send error: {}", e)))?;
+
+    let mut exit_code: Option<i32> = None;
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+
+    // Read frames until we get an exit or error for this op
+    while let Some(frame) = ws.next().await {
+        let frame = frame.map_err(|e| CliError::Internal(eyre!("WebSocket read error: {}", e)))?;
+
+        match frame {
+            tungstenite::Message::Text(text) => {
+                let resp: SandboxWsResponse = serde_json::from_str(&text)
+                    .map_err(|e| CliError::Internal(eyre!("Invalid response frame: {}", e)))?;
+
+                if resp.id != op_id {
+                    continue;
+                }
+
+                match resp.response_type.as_str() {
+                    "stdout" => {
+                        if let Some(data) = &resp.data {
+                            let s = data.as_str().unwrap_or("");
+                            if json {
+                                stdout_buf.push_str(s);
+                            } else {
+                                print!("{}", s);
+                            }
+                        }
+                    }
+                    "stderr" => {
+                        if let Some(data) = &resp.data {
+                            let s = data.as_str().unwrap_or("");
+                            if json {
+                                stderr_buf.push_str(s);
+                            } else {
+                                eprint!("{}", s);
+                            }
+                        }
+                    }
+                    "exit" => {
+                        exit_code = resp.code;
+                        break;
+                    }
+                    "error" => {
+                        let msg = resp.error.unwrap_or_else(|| "Unknown error".to_string());
+                        let code = resp.error_code.unwrap_or_default();
+                        return Err(CliError::Internal(eyre!(
+                            "exec-agent error [{}]: {}",
+                            code,
+                            msg
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+            tungstenite::Message::Close(_) => break,
+            _ => {}
+        }
+    }
+
+    // Close WebSocket
+    let _ = ws.close(None).await;
+
+    if json {
+        json_output(&serde_json::json!({
+            "stdout": stdout_buf,
+            "stderr": stderr_buf,
+            "exit_code": exit_code,
+        }))?;
+    }
+
+    if let Some(code) = exit_code {
+        if code != 0 {
+            std::process::exit(code);
+        }
+    }
+
+    Ok(())
+}
+
+/// Interactive sandbox session — read commands, send exec ops, display output
+async fn interactive_session(domain: &str, secret: &str) -> Result<(), CliError> {
+    let (mut ws, _) = connect_ws(domain, secret).await?;
+
+    println!(
+        "{} Connected to {}",
+        style("●").green(),
+        style(domain).cyan()
+    );
+    println!(
+        "{}",
+        style("Type commands to execute. Ctrl+C or 'exit' to disconnect.").dim()
+    );
+    println!(
+        "{}",
+        style("File ops: :read <path>, :write <path> <content>, :ls <path>, :stat <path>").dim()
+    );
+    println!();
+
+    let stdin = tokio::io::stdin();
+    let reader = tokio::io::BufReader::new(stdin);
+    let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
+
+    loop {
+        // Print prompt
+        eprint!("{} ", style("sandbox>").green().bold());
+
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => break, // EOF
+            Err(_) => break,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed == "exit" || trimmed == "quit" {
+            break;
+        }
+
+        // Check for file op shortcuts
+        let (op, args) = parse_interactive_command(trimmed);
+
+        let op_id = uuid::Uuid::new_v4().to_string();
+        let request = SandboxWsRequest {
+            id: op_id.clone(),
+            op,
+            args: Some(args),
+        };
+
+        let msg = serde_json::to_string(&request)
+            .map_err(|e| CliError::Internal(eyre!("Failed to serialize: {}", e)))?;
+
+        if ws.send(tungstenite::Message::Text(msg)).await.is_err() {
+            eprintln!("{} Connection lost. Attempting reconnect...", style("●").red());
+            match connect_ws(domain, secret).await {
+                Ok((new_ws, _)) => {
+                    ws = new_ws;
+                    println!("{} Reconnected", style("●").green());
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("Reconnect failed: {}", e);
+                    eprintln!("Create a new sandbox with: basilica sandbox create");
+                    return Err(e);
+                }
+            }
+        }
+
+        // Read response frames for this op
+        let done = read_op_response(&mut ws, &op_id).await?;
+        if done {
+            break;
+        }
+    }
+
+    let _ = ws.close(None).await;
+    println!("Disconnected.");
+    Ok(())
+}
+
+/// Parse interactive command into (op, args) pair
+fn parse_interactive_command(input: &str) -> (String, serde_json::Value) {
+    if let Some(rest) = input.strip_prefix(":read ") {
+        return (
+            "read_file".to_string(),
+            serde_json::json!({ "path": rest.trim() }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":write ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 {
+            return (
+                "write_file".to_string(),
+                serde_json::json!({ "path": parts[0], "content": parts[1] }),
+            );
+        }
+        return (
+            "write_file".to_string(),
+            serde_json::json!({ "path": rest.trim(), "content": "" }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":ls") {
+        let path = rest.trim();
+        let path = if path.is_empty() { "." } else { path };
+        return (
+            "list_dir".to_string(),
+            serde_json::json!({ "path": path }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":stat ") {
+        return (
+            "stat".to_string(),
+            serde_json::json!({ "path": rest.trim() }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":mkdir ") {
+        return (
+            "mkdir".to_string(),
+            serde_json::json!({ "path": rest.trim() }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":rm ") {
+        return (
+            "remove".to_string(),
+            serde_json::json!({ "path": rest.trim() }),
+        );
+    }
+    if let Some(rest) = input.strip_prefix(":upload ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 {
+            return (
+                "upload_r2".to_string(),
+                serde_json::json!({ "local_path": parts[0], "key": parts[1] }),
+            );
+        }
+    }
+    if let Some(rest) = input.strip_prefix(":download ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 {
+            return (
+                "download_r2".to_string(),
+                serde_json::json!({ "key": parts[0], "local_path": parts[1] }),
+            );
+        }
+    }
+
+    // Default: exec command
+    (
+        "exec".to_string(),
+        serde_json::json!({ "command": input.split_whitespace().collect::<Vec<&str>>() }),
+    )
+}
+
+/// Read all response frames for a given op ID. Returns true if connection closed.
+async fn read_op_response(
+    ws: &mut WsStream,
+    op_id: &str,
+) -> Result<bool, CliError> {
+    loop {
+        let frame = match tokio::time::timeout(Duration::from_secs(30), ws.next()).await {
+            Ok(Some(Ok(frame))) => frame,
+            Ok(Some(Err(e))) => {
+                return Err(CliError::Internal(eyre!("WebSocket error: {}", e)));
+            }
+            Ok(None) => return Ok(true), // stream ended
+            Err(_) => {
+                // Timeout — for exec ops this is fine, just means long-running command
+                continue;
+            }
+        };
+
+        match frame {
+            tungstenite::Message::Text(text) => {
+                let resp: SandboxWsResponse = match serde_json::from_str(&text) {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+
+                if resp.id != op_id {
+                    continue;
+                }
+
+                match resp.response_type.as_str() {
+                    "stdout" => {
+                        if let Some(data) = &resp.data {
+                            print!("{}", data.as_str().unwrap_or(""));
+                        }
+                    }
+                    "stderr" => {
+                        if let Some(data) = &resp.data {
+                            eprint!("{}", data.as_str().unwrap_or(""));
+                        }
+                    }
+                    "exit" => {
+                        if let Some(code) = resp.code {
+                            if code != 0 {
+                                eprintln!(
+                                    "{}",
+                                    style(format!("(exit code: {})", code)).dim()
+                                );
+                            }
+                        }
+                        return Ok(false);
+                    }
+                    "ok" => return Ok(false),
+                    "file" => {
+                        if let Some(data) = &resp.data {
+                            println!("{}", serde_json::to_string_pretty(data).unwrap_or_default());
+                        }
+                        return Ok(false);
+                    }
+                    "stat" => {
+                        if let Some(data) = &resp.data {
+                            println!("{}", serde_json::to_string_pretty(data).unwrap_or_default());
+                        }
+                        return Ok(false);
+                    }
+                    "dir" => {
+                        if let Some(data) = &resp.data {
+                            if let Some(entries) = data.as_array() {
+                                for entry in entries {
+                                    println!("{}", entry.as_str().unwrap_or(""));
+                                }
+                            } else {
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(data).unwrap_or_default()
+                                );
+                            }
+                        }
+                        return Ok(false);
+                    }
+                    "pong" => return Ok(false),
+                    "error" => {
+                        let msg = resp.error.unwrap_or_else(|| "Unknown error".to_string());
+                        let code = resp.error_code.unwrap_or_default();
+                        eprintln!(
+                            "{} [{}] {}",
+                            style("error").red().bold(),
+                            code,
+                            msg
+                        );
+                        return Ok(false);
+                    }
+                    other => {
+                        eprintln!("{}: {}", style("unknown response type").dim(), other);
+                        return Ok(false);
+                    }
+                }
+            }
+            tungstenite::Message::Close(_) => return Ok(true),
+            tungstenite::Message::Ping(data) => {
+                let _ = ws.send(tungstenite::Message::Pong(data)).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// WebSocket stream type alias for exec-agent connections
+type WsStream = tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+>;
+
+/// Connect to exec-agent WebSocket endpoint
+async fn connect_ws(
+    domain: &str,
+    secret: &str,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        tungstenite::http::Response<Option<Vec<u8>>>,
+    ),
+    CliError,
+> {
+    let url = format!("wss://{}/ws", domain);
+
+    let request = tungstenite::http::Request::builder()
+        .uri(&url)
+        .header("X-Exec-Secret", secret)
+        .header("Host", domain)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header(
+            "Sec-WebSocket-Key",
+            tungstenite::handshake::client::generate_key(),
+        )
+        .body(())
+        .map_err(|e| CliError::Internal(eyre!("Failed to build WS request: {}", e)))?;
+
+    tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|e| {
+            CliError::Internal(eyre!(
+                "WebSocket connection to {} failed: {}.\n\
+                 If the sandbox pod is gone, create a new one with: basilica sandbox create",
+                domain,
+                e
+            ))
+        })
+}
+
+/// Format sandbox phase with color
+fn format_phase(phase: &SandboxPhase) -> String {
+    match phase {
+        SandboxPhase::Pending => style("Pending").yellow().to_string(),
+        SandboxPhase::Running => style("Running").green().to_string(),
+        SandboxPhase::Terminating => style("Terminating").red().to_string(),
+        SandboxPhase::Failed => style("Failed").red().bold().to_string(),
+    }
+}
+
+/// Print help text about sandbox lifecycle
+fn print_sandbox_help_text() {
+    println!("{}", style("Sandbox Info:").bold().dim());
+    println!(
+        "  {} Sandboxes auto-terminate after the configured TTL (default: 30 min, max: 2 hrs).",
+        style("·").dim()
+    );
+    println!(
+        "  {} Idle sandboxes are terminated after 120s of no WebSocket activity.",
+        style("·").dim()
+    );
+    println!(
+        "  {} Files are ephemeral — stored on the container filesystem only.",
+        style("·").dim()
+    );
+    println!(
+        "  {} Use :upload / :download in a session to persist files to R2 object storage.",
+        style("·").dim()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_exec_command() {
+        let (op, args) = parse_interactive_command("echo hello world");
+        assert_eq!(op, "exec");
+        assert_eq!(
+            args,
+            serde_json::json!({"command": ["echo", "hello", "world"]})
+        );
+    }
+
+    #[test]
+    fn test_parse_read_file() {
+        let (op, args) = parse_interactive_command(":read /workspace/main.py");
+        assert_eq!(op, "read_file");
+        assert_eq!(args, serde_json::json!({"path": "/workspace/main.py"}));
+    }
+
+    #[test]
+    fn test_parse_write_file() {
+        let (op, args) = parse_interactive_command(":write /tmp/test.txt hello world");
+        assert_eq!(op, "write_file");
+        assert_eq!(
+            args,
+            serde_json::json!({"path": "/tmp/test.txt", "content": "hello world"})
+        );
+    }
+
+    #[test]
+    fn test_parse_list_dir_default() {
+        let (op, args) = parse_interactive_command(":ls");
+        assert_eq!(op, "list_dir");
+        assert_eq!(args, serde_json::json!({"path": "."}));
+    }
+
+    #[test]
+    fn test_parse_list_dir_path() {
+        let (op, args) = parse_interactive_command(":ls /workspace");
+        assert_eq!(op, "list_dir");
+        assert_eq!(args, serde_json::json!({"path": "/workspace"}));
+    }
+
+    #[test]
+    fn test_parse_stat() {
+        let (op, args) = parse_interactive_command(":stat /workspace/file.py");
+        assert_eq!(op, "stat");
+        assert_eq!(args, serde_json::json!({"path": "/workspace/file.py"}));
+    }
+
+    #[test]
+    fn test_parse_mkdir() {
+        let (op, args) = parse_interactive_command(":mkdir /workspace/subdir");
+        assert_eq!(op, "mkdir");
+        assert_eq!(args, serde_json::json!({"path": "/workspace/subdir"}));
+    }
+
+    #[test]
+    fn test_parse_rm() {
+        let (op, args) = parse_interactive_command(":rm /tmp/junk");
+        assert_eq!(op, "remove");
+        assert_eq!(args, serde_json::json!({"path": "/tmp/junk"}));
+    }
+
+    #[test]
+    fn test_parse_upload_r2() {
+        let (op, args) = parse_interactive_command(":upload /local/file.tar.gz models/v1.tar.gz");
+        assert_eq!(op, "upload_r2");
+        assert_eq!(
+            args,
+            serde_json::json!({"local_path": "/local/file.tar.gz", "key": "models/v1.tar.gz"})
+        );
+    }
+
+    #[test]
+    fn test_parse_download_r2() {
+        let (op, args) = parse_interactive_command(":download models/v1.tar.gz /local/file.tar.gz");
+        assert_eq!(op, "download_r2");
+        assert_eq!(
+            args,
+            serde_json::json!({"key": "models/v1.tar.gz", "local_path": "/local/file.tar.gz"})
+        );
+    }
+
+    #[test]
+    fn test_format_phase() {
+        // Just verify no panics and correct string content
+        assert!(format_phase(&SandboxPhase::Running).contains("Running"));
+        assert!(format_phase(&SandboxPhase::Pending).contains("Pending"));
+        assert!(format_phase(&SandboxPhase::Failed).contains("Failed"));
+        assert!(format_phase(&SandboxPhase::Terminating).contains("Terminating"));
+    }
+
+    #[test]
+    fn test_sandbox_ws_request_serialization() {
+        let req = SandboxWsRequest {
+            id: "test-123".to_string(),
+            op: "exec".to_string(),
+            args: Some(serde_json::json!({"command": ["echo", "hi"]})),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"op\":\"exec\""));
+        assert!(json.contains("\"id\":\"test-123\""));
+
+        let parsed: SandboxWsRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.op, "exec");
+        assert_eq!(parsed.id, "test-123");
+    }
+
+    #[test]
+    fn test_sandbox_ws_response_deserialization() {
+        let json = r#"{"id":"op-1","type":"stdout","data":"hello\n"}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "op-1");
+        assert_eq!(resp.response_type, "stdout");
+        assert_eq!(resp.data.unwrap().as_str().unwrap(), "hello\n");
+
+        let json = r#"{"id":"op-1","type":"exit","code":0}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response_type, "exit");
+        assert_eq!(resp.code, Some(0));
+
+        let json = r#"{"id":"op-1","type":"error","error":"file not found","error_code":"NOT_FOUND"}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response_type, "error");
+        assert_eq!(resp.error.unwrap(), "file not found");
+        assert_eq!(resp.error_code.unwrap(), "NOT_FOUND");
+    }
+
+    #[test]
+    fn test_sandbox_phase_display() {
+        assert_eq!(SandboxPhase::Pending.to_string(), "Pending");
+        assert_eq!(SandboxPhase::Running.to_string(), "Running");
+        assert_eq!(SandboxPhase::Terminating.to_string(), "Terminating");
+        assert_eq!(SandboxPhase::Failed.to_string(), "Failed");
+    }
+
+    #[test]
+    fn test_sandbox_phase_serde_roundtrip() {
+        for phase in [
+            SandboxPhase::Pending,
+            SandboxPhase::Running,
+            SandboxPhase::Terminating,
+            SandboxPhase::Failed,
+        ] {
+            let json = serde_json::to_string(&phase).unwrap();
+            let parsed: SandboxPhase = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, phase);
+        }
+    }
+
+    #[test]
+    fn test_create_sandbox_request_serialization() {
+        let req = CreateSandboxRequest {
+            image: Some("registry.basilica.ai/sandbox/python:3.11".to_string()),
+            cpu: Some("2".to_string()),
+            memory: Some("4Gi".to_string()),
+            ttl_seconds: Some(1800),
+            env: Some(vec![SandboxEnvVar {
+                name: "FOO".to_string(),
+                value: "bar".to_string(),
+            }]),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"ttl_seconds\":1800"));
+        assert!(json.contains("\"cpu\":\"2\""));
+
+        // Minimal request with None fields — they should be omitted
+        let req = CreateSandboxRequest {
+            image: None,
+            cpu: None,
+            memory: None,
+            ttl_seconds: None,
+            env: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("image"));
+        assert!(!json.contains("ttl_seconds"));
+    }
+
+    #[test]
+    fn test_create_sandbox_response_deserialization() {
+        let json = r#"{
+            "sandbox_id": "ab12cd34",
+            "domain": "sb-ab12cd34.sandboxes.basilica.ai",
+            "exec_secret": "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+            "status": {
+                "phase": "Pending",
+                "conditions": []
+            }
+        }"#;
+        let resp: CreateSandboxResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.sandbox_id, "ab12cd34");
+        assert_eq!(resp.domain, "sb-ab12cd34.sandboxes.basilica.ai");
+        assert_eq!(resp.exec_secret.len(), 64);
+        assert_eq!(resp.status.phase, SandboxPhase::Pending);
+    }
+
+    #[test]
+    fn test_sandbox_list_response_deserialization() {
+        let json = r#"{
+            "sandboxes": [
+                {
+                    "sandbox_id": "ab12cd34",
+                    "domain": "sb-ab12cd34.sandboxes.basilica.ai",
+                    "status": {
+                        "phase": "Running",
+                        "started_at": "2026-04-06T12:00:00Z",
+                        "conditions": [
+                            {"type": "Ready", "status": "True"}
+                        ]
+                    }
+                }
+            ]
+        }"#;
+        let resp: SandboxListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.sandboxes.len(), 1);
+        assert_eq!(resp.sandboxes[0].status.phase, SandboxPhase::Running);
+        assert_eq!(
+            resp.sandboxes[0].status.started_at.as_deref(),
+            Some("2026-04-06T12:00:00Z")
+        );
+    }
+}

--- a/crates/basilica-cli/src/cli/handlers/sandbox.rs
+++ b/crates/basilica-cli/src/cli/handlers/sandbox.rs
@@ -36,10 +36,9 @@ pub async fn handle_create(
     json: bool,
 ) -> Result<(), CliError> {
     // Validate TTL
-    if ttl < 60 || ttl > 7200 {
+    if !(60..=7200).contains(&ttl) {
         return Err(CliError::Internal(
-            eyre!("TTL must be between 60 and 7200 seconds (got {})", ttl)
-                .into(),
+            eyre!("TTL must be between 60 and 7200 seconds (got {})", ttl),
         ));
     }
 

--- a/crates/basilica-cli/src/cli/handlers/sandbox.rs
+++ b/crates/basilica-cli/src/cli/handlers/sandbox.rs
@@ -484,7 +484,7 @@ async fn interactive_session(domain: &str, secret: &str) -> Result<(), CliError>
     );
     println!(
         "{}",
-        style("File ops: :read <path>, :write <path> <content>, :ls <path>, :stat <path>").dim()
+        style("File ops: :read <path>, :write <path> <content>, :ls [path], :stat <path>, :mv <old> <new>").dim()
     );
     println!();
 
@@ -613,6 +613,24 @@ fn parse_interactive_command(input: &str) -> (String, serde_json::Value) {
             return (
                 "download_r2".to_string(),
                 serde_json::json!({ "key": parts[0], "local_path": parts[1] }),
+            );
+        }
+    }
+    if let Some(rest) = input.strip_prefix(":rename ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 {
+            return (
+                "rename".to_string(),
+                serde_json::json!({ "old_path": parts[0], "new_path": parts[1] }),
+            );
+        }
+    }
+    if let Some(rest) = input.strip_prefix(":mv ") {
+        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+        if parts.len() == 2 {
+            return (
+                "rename".to_string(),
+                serde_json::json!({ "old_path": parts[0], "new_path": parts[1] }),
             );
         }
     }
@@ -1031,5 +1049,213 @@ mod tests {
             resp.sandboxes[0].status.started_at.as_deref(),
             Some("2026-04-06T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_parse_rename() {
+        let (op, args) = parse_interactive_command(":rename /old/path /new/path");
+        assert_eq!(op, "rename");
+        assert_eq!(
+            args,
+            serde_json::json!({"old_path": "/old/path", "new_path": "/new/path"})
+        );
+    }
+
+    #[test]
+    fn test_parse_mv_alias() {
+        let (op, args) = parse_interactive_command(":mv /workspace/a.py /workspace/b.py");
+        assert_eq!(op, "rename");
+        assert_eq!(
+            args,
+            serde_json::json!({"old_path": "/workspace/a.py", "new_path": "/workspace/b.py"})
+        );
+    }
+
+    #[test]
+    fn test_parse_write_file_no_content() {
+        let (op, args) = parse_interactive_command(":write /tmp/empty.txt");
+        assert_eq!(op, "write_file");
+        assert_eq!(
+            args,
+            serde_json::json!({"path": "/tmp/empty.txt", "content": ""})
+        );
+    }
+
+    #[test]
+    fn test_parse_single_word_exec() {
+        let (op, args) = parse_interactive_command("ls");
+        assert_eq!(op, "exec");
+        assert_eq!(args, serde_json::json!({"command": ["ls"]}));
+    }
+
+    #[test]
+    fn test_parse_upload_missing_key_falls_through_to_exec() {
+        // :upload with only one arg doesn't match the two-arg pattern, falls to exec
+        let (op, _args) = parse_interactive_command(":upload /local/only");
+        assert_eq!(op, "exec");
+    }
+
+    #[test]
+    fn test_parse_download_missing_path_falls_through_to_exec() {
+        // :download with only one arg doesn't match the two-arg pattern, falls to exec
+        let (op, _args) = parse_interactive_command(":download only-key");
+        assert_eq!(op, "exec");
+    }
+
+    #[test]
+    fn test_ws_request_without_args() {
+        let req = SandboxWsRequest {
+            id: "ping-1".to_string(),
+            op: "ping".to_string(),
+            args: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("args"));
+
+        let parsed: SandboxWsRequest = serde_json::from_str(&json).unwrap();
+        assert!(parsed.args.is_none());
+        assert_eq!(parsed.op, "ping");
+    }
+
+    #[test]
+    fn test_ws_response_pong() {
+        let json = r#"{"id":"ping-1","type":"pong"}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response_type, "pong");
+        assert!(resp.data.is_none());
+        assert!(resp.code.is_none());
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn test_ws_response_dir_listing() {
+        let json = r#"{"id":"op-1","type":"dir","data":["file1.py","file2.py","subdir/"]}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response_type, "dir");
+        let entries = resp.data.unwrap();
+        assert_eq!(entries.as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_ws_response_stat() {
+        let json = r#"{"id":"op-1","type":"stat","data":{"size":1024,"mtime":"2026-04-06T12:00:00Z","permissions":"0644"}}"#;
+        let resp: SandboxWsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response_type, "stat");
+        let data = resp.data.unwrap();
+        assert_eq!(data["size"], 1024);
+    }
+
+    #[test]
+    fn test_sandbox_response_without_started_at() {
+        let json = r#"{
+            "sandbox_id": "ab12cd34",
+            "domain": "sb-ab12cd34.sandboxes.basilica.ai",
+            "status": {
+                "phase": "Pending",
+                "conditions": []
+            }
+        }"#;
+        let resp: SandboxResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.status.started_at.is_none());
+        assert_eq!(resp.status.phase, SandboxPhase::Pending);
+    }
+
+    #[test]
+    fn test_sandbox_condition_deserialization() {
+        let json = r#"{
+            "sandbox_id": "ab12cd34",
+            "domain": "sb-ab12cd34.sandboxes.basilica.ai",
+            "status": {
+                "phase": "Running",
+                "started_at": "2026-04-06T12:00:00Z",
+                "conditions": [
+                    {"type": "Ready", "status": "True", "last_transition_time": "2026-04-06T12:00:01Z"},
+                    {"type": "PodScheduled", "status": "True"}
+                ]
+            }
+        }"#;
+        let resp: SandboxResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status.conditions.len(), 2);
+        assert_eq!(resp.status.conditions[0].condition_type, "Ready");
+        assert_eq!(resp.status.conditions[0].status, "True");
+        assert!(resp.status.conditions[0].last_transition_time.is_some());
+        assert!(resp.status.conditions[1].last_transition_time.is_none());
+    }
+
+    #[test]
+    fn test_empty_sandbox_list() {
+        let json = r#"{"sandboxes": []}"#;
+        let resp: SandboxListResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.sandboxes.is_empty());
+    }
+
+    #[test]
+    fn test_all_wire_protocol_ops_parse() {
+        // Verify all 12 wire protocol ops are reachable through interactive commands
+        let ops: Vec<(&str, &str)> = vec![
+            ("echo test", "exec"),
+            (":read /path", "read_file"),
+            (":write /path data", "write_file"),
+            (":stat /path", "stat"),
+            (":ls /path", "list_dir"),
+            (":mkdir /path", "mkdir"),
+            (":rm /path", "remove"),
+            (":rename /a /b", "rename"),
+            (":upload /a key", "upload_r2"),
+            (":download key /a", "download_r2"),
+        ];
+        for (input, expected_op) in ops {
+            let (op, _) = parse_interactive_command(input);
+            assert_eq!(op, expected_op, "Input '{}' should produce op '{}'", input, expected_op);
+        }
+    }
+
+    #[test]
+    fn test_ws_response_all_error_codes() {
+        let error_codes = [
+            "AUTH_FAILED", "NOT_FOUND", "PERMISSION_DENIED", "TIMEOUT",
+            "QUEUE_FULL", "IO_ERROR", "PROCESS_ERROR", "INVALID_REQUEST",
+        ];
+        for code in &error_codes {
+            let json = format!(
+                r#"{{"id":"op-1","type":"error","error":"test error","error_code":"{}"}}"#,
+                code
+            );
+            let resp: SandboxWsResponse = serde_json::from_str(&json).unwrap();
+            assert_eq!(resp.error_code.as_deref(), Some(*code));
+        }
+    }
+
+    #[test]
+    fn test_create_request_with_env_vars() {
+        let req = CreateSandboxRequest {
+            image: None,
+            cpu: None,
+            memory: None,
+            ttl_seconds: None,
+            env: Some(vec![
+                SandboxEnvVar { name: "KEY1".to_string(), value: "val1".to_string() },
+                SandboxEnvVar { name: "KEY2".to_string(), value: "val=with=equals".to_string() },
+            ]),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: CreateSandboxRequest = serde_json::from_str(&json).unwrap();
+        let env = parsed.env.unwrap();
+        assert_eq!(env.len(), 2);
+        assert_eq!(env[1].value, "val=with=equals");
+    }
+
+    #[test]
+    fn test_exec_secret_not_in_get_response() {
+        // GET /v1/sandboxes/{id} response does NOT contain exec_secret
+        let json = r#"{
+            "sandbox_id": "ab12cd34",
+            "domain": "sb-ab12cd34.sandboxes.basilica.ai",
+            "status": {"phase": "Running", "conditions": []}
+        }"#;
+        let resp: SandboxResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.sandbox_id, "ab12cd34");
+        // SandboxResponse has no exec_secret field — this is by design.
+        // Only CreateSandboxResponse includes it.
     }
 }

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen::define_stub_info_gatherer;
 #[cfg(feature = "stub-gen")]
-use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction};
+use pyo3_stub_gen::derive::gen_stub_pyclass;
 use pythonize::pythonize;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -2447,4 +2447,170 @@ mod tests {
         let response = client.create_deployment(request).await.unwrap();
         assert!(response.public_metadata);
     }
+
+    // ===== Sandbox Tests =====
+
+    #[tokio::test]
+    async fn test_create_sandbox() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/sandboxes"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "sandboxId": "abc12345",
+                "domain": "sb-abc12345.sandboxes.basilica.ai",
+                "execSecret": "deadbeef01234567deadbeef01234567deadbeef01234567deadbeef01234567",
+                "status": {
+                    "phase": "Pending",
+                    "conditions": []
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = ClientBuilder::default()
+            .base_url(mock_server.uri())
+            .with_tokens("test-token", "refresh-token")
+            .build()
+            .unwrap();
+
+        let request = crate::types::CreateSandboxRequest {
+            image: Some("registry.basilica.ai/sandbox/python:3.11".to_string()),
+            cpu: Some("2".to_string()),
+            memory: Some("4Gi".to_string()),
+            ttl_seconds: Some(1800),
+            env: None,
+        };
+
+        let response = client.create_sandbox(request).await.unwrap();
+        assert_eq!(response.sandbox_id, "abc12345");
+        assert_eq!(response.domain, "sb-abc12345.sandboxes.basilica.ai");
+        assert_eq!(response.exec_secret.len(), 64);
+        assert_eq!(
+            response.status.phase,
+            crate::types::SandboxPhase::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_sandboxes() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/sandboxes"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "sandboxes": [
+                    {
+                        "sandboxId": "aaa11111",
+                        "domain": "sb-aaa11111.sandboxes.basilica.ai",
+                        "status": {
+                            "phase": "Running",
+                            "startedAt": "2026-04-06T12:00:00Z",
+                            "conditions": [
+                                {
+                                    "type": "Ready",
+                                    "status": "True",
+                                    "lastTransitionTime": "2026-04-06T12:00:01Z"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "sandboxId": "bbb22222",
+                        "domain": "sb-bbb22222.sandboxes.basilica.ai",
+                        "status": {
+                            "phase": "Pending",
+                            "conditions": []
+                        }
+                    }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = ClientBuilder::default()
+            .base_url(mock_server.uri())
+            .with_tokens("test-token", "refresh-token")
+            .build()
+            .unwrap();
+
+        let response = client.list_sandboxes().await.unwrap();
+        assert_eq!(response.sandboxes.len(), 2);
+        assert_eq!(response.sandboxes[0].sandbox_id, "aaa11111");
+        assert_eq!(
+            response.sandboxes[0].status.phase,
+            crate::types::SandboxPhase::Running
+        );
+        assert_eq!(
+            response.sandboxes[1].status.phase,
+            crate::types::SandboxPhase::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_sandbox() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/sandboxes/abc12345"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "sandboxId": "abc12345",
+                "domain": "sb-abc12345.sandboxes.basilica.ai",
+                "status": {
+                    "phase": "Running",
+                    "startedAt": "2026-04-06T12:00:00Z",
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "True",
+                            "lastTransitionTime": "2026-04-06T12:00:01Z"
+                        }
+                    ]
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = ClientBuilder::default()
+            .base_url(mock_server.uri())
+            .with_tokens("test-token", "refresh-token")
+            .build()
+            .unwrap();
+
+        let response = client.get_sandbox("abc12345").await.unwrap();
+        assert_eq!(response.sandbox_id, "abc12345");
+        assert_eq!(
+            response.status.phase,
+            crate::types::SandboxPhase::Running
+        );
+        assert_eq!(
+            response.status.started_at.as_deref(),
+            Some("2026-04-06T12:00:00Z")
+        );
+        assert_eq!(response.status.conditions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_sandbox() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/v1/sandboxes/abc12345"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let client = ClientBuilder::default()
+            .base_url(mock_server.uri())
+            .with_tokens("test-token", "refresh-token")
+            .build()
+            .unwrap();
+
+        let result = client.delete_sandbox("abc12345").await;
+        assert!(result.is_ok());
+    }
 }

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -661,6 +661,9 @@ impl BasilicaClient {
     ///     queue_name: None,
     ///     suspended: false,
     ///     priority: None,
+    ///     topology_spread: None,
+    ///     websocket: None,
+    ///     public_metadata: false,
     /// };
     ///
     /// let deployment = client.create_deployment(request).await?;

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -1258,6 +1258,45 @@ impl BasilicaClient {
         self.get_public(&path).await
     }
 
+    // ===== Sandbox Methods =====
+
+    /// Create a new compute sandbox
+    pub async fn create_sandbox(
+        &self,
+        request: crate::types::CreateSandboxRequest,
+    ) -> Result<crate::types::CreateSandboxResponse> {
+        self.post("/v1/sandboxes", &request).await
+    }
+
+    /// List sandboxes for the authenticated user
+    pub async fn list_sandboxes(&self) -> Result<crate::types::SandboxListResponse> {
+        self.get("/v1/sandboxes").await
+    }
+
+    /// Get sandbox status by ID
+    pub async fn get_sandbox(&self, sandbox_id: &str) -> Result<crate::types::SandboxResponse> {
+        let path = format!("/v1/sandboxes/{}", sandbox_id);
+        self.get(&path).await
+    }
+
+    /// Delete a sandbox by ID
+    pub async fn delete_sandbox(&self, sandbox_id: &str) -> Result<()> {
+        let path = format!("/v1/sandboxes/{}", sandbox_id);
+        let response = self.delete_empty(&path).await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let err = self
+                .handle_error_response::<serde_json::Value>(response)
+                .await
+                .err()
+                .unwrap_or(ApiError::Internal {
+                    message: "Unknown error".into(),
+                });
+            Err(err)
+        }
+    }
+
     // ===== Private Helper Methods =====
 
     /// Apply authentication to request

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1903,6 +1903,10 @@ pub struct SandboxCondition {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_transition_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 /// exec-agent WebSocket request frame

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1812,6 +1812,7 @@ mod tests {
 
 /// Request to create a compute sandbox
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateSandboxRequest {
     /// Container image (must be in allowlist)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1843,6 +1844,7 @@ pub struct SandboxEnvVar {
 
 /// Response from POST /v1/sandboxes
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateSandboxResponse {
     pub sandbox_id: String,
     pub domain: String,
@@ -1853,6 +1855,7 @@ pub struct CreateSandboxResponse {
 
 /// Response from GET /v1/sandboxes/{id}
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SandboxResponse {
     pub sandbox_id: String,
     pub domain: String,
@@ -1867,6 +1870,7 @@ pub struct SandboxListResponse {
 
 /// Sandbox status
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SandboxStatus {
     pub phase: SandboxPhase,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1897,6 +1901,7 @@ impl std::fmt::Display for SandboxPhase {
 
 /// Sandbox condition (K8s-style)
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct SandboxCondition {
     #[serde(rename = "type")]
     pub condition_type: String,

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1804,6 +1804,242 @@ mod tests {
         assert!(json.contains("\"minGpuMemoryGb\":40"));
         assert!(json.contains("\"interconnect\":\"PCIe\""));
     }
+
+    // ===== Sandbox Types Tests =====
+
+    #[test]
+    fn test_create_sandbox_request_serde() {
+        let request = CreateSandboxRequest {
+            image: Some("registry.basilica.ai/sandbox/python:3.11".to_string()),
+            cpu: Some("2".to_string()),
+            memory: Some("4Gi".to_string()),
+            ttl_seconds: Some(1800),
+            env: Some(vec![SandboxEnvVar {
+                name: "WORKSPACE_DIR".to_string(),
+                value: "/workspace".to_string(),
+            }]),
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"ttlSeconds\":1800"));
+        assert!(json.contains("\"cpu\":\"2\""));
+        assert!(json.contains("\"memory\":\"4Gi\""));
+
+        let roundtrip: CreateSandboxRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.ttl_seconds, Some(1800));
+        assert_eq!(roundtrip.cpu, Some("2".to_string()));
+    }
+
+    #[test]
+    fn test_create_sandbox_request_defaults_omit_none() {
+        let request = CreateSandboxRequest {
+            image: None,
+            cpu: None,
+            memory: None,
+            ttl_seconds: None,
+            env: None,
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn test_sandbox_response_serde() {
+        let json = r#"{
+            "sandboxId": "abc12345",
+            "domain": "sb-abc12345.sandboxes.basilica.ai",
+            "status": {
+                "phase": "Running",
+                "startedAt": "2026-04-06T12:00:00Z",
+                "conditions": [
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastTransitionTime": "2026-04-06T12:00:01Z"
+                    }
+                ]
+            }
+        }"#;
+        let response: SandboxResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.sandbox_id, "abc12345");
+        assert_eq!(response.domain, "sb-abc12345.sandboxes.basilica.ai");
+        assert_eq!(response.status.phase, SandboxPhase::Running);
+        assert_eq!(
+            response.status.started_at.as_deref(),
+            Some("2026-04-06T12:00:00Z")
+        );
+        assert_eq!(response.status.conditions.len(), 1);
+        assert_eq!(response.status.conditions[0].condition_type, "Ready");
+        assert_eq!(response.status.conditions[0].status, "True");
+    }
+
+    #[test]
+    fn test_create_sandbox_response_serde() {
+        let json = r#"{
+            "sandboxId": "abc12345",
+            "domain": "sb-abc12345.sandboxes.basilica.ai",
+            "execSecret": "deadbeef01234567deadbeef01234567deadbeef01234567deadbeef01234567",
+            "status": {
+                "phase": "Pending",
+                "conditions": []
+            }
+        }"#;
+        let response: CreateSandboxResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.sandbox_id, "abc12345");
+        assert_eq!(response.exec_secret.len(), 64);
+        assert_eq!(response.status.phase, SandboxPhase::Pending);
+        assert!(response.status.started_at.is_none());
+    }
+
+    #[test]
+    fn test_sandbox_list_response_serde() {
+        let json = r#"{
+            "sandboxes": [
+                {
+                    "sandboxId": "aaa11111",
+                    "domain": "sb-aaa11111.sandboxes.basilica.ai",
+                    "status": {"phase": "Running", "conditions": []}
+                },
+                {
+                    "sandboxId": "bbb22222",
+                    "domain": "sb-bbb22222.sandboxes.basilica.ai",
+                    "status": {"phase": "Pending", "conditions": []}
+                }
+            ]
+        }"#;
+        let response: SandboxListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.sandboxes.len(), 2);
+        assert_eq!(response.sandboxes[0].sandbox_id, "aaa11111");
+        assert_eq!(response.sandboxes[1].status.phase, SandboxPhase::Pending);
+    }
+
+    #[test]
+    fn test_sandbox_phase_all_variants() {
+        for (s, expected) in [
+            ("\"Pending\"", SandboxPhase::Pending),
+            ("\"Running\"", SandboxPhase::Running),
+            ("\"Terminating\"", SandboxPhase::Terminating),
+            ("\"Failed\"", SandboxPhase::Failed),
+        ] {
+            let phase: SandboxPhase = serde_json::from_str(s).unwrap();
+            assert_eq!(phase, expected);
+            let display = format!("{}", phase);
+            assert_eq!(display, s.trim_matches('"'));
+        }
+    }
+
+    #[test]
+    fn test_sandbox_ws_request_all_ops() {
+        let ops = [
+            "exec", "signal", "read_file", "write_file", "stat", "list_dir", "mkdir", "remove",
+            "rename", "upload_r2", "download_r2", "ping",
+        ];
+        for op in ops {
+            let req = SandboxWsRequest {
+                id: "req-001".to_string(),
+                op: op.to_string(),
+                args: Some(serde_json::json!({"key": "value"})),
+            };
+            let json = serde_json::to_string(&req).unwrap();
+            let roundtrip: SandboxWsRequest = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtrip.op, op);
+            assert_eq!(roundtrip.id, "req-001");
+            assert!(roundtrip.args.is_some());
+        }
+    }
+
+    #[test]
+    fn test_sandbox_ws_request_no_args() {
+        let req = SandboxWsRequest {
+            id: "ping-1".to_string(),
+            op: "ping".to_string(),
+            args: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("args"));
+        let roundtrip: SandboxWsRequest = serde_json::from_str(&json).unwrap();
+        assert!(roundtrip.args.is_none());
+    }
+
+    #[test]
+    fn test_sandbox_ws_response_all_types() {
+        // ok
+        let ok: SandboxWsResponse =
+            serde_json::from_str(r#"{"id":"1","type":"ok"}"#).unwrap();
+        assert_eq!(ok.response_type, "ok");
+        assert!(ok.data.is_none());
+
+        // stdout with data
+        let stdout: SandboxWsResponse =
+            serde_json::from_str(r#"{"id":"2","type":"stdout","data":"hello\n"}"#).unwrap();
+        assert_eq!(stdout.response_type, "stdout");
+        assert_eq!(stdout.data.unwrap(), "hello\n");
+
+        // stderr
+        let stderr: SandboxWsResponse =
+            serde_json::from_str(r#"{"id":"3","type":"stderr","data":"err"}"#).unwrap();
+        assert_eq!(stderr.response_type, "stderr");
+
+        // exit with code
+        let exit: SandboxWsResponse =
+            serde_json::from_str(r#"{"id":"4","type":"exit","code":0}"#).unwrap();
+        assert_eq!(exit.response_type, "exit");
+        assert_eq!(exit.code, Some(0));
+
+        // error with error_code
+        let err: SandboxWsResponse = serde_json::from_str(
+            r#"{"id":"5","type":"error","error":"not found","error_code":"NOT_FOUND"}"#,
+        )
+        .unwrap();
+        assert_eq!(err.response_type, "error");
+        assert_eq!(err.error.as_deref(), Some("not found"));
+        assert_eq!(err.error_code.as_deref(), Some("NOT_FOUND"));
+
+        // pong
+        let pong: SandboxWsResponse =
+            serde_json::from_str(r#"{"id":"6","type":"pong"}"#).unwrap();
+        assert_eq!(pong.response_type, "pong");
+
+        // file, stat, dir
+        for resp_type in ["file", "stat", "dir"] {
+            let json = format!(r#"{{"id":"7","type":"{}","data":{{"k":"v"}}}}"#, resp_type);
+            let resp: SandboxWsResponse = serde_json::from_str(&json).unwrap();
+            assert_eq!(resp.response_type, resp_type);
+            assert!(resp.data.is_some());
+        }
+    }
+
+    #[test]
+    fn test_sandbox_ws_response_roundtrip() {
+        let resp = SandboxWsResponse {
+            id: "x".to_string(),
+            response_type: "exit".to_string(),
+            data: None,
+            code: Some(42),
+            error: None,
+            error_code: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let roundtrip: SandboxWsResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.code, Some(42));
+        assert!(!json.contains("\"error\""));
+        assert!(!json.contains("\"data\""));
+    }
+
+    #[test]
+    fn test_sandbox_condition_serde() {
+        let json = r#"{
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2026-04-06T12:00:01Z",
+            "reason": "PodReady",
+            "message": "Pod is running"
+        }"#;
+        let cond: SandboxCondition = serde_json::from_str(json).unwrap();
+        assert_eq!(cond.condition_type, "Ready");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason.as_deref(), Some("PodReady"));
+        assert_eq!(cond.message.as_deref(), Some("Pod is running"));
+    }
 }
 
 // ============================================================================

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1805,3 +1805,131 @@ mod tests {
         assert!(json.contains("\"interconnect\":\"PCIe\""));
     }
 }
+
+// ============================================================================
+// Sandbox Types
+// ============================================================================
+
+/// Request to create a compute sandbox
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateSandboxRequest {
+    /// Container image (must be in allowlist)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+
+    /// CPU allocation (e.g., "2")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+
+    /// Memory allocation (e.g., "4Gi")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+
+    /// Time-to-live in seconds (max 7200)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<u32>,
+
+    /// Environment variables
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<Vec<SandboxEnvVar>>,
+}
+
+/// Environment variable for sandbox
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxEnvVar {
+    pub name: String,
+    pub value: String,
+}
+
+/// Response from POST /v1/sandboxes
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateSandboxResponse {
+    pub sandbox_id: String,
+    pub domain: String,
+    /// Bearer credential for exec-agent WebSocket auth. NEVER persist or log.
+    pub exec_secret: String,
+    pub status: SandboxStatus,
+}
+
+/// Response from GET /v1/sandboxes/{id}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxResponse {
+    pub sandbox_id: String,
+    pub domain: String,
+    pub status: SandboxStatus,
+}
+
+/// Response from GET /v1/sandboxes
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxListResponse {
+    pub sandboxes: Vec<SandboxResponse>,
+}
+
+/// Sandbox status
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxStatus {
+    pub phase: SandboxPhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default)]
+    pub conditions: Vec<SandboxCondition>,
+}
+
+/// Sandbox lifecycle phase
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxPhase {
+    Pending,
+    Running,
+    Terminating,
+    Failed,
+}
+
+impl std::fmt::Display for SandboxPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SandboxPhase::Pending => write!(f, "Pending"),
+            SandboxPhase::Running => write!(f, "Running"),
+            SandboxPhase::Terminating => write!(f, "Terminating"),
+            SandboxPhase::Failed => write!(f, "Failed"),
+        }
+    }
+}
+
+/// Sandbox condition (K8s-style)
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxCondition {
+    #[serde(rename = "type")]
+    pub condition_type: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_transition_time: Option<String>,
+}
+
+/// exec-agent WebSocket request frame
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxWsRequest {
+    pub id: String,
+    pub op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<serde_json::Value>,
+}
+
+/// exec-agent WebSocket response frame
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SandboxWsResponse {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub response_type: String,
+    /// Present on stdout/stderr/file/dir/stat/pong responses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    /// Present on exit responses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+    /// Present on error responses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Error code on error responses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+}


### PR DESCRIPTION
## Summary
- Add M1 Compute Sandboxes control plane: tenant-scoped, ephemeral Linux execution environments accessed via WebSocket through Envoy Gateway
- Introduce `basilica-exec-agent` crate — in-pod binary handling WebSocket connections, command execution, filesystem ops (`read_file`, `write_file`, `list_dir`), and R2 upload/download, authenticated via `X-Exec-Secret` header
- Introduce `basilica-sandbox-operator` crate — K8s operator reconciling `BasilicaSandbox` CRD with TTL-based cleanup, billing bridge (credits deducted per-second), and Prometheus metrics
- Introduce `sandbox-router` crate — Envoy Gateway `BackendRef` that resolves `Host: sb-{id}.sandboxes.basilica.ai` to `sandbox-{id}.u-{user_id}.svc.cluster.local:9999` using an in-memory CRD informer cache
- Add sandbox API routes in `basilica-api` (`POST /v1/sandboxes`, `GET /v1/sandboxes/{id}`, `DELETE /v1/sandboxes/{id}`, `GET /v1/sandboxes`) with `MultiClusterK8sClient` for cross-cluster CRD management (fail-hard, no silent fallback per D-2)
- Add `CloudType::Sandbox` variant to `basilica-billing` with migration `046_sandbox_cloud_type.sql`
- Add K8s manifests for sandbox cluster: `BasilicaSandbox` CRD, operator deployment/RBAC, sandbox-router deployment/service/RBAC, Envoy Gateway config (wildcard HTTPRoute `*.sandboxes.basilica.ai`), image pre-pull DaemonSet
- Add Ansible roles for sandbox cluster provisioning: `sandbox_k3s_server`, `sandbox_k3s_agent`, `sandbox_gateway`, `sandbox_operator`, `sandbox_networking`, `sandbox_prepuller`
- Add `sandbox_k8s_integration` test in `integration-tests` crate covering CRD creation, status transitions, and cleanup
- Fix basilica-api doctest OOM during full workspace `cargo test`

## Validation
- `cargo test --workspace` passes: 493+ tests (123 aggregator, 357 api, 8 verda, 5 masscompute) with 0 failures
- Integration test `sandbox_k8s_integration` validates CRD lifecycle against mock K8s API
- All sandbox crates compile and pass unit tests covering auth token validation, wire protocol serialization, CRD informer cache, TTL reaping, billing bridge, router host-header extraction, and exec/fs/r2 operations
- No clippy or `cargo vet` regressions

## Risks
- `basilica-sandbox-operator` controller at 777 LOC exceeds the 300 LOC guideline in the workspace CLAUDE.md; may warrant splitting before further iteration
- Sandbox cluster infrastructure (K3s, Envoy Gateway, WireGuard) requires provisioning via Ansible before sandbox APIs are functional — no runtime fallback if the sandbox cluster is unreachable
- `MultiClusterK8sClient` fail-hard behavior (D-2) means sandbox API routes return 503 if sandbox cluster kubeconfig is missing or invalid at startup
- M1 targets 1,000–10,000 concurrent sandboxes per cluster; load testing against production-like infrastructure has not been performed

Closes one-covenant/basilica-backend#271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox management: create, list, view status, and delete sandboxes from CLI
  * Execute commands interactively in sandboxes with WebSocket-based exec sessions
  * Configure sandbox resources with CPU, memory, TTL, and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->