### PR TITLE
feat(common): add ComputeBroker variant to CloudProvider enum

### DIFF
--- a/crates/basilica-common/src/types.rs
+++ b/crates/basilica-common/src/types.rs
@@ -772,6 +772,14 @@ pub enum CloudProvider {
     MassCompute,
     /// Shadeform - multi-cloud GPU aggregator (routes to underlying clouds like hyperstack, tensordock)
     Shadeform,
+    /// Compute Broker - internal Basilica service that owns a finite, admin-managed inventory
+    /// of underlying machines purchased from fixed-contract suppliers (e.g. Contabo). Exposes
+    /// inventory through the standard Provider-trait REST API; from the aggregator's perspective
+    /// it is just another datacenter. Backend-specific quirks (monthly contracts, no pricing API,
+    /// re-image between tenants) live inside the broker, not in the platform.
+    /// Tracking issue: basilica-backend#326
+    #[serde(rename = "compute-broker")]
+    ComputeBroker,
     /// The Priory - VIP managed machines (not a real cloud provider, but uses Deployment model)
     Vip,
 }
@@ -785,6 +793,7 @@ impl CloudProvider {
             CloudProvider::Verda => "verda",
             CloudProvider::MassCompute => "masscompute",
             CloudProvider::Shadeform => "shadeform",
+            CloudProvider::ComputeBroker => "compute-broker",
             CloudProvider::Vip => "vip",
         }
     }
@@ -808,6 +817,7 @@ impl FromStr for CloudProvider {
             "verda" => Ok(CloudProvider::Verda),
             "masscompute" | "mass_compute" | "mass-compute" => Ok(CloudProvider::MassCompute),
             "shadeform" | "shade_form" | "shade-form" => Ok(CloudProvider::Shadeform),
+            "compute-broker" | "compute_broker" | "computebroker" => Ok(CloudProvider::ComputeBroker),
             "vip" => Ok(CloudProvider::Vip),
             _ => Err(format!("Unknown provider: {}", s)),
         }
@@ -854,6 +864,7 @@ mod cloud_provider_tests {
         assert_eq!(CloudProvider::Verda.as_str(), "verda");
         assert_eq!(CloudProvider::MassCompute.as_str(), "masscompute");
         assert_eq!(CloudProvider::Shadeform.as_str(), "shadeform");
+        assert_eq!(CloudProvider::ComputeBroker.as_str(), "compute-broker");
         assert_eq!(CloudProvider::Vip.as_str(), "vip");
     }
 
@@ -912,6 +923,30 @@ mod cloud_provider_tests {
     }
 
     #[test]
