### PR TITLE
chore(release): basilica-cli 0.28.0, basilica-sdk 0.28.0, basilica-sdk-python 0.28.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,25 @@ jobs:
           shared-key: "shared-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
@@ -167,10 +182,25 @@ jobs:
           shared-key: "shared-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
@@ -206,10 +236,25 @@ jobs:
           shared-key: "shared-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
@@ -267,10 +312,25 @@ jobs:
           shared-key: "shared-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
@@ -328,10 +388,25 @@ jobs:
           shared-key: "shared-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
@@ -371,10 +446,25 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
 
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
@@ -169,7 +169,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
@@ -208,7 +208,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
@@ -269,7 +269,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
@@ -330,7 +330,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache and install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
@@ -373,7 +373,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache and install system dependencies

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -124,10 +124,25 @@ jobs:
           python-version: '3.10'
 
       - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "25.9"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=25.9
+          PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          DOWNLOAD_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/${PROTOC_ZIP} "${DOWNLOAD_URL}"; then
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "ERROR: protoc download failed after 5 attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+          sudo unzip -q -o /tmp/${PROTOC_ZIP} -d /usr/local
+          rm -f /tmp/${PROTOC_ZIP}
+          protoc --version
 
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
-          version: "25.x"
+          version: "25.9"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build sdist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basilica-cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.21.7",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64 0.21.7",
  "basilica-common",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-04-27
+
+### Added
+- Denvr Data cloud provider support (`CloudProvider::Denvr`). The CLI
+  can now list, filter, and display GPU offerings served from Denvr's
+  Hou1 and Msc1 clusters without deserialization errors.
+
 ## [0.27.0] - 2026-04-20
 
 ### Added

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Denvr Data cloud provider support (`CloudProvider::Denvr`). The CLI
   can now list, filter, and display GPU offerings served from Denvr's
   Hou1 and Msc1 clusters without deserialization errors.
+- Card payment support in `basilica fund`. Users can top up their
+  account with a credit or debit card via a hosted Stripe checkout
+  session alongside the existing TAO funding flow.
+- `basilica fund list` now renders card payment history alongside
+  TAO deposits, with hyperlinked receipt and invoice artifacts in
+  the Invoice column and status filtering on the listing.
+
+### Changed
+- Card funding cap raised from $1000 to $5000 per checkout session.
+
+### Security
+- Bumped rustls-webpki to 0.103.13 to address RUSTSEC-2026-0104
+  (reachable panic in CRL parsing).
 
 ## [0.27.0] - 2026-04-20
 

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-cli"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Unified CLI for Basilica GPU rental and network management"

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-04-27
+
+### Added
+- Denvr Data cloud provider support. Secure cloud GPU listings that
+  include Denvr offerings now deserialize successfully instead of
+  failing the entire response.
+
+### Fixed
+- `basilica.__version__` now reflects the installed package version.
+  Previously the module exposed a hardcoded literal that drifted from
+  `pyproject.toml` across releases (e.g. 0.27.0 wheels reported
+  `__version__ == "0.17.0"`). The attribute is now resolved at import
+  time via `importlib.metadata.version("basilica-sdk")` so it can no
+  longer drift.
+
 ## [0.27.0] - 2026-04-20
 
 ### Added

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time via `importlib.metadata.version("basilica-sdk")` so it can no
   longer drift.
 
+### Security
+- Bumped rustls-webpki to 0.103.13 in the bundled native extension to
+  address RUSTSEC-2026-0104 (reachable panic in CRL parsing).
+
 ## [0.27.0] - 2026-04-20
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.27.0"
+version = "0.28.0"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -210,7 +210,12 @@ def _build_inference_health_check(port: int) -> HealthCheckConfig:
     )
 
 
