### PR TITLE
feat(cli): show resume link for pending card payments in fund list

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Resume link for pending card purchases in `basilica fund list`
+
+## [0.28.0] - 2026-04-27
+
+### Added
+- Card funding via `basilica fund`
+- Card payment history in `basilica fund list`
+
 ## [0.27.0] - 2026-04-20
 
 ### Added

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -12,7 +12,7 @@ use basilica_sdk::{
     },
     AvailableNode,
 };
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, Utc};
 use console::style;
 use rust_decimal::Decimal;
 use std::{collections::HashMap, str::FromStr};
@@ -593,6 +593,7 @@ pub fn display_card_purchases(response: &ListCardPurchasesResponse) -> Result<()
                 link_cell(label, url)
             }
             Some((PrimaryLinkKind::Receipt, url)) => link_cell("Receipt", url),
+            Some((PrimaryLinkKind::Resume, url)) => link_cell("Resume", url),
             None => "-".to_string(),
         };
 
@@ -620,13 +621,18 @@ pub fn display_card_purchases(response: &ListCardPurchasesResponse) -> Result<()
 enum PrimaryLinkKind {
     Invoice,
     Receipt,
+    Resume,
 }
 
 /// Choose the single most informative link to surface per session.
 ///
-/// Prefer the hosted invoice page when present — it renders both the
-/// invoice detail and the payment confirmation, so showing the receipt
-/// alongside would be redundant.
+/// Completed sessions land on the hosted invoice page when present —
+/// it renders both the invoice detail and the payment confirmation,
+/// so a separate receipt link would be redundant. Pending sessions
+/// whose Stripe checkout has not yet expired fall through to a Resume
+/// link so users can pick up the existing checkout instead of starting
+/// a new session. A `None` `expires_at` is treated as resumable; only
+/// a known-past timestamp disqualifies the row.
 fn purchase_primary_link(
     purchase: &basilica_sdk::types::CardPurchaseSummary,
 ) -> Option<(PrimaryLinkKind, &str)> {
@@ -635,6 +641,11 @@ fn purchase_primary_link(
     }
     if let Some(url) = purchase.receipt_url.as_deref() {
         return Some((PrimaryLinkKind::Receipt, url));
+    }
+    if matches!(purchase.status, CardPurchaseStatus::Pending)
+        && purchase.expires_at.is_none_or(|t| t > Utc::now())
+    {
+        return Some((PrimaryLinkKind::Resume, &purchase.checkout_url));
     }
     None
 }
