### PR TITLE
chore(release): basilica-cli 0.27.0, basilica-sdk 0.27.0, basilica-sdk-python 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basilica-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.21.7",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64 0.21.7",
  "basilica-common",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-04-20
+
+### Added
+- Shadeform cloud provider support (`CloudProvider::Shadeform`). The CLI
+  can now list, filter, and display GPU offerings served from the
+  Shadeform multi-cloud aggregator without deserialization errors.
+
 ## [0.26.0] - 2026-04-18
 
 ### Added

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-cli"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Unified CLI for Basilica GPU rental and network management"

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-04-20
+
+### Added
+- Shadeform cloud provider support. Secure cloud GPU listings that
+  include Shadeform offerings now deserialize successfully instead of
+  failing the entire response.
+
 ## [0.26.0] - 2026-04-18
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.26.0"
+version = "0.27.0"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-04-20
+
+### Added
+- Shadeform cloud provider support (`CloudProvider::Shadeform`).
+  `GpuOffering` responses from `/secure-cloud/gpu-prices` that include
+  Shadeform offerings now deserialize successfully instead of failing
+  the entire response.
+
 ## [0.26.0] - 2026-04-18
 
 ### Added

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "SDK for interacting with the Basilica GPU rental network"


### PR DESCRIPTION
## Summary

Release the Shadeform CloudProvider variant added in #425.

## Why

This release must ship **before** basilica-backend enables Shadeform server-side. Otherwise any `GpuOffering` in a `/secure-cloud/gpu-prices` response with `provider: \"shadeform\"` fails to deserialize on older clients and takes down the whole response (not just Shadeform offerings) for every CLI/SDK user.

## Versions

- `basilica-cli` 0.26.0 → 0.27.0
- `basilica-sdk` 0.26.0 → 0.27.0
- `basilica-sdk-python` 0.26.0 → 0.27.0 (both Cargo.toml and pyproject.toml)

## What lands with this release

Only the CloudProvider::Shadeform variant from #425. No other user-facing changes.

## Post-merge

Tag releases to trigger the release workflows:
- `basilica-cli-v0.27.0` → multi-platform binaries + GitHub release
- `basilica-sdk-python-v0.27.0` → PyPI wheels (Linux x86_64/ARM64, macOS Intel/ARM, Windows)

## Test plan

- [x] `cargo check -p basilica-cli -p basilica-sdk -p basilica-sdk-python -p basilica-common` clean at 0.27.0
- [x] CHANGELOGs updated in each crate
- [x] Cargo.lock regenerated
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shadeform cloud provider support to the CLI and SDK, enabling listing and filtering of Shadeform GPU offerings.

* **Bug Fixes**
  * Fixed deserialization errors when GPU offerings include Shadeform providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->