### PR TITLE
feat(validator): add Prometheus metrics and improve telemetry for incentive mechanism

### DIFF
--- a/crates/basilica-validator/src/bittensor_core/weight_setter.rs
+++ b/crates/basilica-validator/src/bittensor_core/weight_setter.rs
@@ -4,13 +4,10 @@
 //! Sets weights every N blocks based on miner scores from node validations.
 
 use crate::basilica_api::{BasilicaApiClient, IncentiveConfigResponse};
-use rust_decimal::prelude::ToPrimitive;
 use crate::config::emission::EmissionConfig;
 use crate::gpu::categorization;
 use crate::gpu::GpuScoringEngine;
-use crate::incentive::incentive_pool::{
-    compute_incentive_pool, MinerCategoryDetail,
-};
+use crate::incentive::incentive_pool::{compute_incentive_pool, MinerCategoryDetail};
 use crate::metrics::ValidatorMetrics;
 use crate::persistence::entities::VerificationLog;
 use crate::persistence::gpu_profile_repository::GpuProfileRepository;
@@ -21,6 +18,7 @@ use basilica_common::identity::{Hotkey, MinerUid, NodeId};
 use basilica_common::{KeyValueStorage, MemoryStorage};
 use bittensor::{Metagraph, NormalizedWeight, Service as BittensorService};
 use chrono::{DateTime, Utc};
+use rust_decimal::prelude::ToPrimitive;
 use sqlx::Row;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -370,9 +368,7 @@ impl WeightSetter {
         let prom = metrics.prometheus();
 
         // Pool state
-        prom.set_incentive_pool_usd_required(
-            result.usd_required_epoch.to_f64().unwrap_or(0.0),
-        );
+        prom.set_incentive_pool_usd_required(result.usd_required_epoch.to_f64().unwrap_or(0.0));
         prom.set_incentive_pool_usd_emission_capacity(
             result.usd_emission_capacity.to_f64().unwrap_or(0.0),
         );

--- a/crates/basilica-validator/src/bittensor_core/weight_setter.rs
+++ b/crates/basilica-validator/src/bittensor_core/weight_setter.rs
@@ -4,11 +4,12 @@
 //! Sets weights every N blocks based on miner scores from node validations.
 
 use crate::basilica_api::{BasilicaApiClient, IncentiveConfigResponse};
+use rust_decimal::prelude::ToPrimitive;
 use crate::config::emission::EmissionConfig;
 use crate::gpu::categorization;
 use crate::gpu::GpuScoringEngine;
 use crate::incentive::incentive_pool::{
-    compute_cu_vested_fraction, compute_incentive_pool, compute_ru_vested_fraction,
+    compute_incentive_pool, MinerCategoryDetail,
 };
 use crate::metrics::ValidatorMetrics;
 use crate::persistence::entities::VerificationLog;
@@ -25,7 +26,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, instrument, warn};
 use uuid::Uuid;
 
 // NormalizedWeight is imported from bittensor crate
@@ -45,22 +46,6 @@ pub struct NodeValidationResult {
     pub gpu_model: String,
 }
 
