### PR TITLE
fix(cli): correct card funding minimum to $10

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/fund/card.rs
+++ b/crates/basilica-cli/src/cli/handlers/fund/card.rs
@@ -95,7 +95,10 @@ fn prompt_amount_usd() -> Result<u32, CliError> {
             if (MIN_USD..=MAX_USD).contains(input) {
                 Ok(())
             } else {
-                Err(format!("Amount must be between ${} and ${}", MIN_USD, MAX_USD))
+                Err(format!(
+                    "Amount must be between ${} and ${}",
+                    MIN_USD, MAX_USD
+                ))
             }
         })
         .interact_text()

--- a/crates/basilica-cli/src/cli/handlers/fund/card.rs
+++ b/crates/basilica-cli/src/cli/handlers/fund/card.rs
@@ -95,7 +95,7 @@ fn prompt_amount_usd() -> Result<u32, CliError> {
             if (MIN_USD..=MAX_USD).contains(input) {
                 Ok(())
             } else {
-                Err("Amount must be between $10 and $5000")
+                Err(format!("Amount must be between ${} and ${}", MIN_USD, MAX_USD))
             }
         })
         .interact_text()
@@ -106,7 +106,9 @@ fn prompt_amount_usd() -> Result<u32, CliError> {
 fn map_create_error(err: ApiError) -> CliError {
     match &err {
         ApiError::BadRequest { message } => CliError::Internal(eyre!(
-            "Card purchase rejected: {message}. Amounts must be whole dollars between $10 and $5000."
+            "Card purchase rejected: {message}. Amounts must be whole dollars between ${} and ${}.",
+            MIN_USD,
+            MAX_USD
         )),
         ApiError::ServiceUnavailable => CliError::Internal(eyre!(
             "Card funding is not available right now. Try 'basilica fund --tao' to fund with TAO instead."

--- a/crates/basilica-cli/src/cli/handlers/fund/card.rs
+++ b/crates/basilica-cli/src/cli/handlers/fund/card.rs
@@ -22,8 +22,8 @@ use crate::{
 };
 
 /// `amount_cents` bounds the SDK accepts before even hitting the server.
-/// Matches basilica-stripe's default config of $1–$5000.
-const MIN_USD: u32 = 1;
+/// Matches basilica-stripe's default config of $10–$5000.
+const MIN_USD: u32 = 10;
 const MAX_USD: u32 = 5000;
 
 /// How often the poll loop checks purchase status.
@@ -95,7 +95,7 @@ fn prompt_amount_usd() -> Result<u32, CliError> {
             if (MIN_USD..=MAX_USD).contains(input) {
                 Ok(())
             } else {
-                Err("Amount must be between $1 and $5000")
+                Err("Amount must be between $10 and $5000")
             }
         })
         .interact_text()
@@ -106,7 +106,7 @@ fn prompt_amount_usd() -> Result<u32, CliError> {
 fn map_create_error(err: ApiError) -> CliError {
     match &err {
         ApiError::BadRequest { message } => CliError::Internal(eyre!(
-            "Card purchase rejected: {message}. Amounts must be whole dollars between $1 and $5000."
+            "Card purchase rejected: {message}. Amounts must be whole dollars between $10 and $5000."
         )),
         ApiError::ServiceUnavailable => CliError::Internal(eyre!(
             "Card funding is not available right now. Try 'basilica fund --tao' to fund with TAO instead."


### PR DESCRIPTION
The CLI advertised a $1 card-funding minimum in three places, but the server requires 1000 cents ($10). Inputs of $1–$9 passed client-side validation and then failed server-side as `BadRequest`.

Updates `MIN_USD`, the interactive validator error, and the `BadRequest` fallback string in `crates/basilica-cli/src/cli/handlers/fund/card.rs` so the advertised bound matches the server's actual floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated card funding minimum purchase amount from $1 to $10 USD. User-facing validation messages and API error responses now consistently reflect the new $10–$5,000 USD transaction range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->