### PR TITLE
feat(common): add Shadeform variant to CloudProvider enum

### DIFF
--- a/crates/basilica-common/src/types.rs
+++ b/crates/basilica-common/src/types.rs
@@ -770,6 +770,8 @@ pub enum CloudProvider {
     Verda,
     /// Mass Compute - VM-based GPU rental provider (polling-based, no webhooks)
     MassCompute,
+    /// Shadeform - multi-cloud GPU aggregator (routes to underlying clouds like hyperstack, tensordock)
+    Shadeform,
     /// The Priory - VIP managed machines (not a real cloud provider, but uses Deployment model)
     Vip,
 }
@@ -782,6 +784,7 @@ impl CloudProvider {
             CloudProvider::HydraHost => "hydrahost",
             CloudProvider::Verda => "verda",
             CloudProvider::MassCompute => "masscompute",
+            CloudProvider::Shadeform => "shadeform",
             CloudProvider::Vip => "vip",
         }
     }
@@ -804,6 +807,7 @@ impl FromStr for CloudProvider {
             "hydrahost" => Ok(CloudProvider::HydraHost),
             "verda" => Ok(CloudProvider::Verda),
             "masscompute" | "mass_compute" | "mass-compute" => Ok(CloudProvider::MassCompute),
+            "shadeform" | "shade_form" | "shade-form" => Ok(CloudProvider::Shadeform),
             "vip" => Ok(CloudProvider::Vip),
             _ => Err(format!("Unknown provider: {}", s)),
         }
@@ -849,6 +853,7 @@ mod cloud_provider_tests {
         assert_eq!(CloudProvider::HydraHost.as_str(), "hydrahost");
         assert_eq!(CloudProvider::Verda.as_str(), "verda");
         assert_eq!(CloudProvider::MassCompute.as_str(), "masscompute");
+        assert_eq!(CloudProvider::Shadeform.as_str(), "shadeform");
         assert_eq!(CloudProvider::Vip.as_str(), "vip");
     }
 
@@ -879,6 +884,30 @@ mod cloud_provider_tests {
         assert_eq!(
             "MASSCOMPUTE".parse::<CloudProvider>().unwrap(),
             CloudProvider::MassCompute
+        );
+    }
+
+    #[test]
+    fn test_cloud_provider_from_str_shadeform() {
+        assert_eq!(
+            "shadeform".parse::<CloudProvider>().unwrap(),
+            CloudProvider::Shadeform
+        );
+        assert_eq!(
+            "shade_form".parse::<CloudProvider>().unwrap(),
+            CloudProvider::Shadeform
+        );
+        assert_eq!(
+            "shade-form".parse::<CloudProvider>().unwrap(),
+            CloudProvider::Shadeform
+        );
+        assert_eq!(
+            "Shadeform".parse::<CloudProvider>().unwrap(),
+            CloudProvider::Shadeform
+        );
+        assert_eq!(
+            "SHADEFORM".parse::<CloudProvider>().unwrap(),
+            CloudProvider::Shadeform
         );
     }
 
@@ -931,6 +960,7 @@ mod cloud_provider_tests {
             (CloudProvider::HydraHost, "\"hydrahost\""),
             (CloudProvider::Verda, "\"verda\""),
             (CloudProvider::MassCompute, "\"masscompute\""),
+            (CloudProvider::Shadeform, "\"shadeform\""),
             (CloudProvider::Vip, "\"vip\""),
         ];
 
@@ -949,6 +979,31 @@ mod cloud_provider_tests {
                 expected_json
             );
         }
+    }
+
+    #[test]
+    fn test_gpu_offering_with_shadeform_provider() {
+        let json = r#"{
+            "id": "shadeform-hyperstack-H100-canada-1",
+            "provider": "shadeform",
+            "gpu_type": "H100",
+            "gpu_memory_gb_per_gpu": 80,
+            "gpu_count": 8,
+            "interconnect": "NVLink",
+            "system_memory_gb": 1800,
+            "vcpu_count": 208,
+            "region": "canada-1",
+            "hourly_rate_per_gpu": "2.10",
+            "availability": true,
+            "is_spot": false,
+            "fetched_at": "2025-01-01T00:00:00Z"
+        }"#;
+
+        let offering: GpuOffering = serde_json::from_str(json).unwrap();
+        assert_eq!(offering.provider, CloudProvider::Shadeform);
+        assert_eq!(offering.gpu_type, GpuCategory::H100);
+        assert_eq!(offering.gpu_count, 8);
+        assert_eq!(offering.region, "canada-1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prepares CLI/SDK/Python SDK for the upcoming Shadeform provider integration in the backend (basilica-backend PR #270).

## Why this matters

Without this change, any `GpuOffering` returned from `/secure-cloud/gpu-prices` with `provider: "shadeform"` fails to deserialize on clients using this SDK. Because serde fails on any single item in a `Vec<GpuOffering>`, the **entire response** fails -- including existing Hyperstack/Verda/MassCompute offerings, not just Shadeform ones. This would break `basilica ls --compute citadel` and `basilica up --compute citadel` for every client on a pre-Shadeform SDK.

## What changed

- Adds `CloudProvider::Shadeform` variant
- Adds `as_str()` mapping to `"shadeform"`
- Adds `FromStr` match with aliases (`"shadeform" | "shade_form" | "shade-form"`)
- Adds 3 new tests (from_str aliases, serde roundtrip coverage, full GpuOffering deserialization)

Matches the pattern used when `MassCompute` was added (commit `683ba3fe`). Same file, same surgical surface, +55 lines.

## Deploy ordering (important)

This PR must merge and release **before** basilica-backend enables Shadeform in production config:

1. Merge + release this PR (bump basilica-cli, basilica-sdk, basilica-sdk-python)
2. Users upgrade CLI/SDK (or accept breakage on old versions once Shadeform is enabled server-side)
3. Merge basilica-backend PR #270 and deploy images (code-only, Shadeform config still disabled -- zero user impact)
4. Enable `BASILICA_AGGREGATOR_PROVIDERS_SHADEFORM_API_KEY` in API config (activates offerings)

## Test plan

- [x] `cargo test -p basilica-common cloud_provider` -- 10/10 pass (3 new)
- [x] `cargo check -p basilica-common -p basilica-sdk -p basilica-cli -p basilica-sdk-python` -- clean
- [x] Verified no exhaustive `match` on `CloudProvider` exists outside `as_str()` that would break from the new variant
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Shadeform as a cloud provider option in GPU offerings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->