-/// CU contribution for one category in incentive pool logging
-struct IncentiveCuCategory {
-    category: String,
-    cu_amount: rust_decimal::Decimal,
-    cu_usd: rust_decimal::Decimal,
-}
-
-/// One miner's full payout breakdown for incentive pool logging
-struct IncentiveMinerPayout {
-    miner_uid: u16,
-    hotkey: String,
-    cu_categories: Vec<IncentiveCuCategory>,
-    ru_usd: rust_decimal::Decimal,
-    total_usd: rust_decimal::Decimal,
-}
-
 /// Result from the incentive-pool weight calculation
 struct IncentiveWeightResult {
     distribution: crate::bittensor_core::weight_allocation::WeightDistribution,
@@ -78,8 +63,8 @@ struct IncentiveWeightResult {
     incentive_config: IncentiveConfigResponse,
     // Pool breakdown
     category_payouts: HashMap<String, rust_decimal::Decimal>,
-    // Per-miner breakdown
-    miner_payouts_detail: Vec<IncentiveMinerPayout>,
+    // Per-miner per-category detail (from incentive pool)
+    miner_category_detail: Vec<MinerCategoryDetail>,
 }
 
 /// Manages weight setting operations for Bittensor network
@@ -229,6 +214,9 @@ impl WeightSetter {
         for attempt in 1..=MAX_RETRIES {
             match self.attempt_weight_setting().await {
                 Ok(()) => {
+                    if let Some(ref metrics) = self.metrics {
+                        metrics.prometheus().record_weight_setting(true);
+                    }
                     info!("Weight setting successful on attempt {}", attempt);
                     return Ok(());
                 }
@@ -245,6 +233,9 @@ impl WeightSetter {
             }
         }
 
+        if let Some(ref metrics) = self.metrics {
+            metrics.prometheus().record_weight_setting(false);
+        }
         Err(anyhow::anyhow!(
             "Failed to set weights after {} attempts",
             MAX_RETRIES
@@ -254,6 +245,7 @@ impl WeightSetter {
     /// Attempt to set weights (extracted for retry logic).
     ///
     /// Uses the CU/RU incentive pool to compute and submit weights.
+    #[instrument(skip(self), name = "weight_setting")]
     async fn attempt_weight_setting(&self) -> Result<()> {
         info!(
             "Setting weights for subnet {} with GPU-based allocation",
@@ -272,6 +264,7 @@ impl WeightSetter {
             .compute_incentive_pool_weights(&epoch, &hotkey_to_uid, &metagraph)
             .await?;
         self.log_incentive_weight_result(&result);
+        self.record_incentive_pool_metrics(&result);
 
         let weight_distribution = &result.distribution;
         self.log_weight_distribution(weight_distribution);
@@ -329,25 +322,18 @@ impl WeightSetter {
             "Incentive pool summary"
         );
 
-        // Per-miner breakdown
-        for miner in &result.miner_payouts_detail {
-            let cu_breakdown: String = miner
-                .cu_categories
-                .iter()
-                .map(|c| {
-                    format!(
-                        "{}: {:.2} CU (vested ${:.2} this epoch)",
-                        c.category, c.cu_amount, c.cu_usd
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
+        // Per-miner per-category breakdown
+        for detail in &result.miner_category_detail {
+            let total_usd = detail.cu_usd + detail.ru_usd;
             info!(
-                miner_uid = miner.miner_uid,
-                hotkey = %miner.hotkey,
-                cu_breakdown = %cu_breakdown,
-                ru_usd = %miner.ru_usd,
-                total_usd = %miner.total_usd,
+                miner_uid = detail.miner_uid,
+                hotkey = %detail.hotkey,
+                category = %detail.category,
+                cu_amount = %detail.cu_amount,
+                cu_vested_pct = %detail.cu_vested_pct,
+                cu_usd = %detail.cu_usd,
+                ru_usd = %detail.ru_usd,
+                total_usd = %total_usd,
                 "Miner payout"
             );
         }
@@ -376,6 +362,55 @@ impl WeightSetter {
         );
     }
 
+    /// Record incentive pool metrics to Prometheus gauges.
+    fn record_incentive_pool_metrics(&self, result: &IncentiveWeightResult) {
+        let Some(ref metrics) = self.metrics else {
+            return;
+        };
+        let prom = metrics.prometheus();
+
+        // Pool state
+        prom.set_incentive_pool_usd_required(
+            result.usd_required_epoch.to_f64().unwrap_or(0.0),
+        );
+        prom.set_incentive_pool_usd_emission_capacity(
+            result.usd_emission_capacity.to_f64().unwrap_or(0.0),
+        );
+
+        // Token prices
+        prom.set_alpha_price_usd(result.alpha_price_usd.to_f64().unwrap_or(0.0));
+        prom.set_tao_price_usd(result.tao_price_usd.to_f64().unwrap_or(0.0));
+
+        // Incentive config per category (resolved window_hours)
+        let global_window = result.incentive_config.window_hours;
+        for (category, cat_config) in &result.incentive_config.gpu_categories {
+            let resolved_window = cat_config.window_hours.unwrap_or(global_window);
+            prom.set_incentive_config_gpu_category(
+                category,
+                cat_config.target_count,
+                cat_config.price_per_gpu_cents,
+                resolved_window,
+            );
+        }
+
+        // Global config
+        prom.set_incentive_config_global(
+            result.incentive_config.revenue_share_pct,
+            result.incentive_config.slash_pct,
+        );
+
+        // Per-miner per-category CU detail
+        for detail in &result.miner_category_detail {
+            prom.set_incentive_miner_cu(
+                detail.miner_uid,
+                &detail.category,
+                detail.cu_amount.to_f64().unwrap_or(0.0),
+                detail.cu_vested_pct.to_f64().unwrap_or(0.0),
+            );
+        }
+    }
+
+    #[instrument(skip_all, fields(epoch_id = epoch.id))]
     async fn compute_incentive_pool_weights(
         &self,
         epoch: &WeightSetEpoch,
@@ -413,16 +448,6 @@ impl WeightSetter {
             alpha_tokens_per_block * miner_emission_share * blocks_per_epoch;
         let usd_emission_capacity = miner_alpha_per_epoch * token_prices.alpha_price_usd;
 
-        // Build per-miner-per-category CU/RU breakdown from raw rows
-        let miner_payouts_detail = self.compute_miner_breakdown(
-            &incentive_config,
-            &cu_rows,
-            &ru_rows,
-            epoch_start,
-            epoch.period_end,
-            hotkey_to_uid,
-        );
-
         let incentive_result = compute_incentive_pool(
             &incentive_config,
             &cu_rows,
@@ -448,133 +473,8 @@ impl WeightSetter {
             blocks_per_epoch: self.blocks_per_weight_set,
             incentive_config,
             category_payouts: incentive_result.category_payouts,
-            miner_payouts_detail,
+            miner_category_detail: incentive_result.miner_category_detail,
         })
-    }
-
-    /// Build per-miner breakdown of CU (per category) and RU (total) for logging.
-    /// Replicates the payout math from `compute_incentive_pool` but keeps CU/RU separate.
-    fn compute_miner_breakdown(
-        &self,
-        config: &IncentiveConfigResponse,
-        cu_rows: &[crate::basilica_api::CuLedgerRowResponse],
-        ru_rows: &[crate::basilica_api::RuLedgerRowResponse],
-        epoch_start: DateTime<Utc>,
-        epoch_end: DateTime<Utc>,
-        hotkey_to_uid: &HashMap<String, u16>,
-    ) -> Vec<IncentiveMinerPayout> {
-        use rust_decimal::Decimal;
-
-        // CU supply per category (dilution denominator)
-        let mut category_cu_supply: HashMap<String, Decimal> = HashMap::new();
-        for row in cu_rows {
-            if row.is_slashed
-                || !hotkey_to_uid.contains_key(&row.hotkey)
-                || !config.gpu_categories.contains_key(&row.gpu_category)
-            {
-                continue;
-            }
-            *category_cu_supply
-                .entry(row.gpu_category.clone())
-                .or_insert(Decimal::ZERO) += row.cu_amount;
-        }
-
-        // Accumulate CU per (hotkey, category)
-        let mut cu_accum: HashMap<String, HashMap<String, (Decimal, Decimal)>> = HashMap::new();
-        for row in cu_rows {
-            if row.is_slashed
-                || !hotkey_to_uid.contains_key(&row.hotkey)
-                || !config.gpu_categories.contains_key(&row.gpu_category)
-            {
-                continue;
-            }
-            let vested = compute_cu_vested_fraction(row, epoch_start, epoch_end);
-            if vested <= Decimal::ZERO {
-                continue;
-            }
-            let Some(cat_config) = config.gpu_categories.get(&row.gpu_category) else {
-                continue;
-            };
-            let supply = category_cu_supply
-                .get(&row.gpu_category)
-                .copied()
-                .unwrap_or(Decimal::ZERO);
-            if supply <= Decimal::ZERO {
-                continue;
-            }
-            let target_gpus = Decimal::from(cat_config.target_count) * Decimal::from(8u32);
-            let row_price_usd = Decimal::from(row.price_per_gpu_cents) / Decimal::from(100u32);
-            let capacity_budget = target_gpus * Decimal::from(row.window_hours) * row_price_usd;
-            let per_cu_budget = capacity_budget / supply;
-            let effective_price = row_price_usd.min(per_cu_budget);
-            let cu_usd = vested * row.cu_amount * effective_price;
-            if cu_usd <= Decimal::ZERO {
-                continue;
-            }
-
-            let entry = cu_accum
-                .entry(row.hotkey.clone())
-                .or_default()
-                .entry(row.gpu_category.clone())
-                .or_insert((Decimal::ZERO, Decimal::ZERO));
-            entry.0 += row.cu_amount;
-            entry.1 += cu_usd;
-        }
-
-        // Accumulate RU per hotkey (total, not per category)
-        let mut ru_accum: HashMap<String, Decimal> = HashMap::new();
-        for row in ru_rows {
-            if row.is_slashed || !hotkey_to_uid.contains_key(&row.hotkey) {
-                continue;
-            }
-            let vested = compute_ru_vested_fraction(row, epoch_start, epoch_end);
-            if vested <= Decimal::ZERO {
-                continue;
-            }
-            let ru_usd = vested * row.ru_amount * Decimal::from(row.revenue_share_pct)
-                / Decimal::from(100u32);
-            if ru_usd <= Decimal::ZERO {
-                continue;
-            }
-            *ru_accum.entry(row.hotkey.clone()).or_insert(Decimal::ZERO) += ru_usd;
-        }
-
-        // Merge into Vec<IncentiveMinerPayout>
-        let all_hotkeys: std::collections::HashSet<&String> =
-            cu_accum.keys().chain(ru_accum.keys()).collect();
-
-        let mut payouts: Vec<IncentiveMinerPayout> = all_hotkeys
-            .into_iter()
-            .filter_map(|hotkey| {
-                let uid = hotkey_to_uid.get(hotkey)?;
-                let cu_categories: Vec<IncentiveCuCategory> = cu_accum
-                    .get(hotkey)
-                    .map(|cats| {
-                        cats.iter()
-                            .map(|(cat, (amount, usd))| IncentiveCuCategory {
-                                category: cat.clone(),
-                                cu_amount: *amount,
-                                cu_usd: *usd,
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let ru_usd = ru_accum.get(hotkey).copied().unwrap_or(Decimal::ZERO);
-                let cu_total: Decimal = cu_categories.iter().map(|c| c.cu_usd).sum();
-                let total_usd = cu_total + ru_usd;
-
-                Some(IncentiveMinerPayout {
-                    miner_uid: *uid,
-                    hotkey: hotkey.clone(),
-                    cu_categories,
-                    ru_usd,
-                    total_usd,
-                })
-            })
-            .collect();
-
-        payouts.sort_by_key(|p| p.miner_uid);
-        payouts
     }
 
     async fn fetch_metagraph_with_logging(&self) -> Result<Metagraph> {
@@ -840,6 +740,7 @@ impl WeightSetter {
     }
 
     /// Submit weights to chain with retry logic
+    #[instrument(skip(self, normalized_weights), fields(weight_count = normalized_weights.len()))]
     async fn submit_weights_to_chain_with_retry(
         &self,
         normalized_weights: Vec<NormalizedWeight>,
@@ -877,6 +778,7 @@ impl WeightSetter {
     }
 
     /// Submit weights to chain using the provided set_weights_payload function
+    #[instrument(skip(self, normalized_weights), fields(weight_count = normalized_weights.len(), version_key))]
     async fn submit_weights_to_chain(
         &self,
         normalized_weights: Vec<NormalizedWeight>,

--- a/crates/basilica-validator/src/incentive/incentive_pool.rs
+++ b/crates/basilica-validator/src/incentive/incentive_pool.rs
@@ -10,7 +10,23 @@ use rust_decimal::Decimal;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
+
+/// Per-miner per-category breakdown of CU amounts and vesting progress.
+#[derive(Debug, Clone)]
+pub struct MinerCategoryDetail {
+    pub hotkey: String,
+    pub miner_uid: u16,
+    pub category: String,
+    /// Total CU amount with pending vesting.
+    pub cu_amount: Decimal,
+    /// Cumulative vesting progress (0–100).
+    pub cu_vested_pct: Decimal,
+    /// Vested USD payout this epoch (from CU).
+    pub cu_usd: Decimal,
+    /// Vested USD payout this epoch (from RU).
+    pub ru_usd: Decimal,
+}
 
 #[derive(Debug, Clone)]
 pub struct IncentivePoolResult {
@@ -21,6 +37,7 @@ pub struct IncentivePoolResult {
     pub usd_emission_capacity: Decimal,
     pub category_payouts: HashMap<String, Decimal>,
     pub miner_payouts: HashMap<String, Decimal>,
+    pub miner_category_detail: Vec<MinerCategoryDetail>,
 }
 
 pub fn compute_cu_vested_fraction(
@@ -46,6 +63,7 @@ fn normalize_gpu_category(raw: &str) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[instrument(skip_all, fields(cu_rows = cu_rows.len(), ru_rows = ru_rows.len()))]
 pub fn compute_incentive_pool(
     config: &IncentiveConfigResponse,
     cu_rows: &[CuLedgerRowResponse],
@@ -103,8 +121,26 @@ pub fn compute_incentive_pool(
     let mut category_payouts = HashMap::new();
     let mut category_miners: HashMap<String, HashSet<String>> = HashMap::new();
 
-    for row in active_cu_rows {
+    // Accumulators for per-miner-per-category detail.
+    // Key: (hotkey, normalized_category)
+    // Value: (total_cu, vested_cu, cu_usd)
+    type DetailKey = (String, String);
+    let mut cu_detail: HashMap<DetailKey, (Decimal, Decimal, Decimal)> = HashMap::new();
+    let mut ru_detail: HashMap<DetailKey, Decimal> = HashMap::new();
+
+    for row in &active_cu_rows {
         let vested_fraction = compute_cu_vested_fraction(row, epoch_start, epoch_end);
+        let normalized_cat = normalize_gpu_category(&row.gpu_category);
+        let cumulative = compute_cumulative_vested_fraction(row.earned_at, row.window_hours, epoch_end);
+
+        // Always accumulate CU totals and cumulative vesting for detail,
+        // even if the per-epoch vested fraction is zero for this row.
+        let detail_entry = cu_detail
+            .entry((row.hotkey.clone(), normalized_cat.clone()))
+            .or_insert((Decimal::ZERO, Decimal::ZERO, Decimal::ZERO));
+        detail_entry.0 += row.cu_amount;
+        detail_entry.1 += cumulative * row.cu_amount;
+
         if vested_fraction <= Decimal::ZERO {
             continue;
         }
@@ -112,7 +148,6 @@ pub fn compute_incentive_pool(
         let Some(category_config) = config.gpu_categories.get(&row.gpu_category) else {
             continue;
         };
-        let normalized_cat = normalize_gpu_category(&row.gpu_category);
         let category_supply = category_cu_supply
             .get(&normalized_cat)
             .copied()
@@ -131,6 +166,7 @@ pub fn compute_incentive_pool(
             continue;
         }
 
+        detail_entry.2 += row_payout;
         *miner_payouts
             .entry(row.hotkey.clone())
             .or_insert(Decimal::ZERO) += row_payout;
@@ -156,6 +192,9 @@ pub fn compute_incentive_pool(
         }
 
         let normalized_cat = normalize_gpu_category(&row.gpu_category);
+        *ru_detail
+            .entry((row.hotkey.clone(), normalized_cat.clone()))
+            .or_insert(Decimal::ZERO) += row_payout;
         *miner_payouts
             .entry(row.hotkey.clone())
             .or_insert(Decimal::ZERO) += row_payout;
@@ -167,6 +206,33 @@ pub fn compute_incentive_pool(
             .or_default()
             .insert(row.hotkey.clone());
     }
+
+    // Build miner_category_detail from accumulators
+    let mut miner_category_detail: Vec<MinerCategoryDetail> = cu_detail
+        .into_iter()
+        .filter_map(|((hotkey, category), (total_cu, vested_cu, cu_usd))| {
+            let miner_uid = *hotkey_to_uid.get(&hotkey)?;
+            let cu_vested_pct = if total_cu > Decimal::ZERO {
+                (vested_cu / total_cu) * Decimal::from(100u32)
+            } else {
+                Decimal::ZERO
+            };
+            let ru_usd = ru_detail
+                .get(&(hotkey.clone(), category.clone()))
+                .copied()
+                .unwrap_or(Decimal::ZERO);
+            Some(MinerCategoryDetail {
+                hotkey,
+                miner_uid,
+                category,
+                cu_amount: total_cu,
+                cu_vested_pct,
+                cu_usd,
+                ru_usd,
+            })
+        })
+        .collect();
+    miner_category_detail.sort_by(|a, b| a.miner_uid.cmp(&b.miner_uid).then_with(|| a.category.cmp(&b.category)));
 
     let raw_usd_required_epoch = sum_decimals(miner_payouts.values().copied());
 
@@ -181,6 +247,7 @@ pub fn compute_incentive_pool(
             usd_emission_capacity,
             category_payouts,
             miner_payouts,
+            miner_category_detail,
         ));
     }
 
@@ -213,6 +280,7 @@ pub fn compute_incentive_pool(
             usd_emission_capacity,
             scaled_category_payouts,
             scaled_miner_payouts,
+            miner_category_detail,
         ));
     }
 
@@ -296,6 +364,7 @@ pub fn compute_incentive_pool(
         usd_emission_capacity,
         category_payouts: scaled_category_payouts,
         miner_payouts: scaled_miner_payouts,
+        miner_category_detail,
     })
 }
 
@@ -322,6 +391,26 @@ fn compute_vested_fraction(
         / Decimal::from_i128_with_scale(window_ms, 0)
 }
 
+/// Cumulative vesting fraction: how much of a CU row has vested in total
+/// (across all past epochs up to `now`), as opposed to the per-epoch overlap.
+fn compute_cumulative_vested_fraction(
+    earned_at: DateTime<Utc>,
+    window_hours: u32,
+    now: DateTime<Utc>,
+) -> Decimal {
+    if window_hours == 0 {
+        return Decimal::ZERO;
+    }
+    let window_ms = (window_hours as i128) * 3_600_000;
+    let elapsed_ms = (now.timestamp_millis() as i128) - (earned_at.timestamp_millis() as i128);
+    if elapsed_ms <= 0 {
+        return Decimal::ZERO;
+    }
+    let fraction =
+        Decimal::from_i128_with_scale(elapsed_ms, 0) / Decimal::from_i128_with_scale(window_ms, 0);
+    min_decimal(fraction, Decimal::ONE)
+}
+
 fn scale_decimal_map(
     values: &HashMap<String, Decimal>,
     scale_factor: Decimal,
@@ -337,6 +426,7 @@ fn all_burn_result(
     usd_emission_capacity: Decimal,
     category_payouts: HashMap<String, Decimal>,
     miner_payouts: HashMap<String, Decimal>,
+    miner_category_detail: Vec<MinerCategoryDetail>,
 ) -> IncentivePoolResult {
     IncentivePoolResult {
         distribution: WeightDistribution {
@@ -359,6 +449,7 @@ fn all_burn_result(
         usd_emission_capacity,
         category_payouts,
         miner_payouts,
+        miner_category_detail,
     }
 }
 

--- a/crates/basilica-validator/src/incentive/incentive_pool.rs
+++ b/crates/basilica-validator/src/incentive/incentive_pool.rs
@@ -131,7 +131,8 @@ pub fn compute_incentive_pool(
     for row in &active_cu_rows {
         let vested_fraction = compute_cu_vested_fraction(row, epoch_start, epoch_end);
         let normalized_cat = normalize_gpu_category(&row.gpu_category);
-        let cumulative = compute_cumulative_vested_fraction(row.earned_at, row.window_hours, epoch_end);
+        let cumulative =
+            compute_cumulative_vested_fraction(row.earned_at, row.window_hours, epoch_end);
 
         // Always accumulate CU totals and cumulative vesting for detail,
         // even if the per-epoch vested fraction is zero for this row.
@@ -232,7 +233,11 @@ pub fn compute_incentive_pool(
             })
         })
         .collect();
-    miner_category_detail.sort_by(|a, b| a.miner_uid.cmp(&b.miner_uid).then_with(|| a.category.cmp(&b.category)));
+    miner_category_detail.sort_by(|a, b| {
+        a.miner_uid
+            .cmp(&b.miner_uid)
+            .then_with(|| a.category.cmp(&b.category))
+    });
 
     let raw_usd_required_epoch = sum_decimals(miner_payouts.values().copied());
 

--- a/crates/basilica-validator/src/metrics/prometheus_metrics.rs
+++ b/crates/basilica-validator/src/metrics/prometheus_metrics.rs
@@ -199,6 +199,56 @@ impl ValidatorPrometheusMetrics {
             "Current validation state of nodes (0=not in state, 1=current, 2=failed)"
         );
 
+        // Incentive pool metrics
+        describe_gauge!(
+            "basilica_validator_incentive_pool_usd_required",
+            "USD required to pay all miners this epoch"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_pool_usd_emission_capacity",
+            "USD emission capacity this epoch"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_config_target_count",
+            "Configured target node count per GPU category"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_config_price_per_gpu_cents",
+            "Configured price per GPU per hour in cents per category"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_config_window_hours",
+            "Resolved vesting window hours per GPU category"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_config_revenue_share_pct",
+            "Configured revenue share percentage"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_config_slash_pct",
+            "Configured slash percentage"
+        );
+        describe_counter!(
+            "basilica_validator_weight_setting_total",
+            "Total weight setting attempts by outcome"
+        );
+        describe_gauge!(
+            "basilica_validator_alpha_price_usd",
+            "Current alpha token price in USD"
+        );
+        describe_gauge!(
+            "basilica_validator_tao_price_usd",
+            "Current TAO token price in USD"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_miner_cu_total",
+            "Total CU amount with pending vesting per miner per GPU category"
+        );
+        describe_gauge!(
+            "basilica_validator_incentive_miner_cu_vested_pct",
+            "Cumulative CU vesting progress (0-100) per miner per GPU category"
+        );
+
         // Billing telemetry metrics
         describe_counter!(
             "basilica_validator_billing_telemetry_collected_total",
@@ -715,6 +765,78 @@ impl ValidatorPrometheusMetrics {
             )
             .set(0.0);
         }
+    }
+
+    // ── Incentive pool metrics ──
+
+    pub fn set_incentive_pool_usd_required(&self, usd: f64) {
+        gauge!("basilica_validator_incentive_pool_usd_required").set(usd);
+    }
+
+    pub fn set_incentive_pool_usd_emission_capacity(&self, usd: f64) {
+        gauge!("basilica_validator_incentive_pool_usd_emission_capacity").set(usd);
+    }
+
+    pub fn set_incentive_config_gpu_category(
+        &self,
+        gpu_category: &str,
+        target_count: u32,
+        price_per_gpu_cents: u32,
+        window_hours: u32,
+    ) {
+        let cat = gpu_category.to_string();
+        gauge!("basilica_validator_incentive_config_target_count",
+            "gpu_category" => cat.clone()
+        )
+        .set(target_count as f64);
+        gauge!("basilica_validator_incentive_config_price_per_gpu_cents",
+            "gpu_category" => cat.clone()
+        )
+        .set(price_per_gpu_cents as f64);
+        gauge!("basilica_validator_incentive_config_window_hours",
+            "gpu_category" => cat
+        )
+        .set(window_hours as f64);
+    }
+
+    pub fn set_incentive_config_global(&self, revenue_share_pct: Option<u32>, slash_pct: u32) {
+        gauge!("basilica_validator_incentive_config_revenue_share_pct")
+            .set(revenue_share_pct.unwrap_or(0) as f64);
+        gauge!("basilica_validator_incentive_config_slash_pct").set(slash_pct as f64);
+    }
+
+    pub fn record_weight_setting(&self, success: bool) {
+        let status = if success { "success" } else { "error" };
+        counter!("basilica_validator_weight_setting_total", "status" => status).increment(1);
+    }
+
+    pub fn set_alpha_price_usd(&self, price: f64) {
+        gauge!("basilica_validator_alpha_price_usd").set(price);
+    }
+
+    pub fn set_tao_price_usd(&self, price: f64) {
+        gauge!("basilica_validator_tao_price_usd").set(price);
+    }
+
+    pub fn set_incentive_miner_cu(
+        &self,
+        miner_uid: u16,
+        gpu_category: &str,
+        cu_total: f64,
+        cu_vested_pct: f64,
+    ) {
+        let uid = miner_uid.to_string();
+        let cat = gpu_category.to_string();
+        gauge!("basilica_validator_incentive_miner_cu_total",
+            "miner_uid" => uid.clone(),
+            "gpu_category" => cat.clone()
+        )
+        .set(cu_total);
+        gauge!("basilica_validator_incentive_miner_cu_vested_pct",
+            "miner_uid" => uid,
+            "gpu_category" => cat
+        )
+        .set(cu_vested_pct);
     }
 
     pub fn record_billing_telemetry_collected(&self, rental_id: &str) {


### PR DESCRIPTION
## Summary

- Add 12 Prometheus metrics for the incentive pool: pool USD required/capacity, alpha/TAO token prices, per-GPU-category incentive config (target count, price, window hours), revenue share/slash config, weight-setting success/error counter, and per-miner CU totals with vesting progress
- Refactor per-miner payout breakdown into a shared `MinerCategoryDetail` struct computed inside `compute_incentive_pool`, eliminating the ~120-line duplicate `compute_miner_breakdown` pass in `weight_setter.rs`
- Add `#[instrument]` tracing spans on `attempt_weight_setting`, `compute_incentive_pool_weights`, `compute_incentive_pool`, and `submit_weights_to_chain`

Closes #413