@@ -1384,10 +1395,95 @@ mod tests {
 
     #[test]
     fn pending_purchase_with_no_artifacts_has_no_link() {
-        // Freshly-created purchases (no webhooks landed yet) carry only
-        // `checkout_url`. The Invoice/Receipt cell collapses to `-`
-        // via the `None` arm in `display_card_purchases`.
+        // The shared `purchase()` helper hardcodes `status = Completed`,
+        // so a row with no invoice/receipt artifacts collapses to `-`.
+        // The Pending-row case is exercised by the Resume tests below.
         let purchase = purchase(None, None, None);
+        assert!(purchase_primary_link(&purchase).is_none());
+    }
+
+    fn purchase_with(
+        status: CardPurchaseStatus,
+        expires_at: Option<chrono::DateTime<Utc>>,
+        hosted_invoice_url: Option<&str>,
+        receipt_url: Option<&str>,
+    ) -> CardPurchaseSummary {
+        CardPurchaseSummary {
+            id: "cs_test".to_string(),
+            status,
+            requested_amount_cents: 1000,
+            paid_amount_cents: None,
+            checkout_url: "https://checkout.stripe.test/cs_test".to_string(),
+            created_at: None,
+            completed_at: None,
+            expires_at,
+            receipt_url: receipt_url.map(String::from),
+            invoice_id: hosted_invoice_url.map(|_| "in_abc".to_string()),
+            invoice_number: None,
+            hosted_invoice_url: hosted_invoice_url.map(String::from),
+            invoice_pdf: None,
+        }
+    }
+
+    #[test]
+    fn pending_with_future_expiry_resumes_to_checkout_url() {
+        // Mirrors the website behavior: a pending session whose Stripe
+        // checkout has not yet expired surfaces a Resume link pointing
+        // at `checkout_url`.
+        let future = Utc::now() + chrono::Duration::minutes(15);
+        let purchase = purchase_with(CardPurchaseStatus::Pending, Some(future), None, None);
+        let (kind, url) = purchase_primary_link(&purchase).expect("future expiry -> resume");
+        assert!(matches!(kind, PrimaryLinkKind::Resume));
+        assert_eq!(url, "https://checkout.stripe.test/cs_test");
+    }
+
+    #[test]
+    fn pending_with_no_expiry_is_resumable() {
+        // `expires_at == None` should not block resumption — only a
+        // known-past timestamp disqualifies the row.
+        let purchase = purchase_with(CardPurchaseStatus::Pending, None, None, None);
+        let (kind, _) = purchase_primary_link(&purchase).expect("no expiry -> resume");
+        assert!(matches!(kind, PrimaryLinkKind::Resume));
+    }
+
+    #[test]
+    fn pending_with_past_expiry_has_no_link() {
+        // The session is technically `Pending` until Stripe's webhook
+        // flips it to `Expired`, but the checkout URL no longer works.
+        // Render `-` instead of a broken Resume link.
+        let past = Utc::now() - chrono::Duration::minutes(1);
+        let purchase = purchase_with(CardPurchaseStatus::Pending, Some(past), None, None);
+        assert!(purchase_primary_link(&purchase).is_none());
+    }
+
+    #[test]
+    fn invoice_wins_over_resume_for_pending_with_invoice_url() {
+        // Defensive: in the unlikely case a pending row already has an
+        // invoice URL attached, the invoice link still wins so users
+        // see the most informative artifact.
+        let future = Utc::now() + chrono::Duration::minutes(15);
+        let purchase = purchase_with(
+            CardPurchaseStatus::Pending,
+            Some(future),
+            Some("https://invoice.stripe.com/i/abc"),
+            None,
+        );
+        let (kind, url) = purchase_primary_link(&purchase).expect("invoice on pending -> invoice");
+        assert!(matches!(kind, PrimaryLinkKind::Invoice));
+        assert_eq!(url, "https://invoice.stripe.com/i/abc");
+    }
+
+    #[test]
+    fn expired_status_has_no_link() {
+        // Once Stripe (or the backend) has marked the session Expired,
+        // the row is terminal and no link is meaningful.
+        let purchase = purchase_with(CardPurchaseStatus::Expired, None, None, None);
+        assert!(purchase_primary_link(&purchase).is_none());
+    }
+
+    #[test]
+    fn unspecified_status_has_no_link() {
+        let purchase = purchase_with(CardPurchaseStatus::Unspecified, None, None, None);
         assert!(purchase_primary_link(&purchase).is_none());
     }
 

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-04-27
+
+### Added
+- Card-purchase types for the Stripe checkout flow: `CreateCardPurchaseRequest`, `CardPurchaseResponse`, `CardPurchaseSummary`, `ListCardPurchasesResponse`, `CardPurchaseStatus`
+- `create_card_purchase`, `get_card_purchase`, and `list_card_purchases` methods on `BasilicaClient`
+
 ## [0.27.0] - 2026-04-20
 
 ### Added


### PR DESCRIPTION
Mirrors the new "Resume pending checkout" affordance shipped on the basilica-site `/openclaw/fund` page. Pending card-purchase rows whose Stripe checkout has not yet expired now render a clickable OSC8 **Resume** link in the `basilica fund list` Invoice/Receipt cell, taking the user back to the existing Stripe session instead of forcing a brand-new one.

Backend already returns `checkout_url`, `status`, and `expires_at` on every `CardPurchaseSummary`, so this is a CLI-display-only change.

### Behavior

| Row state                                  | Cell        |
| ------------------------------------------ | ----------- |
| Completed, has `hosted_invoice_url`        | Invoice link (unchanged) |
| Completed, only `receipt_url`              | Receipt link (unchanged) |
| Pending, `expires_at` in future or `None`  | **Resume** link → `checkout_url` |
| Pending, `expires_at` in past              | `-`         |
| Expired / Unspecified                      | `-`         |

`expires_at == None` is treated as resumable — only a known-past timestamp disqualifies the row.

### Out of scope

A `basilica fund resume <id>` subcommand was considered but intentionally dropped — the OSC8 link in the list is enough; users who want polling can re-run `basilica fund`. JSON output is unchanged (already exposes the same fields).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resume links for pending card purchases in the fund list command, enabling users to return to and complete interrupted transactions.
  * Resume links appear for sessions that are still active; expired or completed sessions display appropriate alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->