### PR TITLE
fix(validator): resolve SQLite contention and harden prod config

### DIFF
--- a/crates/basilica-validator/src/config/main_config.rs
+++ b/crates/basilica-validator/src/config/main_config.rs
@@ -377,7 +377,7 @@ impl Default for StorageValidationConfig {
 }
 
 fn default_min_required_storage_bytes() -> u64 {
-    1_099_511_627_776 // 1TB in bytes
+    109_951_162_777 // 0.1TB in bytes
 }
 
 fn default_docker_image() -> String {

--- a/crates/basilica-validator/src/persistence/simple_persistence.rs
+++ b/crates/basilica-validator/src/persistence/simple_persistence.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
+use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Row, SqlitePool};
 use std::str::FromStr;
 use tracing::info;
@@ -57,17 +58,28 @@ impl SimplePersistence {
             format!("{db_url}?mode=rwc")
         };
 
-        let pool = sqlx::SqlitePool::connect(&final_url).await?;
+        let pool = SqlitePoolOptions::new()
+            .max_connections(16)
+            .min_connections(2)
+            .acquire_timeout(std::time::Duration::from_secs(30))
+            .idle_timeout(Some(std::time::Duration::from_secs(600)))
+            .connect(&final_url)
+            .await?;
 
         sqlx::query("PRAGMA journal_mode = WAL")
             .execute(&pool)
             .await?;
-        sqlx::query("PRAGMA busy_timeout = 5000")
+        sqlx::query("PRAGMA busy_timeout = 30000")
             .execute(&pool)
             .await?;
         sqlx::query("PRAGMA synchronous = NORMAL")
             .execute(&pool)
             .await?;
+        sqlx::query("PRAGMA wal_autocheckpoint = 1000")
+            .execute(&pool)
+            .await?;
+
+        info!("SQLite pool initialized: max_connections=16, busy_timeout=30s, WAL mode");
 
         Ok(Self { pool })
     }

--- a/scripts/validator/compose.prod.yml
+++ b/scripts/validator/compose.prod.yml
@@ -8,6 +8,14 @@ services:
 
     privileged: true
 
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+      nproc:
+        soft: 4096
+        hard: 4096
+
     environment:
       - RUST_LOG=info,sqlx::query=error,sqlx::query_as=error,basilica_validator=debug,alloy_rpc_client=info
       - RUST_BACKTRACE=1


### PR DESCRIPTION
## Summary

- **SQLite write contention fix**: replaced default `SqlitePool::connect()` with explicit `SqlitePoolOptions` (16 max connections, 30s busy_timeout, WAL autocheckpoint). Root cause of `Failed to query non-terminal rentals` errors during concurrent validation bursts.
- **Production compose hardening**: added `ulimits` (nofile=65536, nproc=4096) to match systemd service parity.
- **Config alignment**: corrected `min_required_storage_bytes` default from 1TB to 0.1TB to match `validator.toml.example`.

## Root Cause Analysis

During full validation of miners with many nodes (e.g., 7+ concurrent), multiple async tasks competed for SQLite writes (verification results, misbehaviour checks, availability logs, rental monitoring, billing). The previous 5s `busy_timeout` was insufficient, causing `SQLITE_BUSY` (code 5) errors and cascading `Failed to query non-terminal rentals` failures.

### Evidence from production (`basilica-prod-1xB200-01`)

| Metric | Value |
|---|---|
| `database is locked` errors (24h) | 1 confirmed at 18:40:44 UTC |
| `Failed to query non-terminal rentals` (6h) | 19, in two bursts |
| Container ulimit (nofile) | 524,288 -- NOT the cause |
| Open FDs | 39 -- NOT exhausted |

## Test plan

- [x] `cargo check -p basilica-validator` -- compiles clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- zero warnings
- [x] `cargo fmt --all` -- formatted
- [x] `cargo test -p basilica-validator` -- 6 passed, 0 failed
- [ ] Deploy to `basilica-prod-1xB200-01` and verify no `database is locked` errors over 6h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced default storage validation threshold from 1TB to 0.1TB
  * Enhanced database connection pooling with improved timeout configuration

* **Chores**
  * Added container resource limits for process and file descriptor constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->