-__version__ = "0.17.0"
+try:
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    __version__ = _pkg_version("basilica-sdk")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 __all__ = [
     # Main client
     "BasilicaClient",

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GpuOffering` responses from `/secure-cloud/gpu-prices` that include
   Denvr offerings now deserialize successfully instead of failing
   the entire response.
+- Card payment APIs on the payments client: create checkout session,
+  paginated listing of card purchases, status filtering, and receipt
+  + invoice metadata fields on each session.
+
+### Security
+- Bumped rustls-webpki to 0.103.13 to address RUSTSEC-2026-0104
+  (reachable panic in CRL parsing).
 
 ## [0.27.0] - 2026-04-20
 

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-04-27
+
+### Added
+- Denvr Data cloud provider support (`CloudProvider::Denvr`).
+  `GpuOffering` responses from `/secure-cloud/gpu-prices` that include
+  Denvr offerings now deserialize successfully instead of failing
+  the entire response.
+
 ## [0.27.0] - 2026-04-20
 
 ### Added

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "SDK for interacting with the Basilica GPU rental network"


### PR DESCRIPTION
## Summary

Cuts 0.28.0 for basilica-cli, basilica-sdk, and basilica-sdk-python. Mirrors the Shadeform release (#426) cadence.

This release captures three streams of work that landed on `main` since 0.27.0:

- **Denvr Data cloud provider** (#437, already merged into `main`). Adds `CloudProvider::Denvr` so existing clients deserialize `GpuOffering` responses containing `provider: "denvr"` instead of failing the entire `Vec<GpuOffering>`.
- **Stripe / card payments surface** (#438 + follow-ups). New `basilica fund` card checkout flow, `basilica fund list` rendering of card history with receipt/invoice hyperlinks, $1000 → $5000 cap, plus the corresponding card-purchase APIs on `basilica-sdk`.
- **`basilica.__version__` drift fix** (this PR). The Python SDK literal had been frozen at `0.17.0` while `pyproject.toml` advanced through 0.18 → 0.27. `__version__` is now resolved at import time via `importlib.metadata.version("basilica-sdk")` so it can never drift again. User report that motivated the fix: 0.27.0 wheel installed correctly but reported `basilica.__version__ == "0.17.0"`.

Plus a transitive `rustls-webpki` 0.103.13 bump for RUSTSEC-2026-0104 (reachable panic in CRL parsing). Lockfile-only.

## Why this lands before basilica-backend#334

Without the Denvr variant shipped on the client side, the moment basilica-backend starts emitting `provider: "denvr"` over the wire, every existing CLI/SDK client fails to deserialize the entire `Vec<GpuOffering>` response — not just the Denvr rows. Cross-repo gate per the architecture doc §6.

## Test plan

- [x] `cargo build -p basilica-cli -p basilica-sdk -p basilica-sdk-python` clean
- [x] `cargo test -p basilica-common --lib` — 292 passed; cloud_provider filter — 12 passed including `test_cloud_provider_from_str_denvr` and `test_gpu_offering_with_denvr_provider`
- [x] `__version__` resolution verified against a synthesized `basilica-sdk-0.28.0.dist-info` — module attribute reads from package metadata
- [ ] CI green
- [ ] After merge, push `basilica-cli-v0.28.0` and `basilica-sdk-python-v0.28.0` tags to fire `release-cli.yml` and `release-python-sdk.yml`
- [ ] `pip install basilica-sdk==0.28.0` and confirm `basilica.__version__ == "0.28.0"` end-to-end
- [ ] basilica-backend#334 merges immediately after publish confirmation

## References

- Variant PR (already merged): #437
- Backend integration (gated by this): one-covenant/basilica-backend#334
- Tracking issue: one-covenant/basilica-backend#332
- Prior precedent: #426 (Shadeform 0.27.0 release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Denvr Data cloud provider with GPU offerings.
  * Added card payment funding via Stripe checkout for `basilica fund`.
  * Increased card funding cap to $5,000 per session.
  * Enhanced funding history with payment receipts and status filtering.

* **Bug Fixes**
  * Fixed version detection in Python SDK.

* **Security**
  * Updated certificate validation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->