+    fn test_cloud_provider_from_str_compute_broker() {
+        assert_eq!(
+            "compute-broker".parse::<CloudProvider>().unwrap(),
+            CloudProvider::ComputeBroker
+        );
+        assert_eq!(
+            "compute_broker".parse::<CloudProvider>().unwrap(),
+            CloudProvider::ComputeBroker
+        );
+        assert_eq!(
+            "computebroker".parse::<CloudProvider>().unwrap(),
+            CloudProvider::ComputeBroker
+        );
+        assert_eq!(
+            "ComputeBroker".parse::<CloudProvider>().unwrap(),
+            CloudProvider::ComputeBroker
+        );
+        assert_eq!(
+            "COMPUTE-BROKER".parse::<CloudProvider>().unwrap(),
+            CloudProvider::ComputeBroker
+        );
+    }
+
+    #[test]
     fn test_cloud_provider_from_str_existing() {
         assert_eq!(
             "hyperstack".parse::<CloudProvider>().unwrap(),
@@ -961,6 +996,7 @@ mod cloud_provider_tests {
             (CloudProvider::Verda, "\"verda\""),
             (CloudProvider::MassCompute, "\"masscompute\""),
             (CloudProvider::Shadeform, "\"shadeform\""),
+            (CloudProvider::ComputeBroker, "\"compute-broker\""),
             (CloudProvider::Vip, "\"vip\""),
         ];
 
@@ -1004,6 +1040,32 @@ mod cloud_provider_tests {
         assert_eq!(offering.gpu_type, GpuCategory::H100);
         assert_eq!(offering.gpu_count, 8);
         assert_eq!(offering.region, "canada-1");
+    }
+
+    #[test]
+    fn test_gpu_offering_with_compute_broker_provider() {
+        // Mirrors the offering ID format declared in
+        // docs/architecture/COMPUTE-BROKER-ARCHITECTURE.md §16.1:
+        //   compute-broker-<backend>-<product_id>-<region>
+        let json = r#"{
+            "id": "compute-broker-contabo-V92-EU",
+            "provider": "compute-broker",
+            "gpu_type": "Other",
+            "gpu_memory_gb_per_gpu": 0,
+            "gpu_count": 0,
+            "system_memory_gb": 8,
+            "vcpu_count": 4,
+            "region": "EU",
+            "hourly_rate_per_gpu": "0.12",
+            "availability": true,
+            "is_spot": false,
+            "fetched_at": "2026-04-26T00:00:00Z"
+        }"#;
+
+        let offering: GpuOffering = serde_json::from_str(json).unwrap();
+        assert_eq!(offering.provider, CloudProvider::ComputeBroker);
+        assert_eq!(offering.region, "EU");
+        assert_eq!(offering.id, "compute-broker-contabo-V92-EU");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prerequisite for the upcoming `basilica-compute-broker` service (basilica-backend [#326](https://github.com/one-covenant/basilica-backend/issues/326)). Adds `CloudProvider::ComputeBroker` so the SDK can deserialize `GpuOffering` rows with `provider=\"compute-broker\"` once the backend ships.

Single file change (+62 lines) following the precedent set by Denvr (`20d3b983`), Shadeform (`738f6e27`), and MassCompute (`683ba3fe`).

## Why this PR ships before any backend change

`basilica-sdk` re-exports `GpuOffering` directly from `basilica-common` (`crates/basilica-sdk/src/types.rs:541`). `GpuOffering.provider` is the strongly-typed `CloudProvider` enum. If a backend deployment shipped `provider=\"compute-broker\"` on the wire before every CLI/SDK had this variant, the **entire** `Vec<GpuOffering>` response from `/secure-cloud/gpu-prices` would fail to deserialize on the client side — not just the broker rows.

This is the same regression mode documented in the Shadeform onboarding architecture doc (basilica-backend `docs/architecture/SECURE-CLOUD-PROVIDER-ONBOARDING-ARCHITECTURE.md` §6) and the reason Phase P1 of #326 must merge and release before Phase P3 ships.

## Wire form

The architecture doc's offering ID format is `compute-broker-<backend>-<product_id>-<region>` (e.g. `compute-broker-contabo-V92-EU`), so the wire form is `\"compute-broker\"` with a hyphen.

The default `#[serde(rename_all = \"lowercase\")]` on `CloudProvider` would have produced `\"computebroker\"`; this PR overrides with `#[serde(rename = \"compute-broker\")]` on the variant.

`FromStr` accepts case-insensitive aliases: `compute-broker`, `compute_broker`, `computebroker`, `ComputeBroker`.

## Tests

All in `crates/basilica-common/src/types.rs::cloud_provider_tests` (12 tests pass; clippy clean):

- `test_cloud_provider_as_str` — extended with `compute-broker`
- `test_cloud_provider_from_str_compute_broker` — **new**, covers all 5 alias spellings
- `test_cloud_provider_serde_all_variants` — extended with the new variant
- `test_gpu_offering_with_compute_broker_provider` — **new**, deserializes a `GpuOffering` whose `id` matches the offering-id format the broker will emit (`compute-broker-contabo-V92-EU`); this is the exact regression probe for the SDK-break-on-unknown-provider class

## Verification

\`\`\`
cargo test -p basilica-common --lib types::cloud_provider
# 12 passed; 0 failed; 0 ignored

cargo clippy -p basilica-common --all-targets -- -D warnings
# clean

cargo build -p basilica-sdk -p basilica-cli
# clean
\`\`\`

## What this PR does **not** do

- Does **not** bump `basilica-cli` / `basilica-sdk` / `basilica-sdk-python` versions — that's a follow-up release PR (P1b in #326's plan), opened **after** this merges, that publishes the new variant to PyPI / crates so `basilica-backend` can then ship the broker without breaking existing clients.
- Does **not** implement any backend logic — the variant is inert until basilica-backend [#326](https://github.com/one-covenant/basilica-backend/issues/326) Phase P3/P4 lands.

## Merge note

Per project convention (`feedback_never_squash`), this should be merged with `--merge`, not `--squash`.

## References

- Tracking issue: basilica-backend [#326](https://github.com/one-covenant/basilica-backend/issues/326)
- Companion architecture doc (private repo): \`docs/architecture/COMPUTE-BROKER-ARCHITECTURE.md\` — §16.1 offering-id format, Appendix A Phase-0 findings
- Onboarding pattern this PR follows: \`docs/architecture/SECURE-CLOUD-PROVIDER-ONBOARDING-ARCHITECTURE.md\` §6 cross-repo release choreography
- Precedent commits in this repo: Denvr `20d3b983`, Shadeform `738f6e27`, MassCompute `683ba3fe`

## Test plan

- [x] `cargo test -p basilica-common --lib types::cloud_provider` — 12 / 12 pass
- [x] `cargo clippy -p basilica-common --all-targets -- -D warnings` — clean
- [x] `cargo build -p basilica-sdk -p basilica-cli` — clean (downstream consumers compile)
- [x] New regression probe `test_gpu_offering_with_compute_broker_provider` deserializes the exact offering-id format the broker will emit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ComputeBroker as a supported cloud provider with full parsing and serialization support.

* **Tests**
  * Extended test coverage to validate ComputeBroker provider handling and GPU offering deserialization with the new provider format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->