### PR TITLE
fix(validator): add init process to reap zombie child processes

### DIFF
--- a/scripts/validator/compose.dev.yml
+++ b/scripts/validator/compose.dev.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: scripts/validator/Dockerfile
     container_name: basilica-validator-dev
     restart: unless-stopped
+    init: true
 
     environment:
       - RUST_LOG=debug

--- a/scripts/validator/compose.local.yml
+++ b/scripts/validator/compose.local.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: scripts/validator/Dockerfile
     container_name: basilica-validator-local
     restart: unless-stopped
+    init: true
 
     environment:
       - RUST_LOG=debug

--- a/scripts/validator/compose.prod.yml
+++ b/scripts/validator/compose.prod.yml
@@ -7,6 +7,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
     privileged: true
+    init: true
 
     ulimits:
       nofile:


### PR DESCRIPTION
## Summary

- Adds `init: true` to the validator service in all compose files (prod, dev, local), injecting `tini` as PID 1 to reap orphaned zombie processes.

## Problem

The validator container runs `basilica-validator` as PID 1, which is not designed to reap child processes. When subprocesses like `validator-binary` are killed and restarted, their orphaned children (`pkill`, `sh`) become zombies that accumulate indefinitely. On production, 15 zombies accumulated in ~45 minutes.

**Evidence (31.22.104.49, 2026-04-09 before fix):**
```
$ docker exec basilica-validator ps aux | grep -c defunct
15
```

**After fix:**
```
$ docker inspect basilica-validator --format "Init: {{.HostConfig.Init}}"
Init: true
$ docker exec basilica-validator ps aux | head -3
USER  PID %CPU  STAT COMMAND
root    1  0.0  Ss   /sbin/docker-init -- /usr/local/bin/basilica-validator ...
root    7  3.7  Sl   /usr/local/bin/basilica-validator ...
```

## Note

A separate code-level fix is needed for `ssh-keyscan` zombies whose parent (`basilica-validator`) is still alive -- tini only reaps orphans reparented to PID 1. Tracked in one-covenant/basilica-backend#282.

## Test plan

- [x] Verified on production (31.22.104.49): PID 1 is `/sbin/docker-init`, validator healthy, validator-binary restart orphans are reaped
- [ ] Confirm no behavioral changes to validator startup or healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container initialization configuration for the validator service across development, local, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->