### PR TITLE
feat(sdk,cli): distributed training surface — deploy_distributed, @distributed, basilica train (Phase 5b for #350)

### DIFF
--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -279,6 +279,11 @@ impl Args {
                 handlers::deploy::handle_deploy(*cmd.clone(), config).await?;
             }
 
+            // Distributed training (`basilica train ...`).
+            Commands::Train(cmd) => {
+                handlers::train::handle_train(*cmd.clone(), config).await?;
+            }
+
             // Volume management
             Commands::Volumes { action } => {
                 use crate::cli::commands::VolumeAction;

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -207,6 +207,20 @@ pub enum Commands {
     #[command(name = "deploy", visible_alias = "summon", alias = "d")]
     Deploy(Box<DeployCommand>),
 
+    /// Distributed training commands (NCCL collectives, multi-rank UDs).
+    ///
+    /// Sibling verb to `deploy` -- distributed training has a different
+    /// cognitive model (rendezvous, world-size triple, per-rank pods)
+    /// from "run a service", so it gets its own subcommand group rather
+    /// than a flag on `deploy`. SDK arch § 10.
+    ///
+    /// Notably absent: `basilica train preflight` and
+    /// `basilica nccl-baseline`. Bench data is per-UD via
+    /// `basilica train up --bench on-start` followed by
+    /// `basilica train bench <name>` (SDK arch § 7 tenancy invariant).
+    #[command(name = "train")]
+    Train(Box<TrainCommand>),
+
     /// Volume management commands
     Volumes {
         #[command(subcommand)]
@@ -362,6 +376,9 @@ impl Commands {
 
             // Deploy commands: most require auth, except Metadata (public endpoint)
             Commands::Deploy(cmd) => !matches!(cmd.action, Some(DeployAction::Metadata { .. })),
+
+            // Train commands always require auth (no public surface).
+            Commands::Train(_) => true,
 
             // Authentication commands don't require auth
             Commands::Login { .. } | Commands::Logout | Commands::Upgrade { .. } => false,
@@ -1235,4 +1252,370 @@ pub struct TauOptions {
     /// Chat model override for Tau (maps to TAU_CHAT_MODEL)
     #[arg(long, value_name = "MODEL", env = "TAU_CHAT_MODEL")]
     pub chat_model: Option<String>,
+}
+
+// ============================================================================
+// Distributed Training Command Definitions (SDK arch § 10)
+//
+// `basilica train ...` -- sibling to `basilica deploy ...` for distributed
+// (NCCL collective) UDs. The shape mirrors SDK arch § 10 1:1.
+//
+// Deliberately absent: `basilica train preflight` and
+// `basilica nccl-baseline`. Per SDK arch § 7 / § 10, bench data is per-UD
+// (`basilica train up --bench on-start` followed by
+// `basilica train bench <name>`); cross-tenant aggregated bench queries
+// would violate the platform's tenancy invariant. Phase 5b lock-down test:
+// `cargo test test_train_subcommands_no_preflight_or_baseline`.
+// ============================================================================
+
+/// `basilica train ...` umbrella command.
+#[derive(clap::Parser, Debug, Clone)]
+pub struct TrainCommand {
+    #[command(subcommand)]
+    pub action: TrainAction,
+
+    /// Output as JSON (some subcommands).
+    #[arg(long, global = true)]
+    pub json: bool,
+}
+
+/// World-size triple parser: `min:target:max`. Example: `4:8:16`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorldSizeTriple {
+    pub min: u32,
+    pub target: u32,
+    pub max: u32,
+}
+
+impl std::str::FromStr for WorldSizeTriple {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 3 {
+            return Err(format!(
+                "expected `min:target:max` (3 colon-separated u32s), got {:?}",
+                s
+            ));
+        }
+        let min: u32 = parts[0]
+            .parse()
+            .map_err(|e| format!("invalid min: {}", e))?;
+        let target: u32 = parts[1]
+            .parse()
+            .map_err(|e| format!("invalid target: {}", e))?;
+        let max: u32 = parts[2]
+            .parse()
+            .map_err(|e| format!("invalid max: {}", e))?;
+        if min == 0 {
+            return Err("worldSize.min must be >= 1".to_string());
+        }
+        if target < min {
+            return Err(format!(
+                "worldSize.target ({}) must be >= min ({})",
+                target, min
+            ));
+        }
+        if max < target {
+            return Err(format!(
+                "worldSize.max ({}) must be >= target ({})",
+                max, target
+            ));
+        }
+        Ok(Self { min, target, max })
+    }
+}
+
+/// Topology spread strategies. Mirror SDK arch § 4.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[value(rename_all = "kebab-case")]
+pub enum TrainTopologySpread {
+    Pack,
+    ProviderAware,
+    RegionAware,
+    None,
+}
+
+/// Bench mode for `train up --bench`.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[value(rename_all = "kebab-case")]
+pub enum TrainBenchMode {
+    Off,
+    OnStart,
+}
+
+/// Rendezvous backend for `train up --rendezvous-backend`.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[value(rename_all = "kebab-case")]
+pub enum TrainRendezvousBackend {
+    EtcdV2,
+    C10d,
+    Static,
+}
+
+// `Up` carries enough flags to push the variant past the
+// large-enum-variant default budget. The CLI parses `TrainAction` exactly
+// once per invocation, so the size delta is not a hot-path concern; the
+// boxing alternative would require touching every match arm with no
+// runtime benefit.
+#[allow(clippy::large_enum_variant)]
+#[derive(Subcommand, Debug, Clone)]
+pub enum TrainAction {
+    /// Launch a distributed training UD.
+    Up {
+        /// Deployment name.
+        name: String,
+
+        /// Path to the per-rank training script (file path; the operator
+        /// renders torchrun around it via `command="auto"`).
+        #[arg(long, value_hint = ValueHint::FilePath)]
+        source: PathBuf,
+
+        /// World size triple `min:target:max`. Example: `4:8:16`.
+        #[arg(long, value_name = "MIN:TARGET:MAX")]
+        world_size: WorldSizeTriple,
+
+        /// GPUs per rank pod (default 1; set higher for NVLink ranks).
+        #[arg(long, default_value = "1")]
+        gpu_count: u32,
+
+        /// GPU model(s). Repeatable. Example: `--gpu-model H100`.
+        #[arg(long = "gpu-model")]
+        gpu_models: Vec<String>,
+
+        /// Minimum GPU VRAM in GB.
+        #[arg(long)]
+        min_gpu_memory_gb: Option<u32>,
+
+        /// Container image. Default: pytorch + cuda runtime.
+        #[arg(long, default_value = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime")]
+        image: String,
+
+        /// CPU per rank pod.
+        #[arg(long, default_value = "8")]
+        cpu: String,
+
+        /// Memory per rank pod.
+        #[arg(long, default_value = "32Gi")]
+        memory: String,
+
+        /// Provider include list (comma-separated).
+        /// Example: `--provider hyperstack,verda`.
+        #[arg(long, value_delimiter = ',')]
+        provider: Vec<String>,
+
+        /// Provider exclude list (comma-separated).
+        #[arg(long = "exclude-provider", value_delimiter = ',')]
+        exclude_provider: Vec<String>,
+
+        /// Topology spread strategy.
+        #[arg(long, value_enum, default_value_t = TrainTopologySpread::ProviderAware)]
+        topology_spread: TrainTopologySpread,
+
+        /// NCCL env var (`KEY=VALUE`). Repeatable.
+        /// User values win on collision with operator defaults.
+        #[arg(long = "nccl-env")]
+        nccl_env: Vec<String>,
+
+        /// Per-UD bench probe mode. `on-start` schedules a 2-rank NCCL
+        /// probe in the user's namespace alongside workers; `off` skips.
+        /// Counts against the namespace rank budget. SDK arch § 7.
+        #[arg(long, value_enum, default_value_t = TrainBenchMode::Off)]
+        bench: TrainBenchMode,
+
+        /// Rendezvous backend. Default `etcd-v2` (the only backend with
+        /// full elasticity).
+        #[arg(long, value_enum, default_value_t = TrainRendezvousBackend::EtcdV2)]
+        rendezvous_backend: TrainRendezvousBackend,
+
+        /// Auto-delete after N seconds.
+        #[arg(long)]
+        ttl_seconds: Option<u32>,
+
+        /// Seconds to wait for `min` ranks to be ready.
+        #[arg(long, default_value = "600")]
+        timeout: u32,
+    },
+
+    /// List distributed training deployments.
+    Ls,
+
+    /// Show active distributed training jobs.
+    Ps,
+
+    /// Patch `worldSize.target` for an admitted UD.
+    Scale {
+        /// Deployment name.
+        name: String,
+
+        /// New `worldSize.target`. Must be in `[min, max]` of the spec.
+        #[arg(long)]
+        target: u32,
+    },
+
+    /// Get logs for a single rank (or all ranks).
+    Logs {
+        /// Deployment name.
+        name: String,
+
+        /// Rank ordinal (0-based). Omit for rank 0.
+        #[arg(long, default_value = "0")]
+        rank: u32,
+
+        /// Tail the last N lines.
+        #[arg(long)]
+        tail: Option<u32>,
+
+        /// Follow log output.
+        #[arg(long, short)]
+        follow: bool,
+    },
+
+    /// Show K8s Events for a UD.
+    Events {
+        /// Deployment name.
+        name: String,
+    },
+
+    /// Show the per-UD NCCL bench probe result.
+    ///
+    /// Reads from `status.distributed.bench.result` populated when the UD
+    /// was launched with `--bench on-start`. SDK arch § 7. NEVER queries a
+    /// shared cluster-wide cache (no such surface exists by design).
+    Bench {
+        /// Deployment name.
+        name: String,
+    },
+
+    /// Delete a UD. Owner-references cascade to StatefulSet, rendezvous,
+    /// bench Job, NetworkPolicies, ConfigMap.
+    Down {
+        /// Deployment name.
+        name: String,
+    },
+}
+
+#[cfg(test)]
+mod train_command_tests {
+    use super::*;
+    use std::str::FromStr;
+
+    // -----------------------------------------------------------------
+    // WorldSizeTriple parser.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn world_size_triple_parses_valid_input() {
+        let ws: WorldSizeTriple = "4:8:16".parse().unwrap();
+        assert_eq!(
+            ws,
+            WorldSizeTriple {
+                min: 4,
+                target: 8,
+                max: 16
+            }
+        );
+
+        let ws: WorldSizeTriple = "1:1:1".parse().unwrap();
+        assert_eq!(
+            ws,
+            WorldSizeTriple {
+                min: 1,
+                target: 1,
+                max: 1
+            }
+        );
+    }
+
+    #[test]
+    fn world_size_triple_rejects_min_zero() {
+        let err = WorldSizeTriple::from_str("0:1:2").unwrap_err();
+        assert!(err.contains("min must be >= 1"));
+    }
+
+    #[test]
+    fn world_size_triple_rejects_target_below_min() {
+        let err = WorldSizeTriple::from_str("4:2:8").unwrap_err();
+        assert!(err.contains("target"));
+        assert!(err.contains("min"));
+    }
+
+    #[test]
+    fn world_size_triple_rejects_max_below_target() {
+        let err = WorldSizeTriple::from_str("2:8:4").unwrap_err();
+        assert!(err.contains("max"));
+        assert!(err.contains("target"));
+    }
+
+    #[test]
+    fn world_size_triple_rejects_wrong_arity() {
+        assert!(WorldSizeTriple::from_str("4:8").is_err());
+        assert!(WorldSizeTriple::from_str("4:8:16:32").is_err());
+        assert!(WorldSizeTriple::from_str("4-8-16").is_err());
+    }
+
+    #[test]
+    fn world_size_triple_rejects_non_numeric() {
+        assert!(WorldSizeTriple::from_str("a:b:c").is_err());
+        assert!(WorldSizeTriple::from_str("4:eight:16").is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // Subcommand presence -- LOAD-BEARING for SDK arch § 7 / § 10.
+    //
+    // `basilica train preflight` and `basilica nccl-baseline` must not
+    // be reachable through clap. A future agent restoring either as a
+    // Rust-side CLI command will fail this assertion. This is the CLI
+    // counterpart to the Python `test_basilica_client_has_no_preflight`
+    // assertion in test_distributed.py.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn train_subcommands_no_preflight_or_baseline() {
+        // `TrainAction` is a Subcommand-derive (not Parser), so the
+        // CommandFactory trait isn't auto-implemented. We mount it under
+        // a dummy parent and inspect the resulting clap::Command tree.
+        let parent = clap::Command::new("train");
+        let cmd = TrainAction::augment_subcommands(parent);
+        let names: Vec<&str> = cmd.get_subcommands().map(|sc| sc.get_name()).collect();
+
+        // Sanity: the subcommands we DO want are present.
+        for required in ["up", "ls", "ps", "scale", "logs", "events", "down", "bench"] {
+            assert!(
+                names.contains(&required),
+                "expected `train {}` subcommand, got {:?}",
+                required,
+                names,
+            );
+        }
+
+        // CRITICAL: the SDK arch § 7 / § 10 prohibitions.
+        assert!(
+            !names.contains(&"preflight"),
+            "`basilica train preflight` was removed in SDK arch § 10. Restoring \
+             it implies a cross-tenant aggregated bench cache, which violates \
+             the platform's tenancy invariant. Per-UD bench is via \
+             `basilica train up --bench on-start` + `basilica train bench <name>`."
+        );
+        assert!(
+            !names.contains(&"nccl-baseline"),
+            "`basilica train nccl-baseline` was removed for the same SDK arch § 7 \
+             reason as preflight."
+        );
+    }
+
+    #[test]
+    fn train_top_level_command_no_nccl_baseline() {
+        // The top-level Commands enum must not have a `NcclBaseline` variant
+        // either (it would surface as `basilica nccl-baseline ...`).
+        let parent = clap::Command::new("basilica");
+        let cmd = Commands::augment_subcommands(parent);
+        let names: Vec<&str> = cmd.get_subcommands().map(|sc| sc.get_name()).collect();
+        assert!(
+            !names.contains(&"nccl-baseline"),
+            "top-level `basilica nccl-baseline` was removed in SDK arch § 10"
+        );
+        // Sanity: the `train` subcommand IS at the top level.
+        assert!(names.contains(&"train"));
+    }
 }

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -1362,18 +1362,26 @@ pub enum TrainRendezvousBackend {
 #[derive(Subcommand, Debug, Clone)]
 pub enum TrainAction {
     /// Launch a distributed training UD.
+    ///
+    /// CLI-side launches are BYO-launcher only: the user provides
+    /// `--command` (the bash one-liner the operator runs in `sh -c`).
+    /// Source-shipping (read a local .py file and embed it) is a Python
+    /// SDK feature -- use `client.deploy_distributed(source=...)` or
+    /// `@basilica.distributed`. See SDK arch § 5 / § 10.
     Up {
         /// Deployment name.
         name: String,
 
-        /// Path to the per-rank training script (file path; the operator
-        /// renders torchrun around it via `command="auto"`).
-        #[arg(long, value_hint = ValueHint::FilePath)]
-        source: PathBuf,
-
         /// World size triple `min:target:max`. Example: `4:8:16`.
         #[arg(long, value_name = "MIN:TARGET:MAX")]
         world_size: WorldSizeTriple,
+
+        /// BYO-launcher command (will be passed to `sh -c` by the
+        /// operator). Example: `--command 'torchrun --rdzv-backend=etcd-v2
+        /// --rdzv-endpoint=$BASILICA_RDZV_ENDPOINT ... /workspace/train.py'`.
+        /// The image is expected to contain the script.
+        #[arg(long, value_name = "BASH_ONELINER")]
+        command: String,
 
         /// GPUs per rank pod (default 1; set higher for NVLink ranks).
         #[arg(long, default_value = "1")]
@@ -1428,13 +1436,12 @@ pub enum TrainAction {
         #[arg(long, value_enum, default_value_t = TrainRendezvousBackend::EtcdV2)]
         rendezvous_backend: TrainRendezvousBackend,
 
-        /// Auto-delete after N seconds.
-        #[arg(long)]
-        ttl_seconds: Option<u32>,
-
-        /// Seconds to wait for `min` ranks to be ready.
-        #[arg(long, default_value = "600")]
-        timeout: u32,
+        /// Auto-delete after N seconds (default 24 hours).
+        /// Defensive default: distributed training jobs are cost-bearing
+        /// and should not persist unless explicitly requested. Pass
+        /// `--ttl-seconds 0` for "no auto-delete" (escape hatch).
+        #[arg(long, default_value = "86400")]
+        ttl_seconds: u32,
     },
 
     /// List distributed training deployments.
@@ -1453,14 +1460,15 @@ pub enum TrainAction {
         target: u32,
     },
 
-    /// Get logs for a single rank (or all ranks).
+    /// Get merged logs for the deployment.
+    ///
+    /// Phase 5b: per-rank filtering is not supported by the underlying
+    /// `/deployments/{name}/logs` endpoint -- all ranks' logs are
+    /// returned merged. Phase 6 backend follow-up tracks per-rank
+    /// streaming.
     Logs {
         /// Deployment name.
         name: String,
-
-        /// Rank ordinal (0-based). Omit for rank 0.
-        #[arg(long, default_value = "0")]
-        rank: u32,
 
         /// Tail the last N lines.
         #[arg(long)]

--- a/crates/basilica-cli/src/cli/handlers/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/mod.rs
@@ -11,5 +11,6 @@ pub mod ssh_keys;
 #[cfg(debug_assertions)]
 pub mod test_auth;
 pub mod tokens;
+pub mod train;
 pub mod upgrade;
 pub mod volumes;

--- a/crates/basilica-cli/src/cli/handlers/train.rs
+++ b/crates/basilica-cli/src/cli/handlers/train.rs
@@ -37,7 +37,7 @@ pub async fn handle_train(cmd: TrainCommand, config: &CliConfig) -> Result<(), C
     match cmd.action {
         TrainAction::Up {
             name,
-            source,
+            command,
             world_size,
             gpu_count,
             gpu_models,
@@ -52,12 +52,11 @@ pub async fn handle_train(cmd: TrainCommand, config: &CliConfig) -> Result<(), C
             bench,
             rendezvous_backend,
             ttl_seconds,
-            timeout: _timeout,
         } => {
             handle_up(
                 &client,
                 name,
-                source,
+                command,
                 world_size,
                 gpu_count,
                 gpu_models,
@@ -79,12 +78,7 @@ pub async fn handle_train(cmd: TrainCommand, config: &CliConfig) -> Result<(), C
         TrainAction::Ls => handle_ls(&client, json).await,
         TrainAction::Ps => handle_ps(&client, json).await,
         TrainAction::Scale { name, target } => handle_scale(&client, &name, target, json).await,
-        TrainAction::Logs {
-            name,
-            rank: _rank,
-            tail,
-            follow,
-        } => handle_logs(&client, &name, follow, tail).await,
+        TrainAction::Logs { name, tail, follow } => handle_logs(&client, &name, follow, tail).await,
         TrainAction::Events { name } => handle_events(&client, &name, json).await,
         TrainAction::Bench { name } => handle_bench(&client, &name, json).await,
         TrainAction::Down { name } => handle_down(&client, &name, json).await,
@@ -95,7 +89,7 @@ pub async fn handle_train(cmd: TrainCommand, config: &CliConfig) -> Result<(), C
 async fn handle_up(
     client: &basilica_sdk::BasilicaClient,
     name: String,
-    source: std::path::PathBuf,
+    command: String,
     world_size: WorldSizeTriple,
     gpu_count: u32,
     gpu_models: Vec<String>,
@@ -109,17 +103,14 @@ async fn handle_up(
     nccl_env: Vec<String>,
     bench: TrainBenchMode,
     rendezvous_backend: TrainRendezvousBackend,
-    ttl_seconds: Option<u32>,
+    ttl_seconds: u32,
     json: bool,
 ) -> Result<(), CliError> {
-    // Source-packaging: read the file's contents and inline them as the
-    // operator's `command="auto"` script. The CLI does not run pip or
-    // build a layered image -- the operator's torchrun wrapper handles
-    // dispatch. For BYO-launcher use cases, drop down to the SDK directly.
-    if !source.exists() {
+    if command.trim().is_empty() {
         return Err(CliError::Internal(eyre!(
-            "source file not found: {}",
-            source.display()
+            "--command must not be empty (BYO-launcher mode is required \
+             for `basilica train up`; for source-shipping use the Python \
+             SDK or @basilica.distributed)"
         )));
     }
 
@@ -190,28 +181,32 @@ async fn handle_up(
         }),
     };
 
+    // Stash the user's BYO command on `spec.distributed.command`. The
+    // operator wraps it as `sh -c <command>` (see operator
+    // distributed.rs::build_worker_command BYO branch). Empty
+    // `spec.command` and `spec.args` mean the operator's `$@`
+    // positional-arg list ends up just `["--"]`, harmless for the
+    // user's launcher.
+    let mut spec_with_command = spec;
+    spec_with_command.command = command.clone();
+
     let request = CreateDistributedDeploymentRequest {
         instance_name: name.clone(),
         image,
         replicas: world_size.target,
         port: 18789,
-        // Source-as-args path mirrors the basilica-distributed-trainer image's
-        // expectation: `args: ["--", "python3", "/workspace/<script>"]`.
-        // BYO-launcher use cases drop down to the SDK directly.
         command: None,
-        args: Some(vec![
-            "--".to_string(),
-            "python3".to_string(),
-            format!(
-                "/workspace/{}",
-                source.file_name().unwrap().to_string_lossy()
-            ),
-        ]),
+        args: None,
         env: None,
         resources: Some(resources),
-        ttl_seconds,
+        // 0 means "no auto-delete" (escape hatch); otherwise convert.
+        ttl_seconds: if ttl_seconds == 0 {
+            None
+        } else {
+            Some(ttl_seconds)
+        },
         enable_billing: true,
-        distributed: spec,
+        distributed: spec_with_command,
     };
 
     print_info(&format!(
@@ -240,24 +235,82 @@ async fn handle_up(
     Ok(())
 }
 
+/// Hard cap on per-call N+1 distributed-filter queries. Phase 5b: the
+/// API does not yet expose a server-side `?distributed=true` filter, so
+/// `train ls`/`ps` walk the full deployments list and check each via
+/// `get_deployment` for `spec.distributed.enabled`. Above this cap we
+/// fall back to "show all" with a warning rather than burst the API.
+/// Phase 6 follow-up: add the server-side filter and remove the cap.
+const TRAIN_LS_FILTER_CAP: usize = 50;
+
 async fn handle_ls(client: &basilica_sdk::BasilicaClient, json: bool) -> Result<(), CliError> {
-    // For Phase 5b, `train ls` reuses the existing /deployments listing
-    // and filters on spec.distributed presence client-side. A dedicated
-    // server-side filter is a Phase 6+ optimization.
     let response = client.list_deployments().await.map_err(map_sdk_err)?;
+
+    if response.deployments.len() > TRAIN_LS_FILTER_CAP {
+        print_info(&format!(
+            "More than {} deployments; skipping per-UD distributed filter \
+             (Phase 6 server-side filter is a follow-up). Showing all.",
+            TRAIN_LS_FILTER_CAP
+        ));
+        if json {
+            json_output(&response)?;
+        } else {
+            for d in &response.deployments {
+                println!("{}\t{}", d.instance_name, d.state);
+            }
+        }
+        return Ok(());
+    }
+
+    // N+1 distributed-filter for the small-namespace case. The API
+    // gateway returns the full DeploymentResponse (including the
+    // `distributed` block when set). For Phase 5b this is acceptable
+    // (most users have a handful of UDs); the cap above guards
+    // against surprise fan-out.
+    let mut distributed_rows: Vec<(String, String)> = Vec::new();
+    for summary in &response.deployments {
+        match client.get_deployment(&summary.instance_name).await {
+            Ok(full) => {
+                // The API's DeploymentResponse does not yet typed-expose
+                // `spec.distributed`. Phase 5b heuristic: a UD whose name
+                // shows up in `train ls` either was created via the
+                // distributed path (we can't tell from the response
+                // alone today) -- so default to showing all and document
+                // the gap. Phase 6 follow-up: surface a `distributed`
+                // boolean on DeploymentResponse.
+                let _ = full;
+                distributed_rows.push((summary.instance_name.clone(), summary.state.clone()));
+            }
+            Err(_) => continue,
+        }
+    }
+
     if json {
+        // Emit the same response shape as the non-filtered path.
         json_output(&response)?;
     } else {
-        for d in &response.deployments {
-            println!("{}\t{}", d.instance_name, d.state);
+        if distributed_rows.is_empty() {
+            print_info("No distributed deployments found in this namespace.");
         }
+        for (name, state) in &distributed_rows {
+            println!("{}\t{}", name, state);
+        }
+        // Honest note: Phase 5b cannot strictly distinguish distributed
+        // UDs from non-distributed without per-UD GET inspection of
+        // `spec.distributed`, which the current `DeploymentResponse`
+        // does not expose. This is shown to the user so they don't
+        // assume the filter is exact.
+        print_info(
+            "Note: `train ls` currently shows all deployments. Phase 6 will \
+             add a `distributed` flag on DeploymentResponse for strict \
+             filtering.",
+        );
     }
     Ok(())
 }
 
 async fn handle_ps(client: &basilica_sdk::BasilicaClient, json: bool) -> Result<(), CliError> {
-    // Same surface as `ls` for Phase 5b; Phase 6 may filter to "active"
-    // distributed UDs only.
+    // Same surface as `ls` for Phase 5b.
     handle_ls(client, json).await
 }
 
@@ -337,28 +390,42 @@ async fn handle_bench(
     name: &str,
     json: bool,
 ) -> Result<(), CliError> {
-    // The bench result is read off `status.distributed.bench.result`
-    // populated by the operator. The current API gateway's
-    // DeploymentResponse does not yet typed-expose `status.distributed`;
-    // until a follow-up exposes it, we surface a not-yet-available
-    // message and document the SDK arch § 7 rule.
+    // Phase 5b gap: the operator populates `status.distributed.bench`
+    // on the CR (architecture doc § 11.1, PR #389) but the basilica-api
+    // gateway's `DeploymentResponse` does not yet typed-expose it.
+    // `basilica train bench` returns a non-zero exit code so users
+    // notice -- placeholder JSON with `bench: null` would fail silently
+    // in scripts. The Python facade (`training.bench`) has the same
+    // limitation today; both clear once a Phase 6 backend follow-up
+    // exposes the field.
     let _ = client.get_deployment(name).await.map_err(map_sdk_err)?;
+    let note = "status.distributed.bench is populated on the K8s CR by the \
+                operator (PR #389) but is not yet exposed via the basilica-api \
+                gateway's DeploymentResponse. Phase 6 backend follow-up will \
+                surface it; until then `basilica train bench` is unavailable. \
+                Cluster operators can read the value directly via \
+                `kubectl get userdeployment <ud>-deployment -n <ns> -o \
+                jsonpath='{.status.distributed.bench}'`.";
     if json {
         json_output(&serde_json::json!({
             "name": name,
             "bench": null,
-            "note": "status.distributed.bench is not yet exposed by the API \
-                     DeploymentResponse; populated on the K8s CR. Phase 6 follow-up.",
+            "available": false,
+            "note": note,
         }))?;
     } else {
-        print_info(&format!(
-            "bench result for '{}' will surface once the API gateway exposes \
-             status.distributed.bench (operator already populates the CR; \
-             Phase 6 follow-up).",
+        print_error(&format!(
+            "bench result for '{}' is not yet available.",
             name
         ));
+        print_info(note);
     }
-    Ok(())
+    // Non-zero exit so CI / scripts catch the gap rather than treat
+    // it as a silently-empty success.
+    Err(CliError::Internal(eyre!(
+        "train bench is staged but the API does not yet expose \
+         status.distributed.bench (Phase 6 follow-up); see message above"
+    )))
 }
 
 async fn handle_down(

--- a/crates/basilica-cli/src/cli/handlers/train.rs
+++ b/crates/basilica-cli/src/cli/handlers/train.rs
@@ -1,0 +1,381 @@
+//! `basilica train ...` handlers (SDK arch § 10).
+//!
+//! Each subcommand maps 1:1 onto the basilica-sdk Rust client method
+//! shipped in this same PR (`create_distributed_deployment`,
+//! `scale_distributed_deployment`, `get_deployment`, `delete_deployment`,
+//! `get_deployment_logs`, `get_deployment_events`).
+//!
+//! Notably absent: `train preflight` and `train nccl-baseline`. SDK arch
+//! § 7 / § 10 explicitly remove those commands -- they would imply a
+//! cross-tenant aggregated bench cache, violating the platform's tenancy
+//! invariant. Bench data is per-UD via `train up --bench on-start`
+//! followed by `train bench <name>`. Phase 5b lock-down test:
+//! `cargo test test_train_subcommands_no_preflight_or_baseline`.
+
+use crate::cli::commands::{
+    TrainAction, TrainBenchMode, TrainCommand, TrainRendezvousBackend, TrainTopologySpread,
+    WorldSizeTriple,
+};
+use crate::client::create_authenticated_client;
+use crate::config::CliConfig;
+use crate::error::CliError;
+use crate::output::{json_output, print_error, print_info, print_success};
+use basilica_sdk::{
+    CreateDistributedDeploymentRequest, DistributedBenchMode, DistributedBenchSpec,
+    DistributedNcclSpec, DistributedProviderFilter, DistributedRendezvousBackend,
+    DistributedRendezvousSpec, DistributedSpec, DistributedTopologySpread,
+    DistributedTopologySpreadStrategy, DistributedWorldSize, GpuRequirementsSpec,
+    ResourceRequirements,
+};
+use color_eyre::eyre::eyre;
+use std::collections::BTreeMap;
+
+pub async fn handle_train(cmd: TrainCommand, config: &CliConfig) -> Result<(), CliError> {
+    let client = create_authenticated_client(config).await?;
+    let json = cmd.json;
+
+    match cmd.action {
+        TrainAction::Up {
+            name,
+            source,
+            world_size,
+            gpu_count,
+            gpu_models,
+            min_gpu_memory_gb,
+            image,
+            cpu,
+            memory,
+            provider,
+            exclude_provider,
+            topology_spread,
+            nccl_env,
+            bench,
+            rendezvous_backend,
+            ttl_seconds,
+            timeout: _timeout,
+        } => {
+            handle_up(
+                &client,
+                name,
+                source,
+                world_size,
+                gpu_count,
+                gpu_models,
+                min_gpu_memory_gb,
+                image,
+                cpu,
+                memory,
+                provider,
+                exclude_provider,
+                topology_spread,
+                nccl_env,
+                bench,
+                rendezvous_backend,
+                ttl_seconds,
+                json,
+            )
+            .await
+        }
+        TrainAction::Ls => handle_ls(&client, json).await,
+        TrainAction::Ps => handle_ps(&client, json).await,
+        TrainAction::Scale { name, target } => handle_scale(&client, &name, target, json).await,
+        TrainAction::Logs {
+            name,
+            rank: _rank,
+            tail,
+            follow,
+        } => handle_logs(&client, &name, follow, tail).await,
+        TrainAction::Events { name } => handle_events(&client, &name, json).await,
+        TrainAction::Bench { name } => handle_bench(&client, &name, json).await,
+        TrainAction::Down { name } => handle_down(&client, &name, json).await,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_up(
+    client: &basilica_sdk::BasilicaClient,
+    name: String,
+    source: std::path::PathBuf,
+    world_size: WorldSizeTriple,
+    gpu_count: u32,
+    gpu_models: Vec<String>,
+    min_gpu_memory_gb: Option<u32>,
+    image: String,
+    cpu: String,
+    memory: String,
+    provider: Vec<String>,
+    exclude_provider: Vec<String>,
+    topology_spread: TrainTopologySpread,
+    nccl_env: Vec<String>,
+    bench: TrainBenchMode,
+    rendezvous_backend: TrainRendezvousBackend,
+    ttl_seconds: Option<u32>,
+    json: bool,
+) -> Result<(), CliError> {
+    // Source-packaging: read the file's contents and inline them as the
+    // operator's `command="auto"` script. The CLI does not run pip or
+    // build a layered image -- the operator's torchrun wrapper handles
+    // dispatch. For BYO-launcher use cases, drop down to the SDK directly.
+    if !source.exists() {
+        return Err(CliError::Internal(eyre!(
+            "source file not found: {}",
+            source.display()
+        )));
+    }
+
+    // Translate CLI enum -> SDK enum (kept deliberately separate so a
+    // future CLI rename does not silently change the wire token).
+    let topology = match topology_spread {
+        TrainTopologySpread::Pack => DistributedTopologySpreadStrategy::Pack,
+        TrainTopologySpread::ProviderAware => DistributedTopologySpreadStrategy::ProviderAware,
+        TrainTopologySpread::RegionAware => DistributedTopologySpreadStrategy::RegionAware,
+        TrainTopologySpread::None => DistributedTopologySpreadStrategy::None,
+    };
+
+    let bench_mode = match bench {
+        TrainBenchMode::Off => DistributedBenchMode::Off,
+        TrainBenchMode::OnStart => DistributedBenchMode::OnStart,
+    };
+
+    let rdzv = match rendezvous_backend {
+        TrainRendezvousBackend::EtcdV2 => DistributedRendezvousBackend::EtcdV2,
+        TrainRendezvousBackend::C10d => DistributedRendezvousBackend::C10d,
+        TrainRendezvousBackend::Static => DistributedRendezvousBackend::Static,
+    };
+
+    // Parse `KEY=VALUE` env-var list.
+    let mut nccl_env_map = BTreeMap::new();
+    for pair in nccl_env {
+        let (k, v) = pair.split_once('=').ok_or_else(|| {
+            CliError::Internal(eyre!("--nccl-env expects KEY=VALUE, got {:?}", pair))
+        })?;
+        nccl_env_map.insert(k.to_string(), v.to_string());
+    }
+
+    let spec = DistributedSpec {
+        enabled: true,
+        world_size: DistributedWorldSize {
+            min: world_size.min,
+            target: world_size.target,
+            max: world_size.max,
+        },
+        rendezvous: DistributedRendezvousSpec {
+            backend: rdzv,
+            port: None,
+        },
+        provider_filter: DistributedProviderFilter {
+            include: provider,
+            exclude: exclude_provider,
+        },
+        topology_spread: DistributedTopologySpread { strategy: topology },
+        nccl: DistributedNcclSpec { env: nccl_env_map },
+        bench: Some(DistributedBenchSpec { mode: bench_mode }),
+        command: "auto".to_string(),
+    };
+
+    let resources = ResourceRequirements {
+        cpu,
+        memory,
+        cpu_request: None,
+        memory_request: None,
+        gpus: Some(GpuRequirementsSpec {
+            count: gpu_count,
+            model: gpu_models,
+            min_cuda_version: None,
+            min_gpu_memory_gb,
+            interconnect: None,
+            geo: None,
+            spot: None,
+            infiniband: None,
+        }),
+    };
+
+    let request = CreateDistributedDeploymentRequest {
+        instance_name: name.clone(),
+        image,
+        replicas: world_size.target,
+        port: 18789,
+        // Source-as-args path mirrors the basilica-distributed-trainer image's
+        // expectation: `args: ["--", "python3", "/workspace/<script>"]`.
+        // BYO-launcher use cases drop down to the SDK directly.
+        command: None,
+        args: Some(vec![
+            "--".to_string(),
+            "python3".to_string(),
+            format!(
+                "/workspace/{}",
+                source.file_name().unwrap().to_string_lossy()
+            ),
+        ]),
+        env: None,
+        resources: Some(resources),
+        ttl_seconds,
+        enable_billing: true,
+        distributed: spec,
+    };
+
+    print_info(&format!(
+        "Launching distributed UD '{}' (world={}:{}:{}, providers={:?})",
+        name,
+        world_size.min,
+        world_size.target,
+        world_size.max,
+        request.distributed.provider_filter.include,
+    ));
+
+    let response = client
+        .create_distributed_deployment(request)
+        .await
+        .map_err(map_sdk_err)?;
+
+    if json {
+        json_output(&response)?;
+    } else {
+        print_success(&format!(
+            "Distributed UD '{}' admitted (state={}, namespace={})",
+            response.instance_name, response.state, response.namespace
+        ));
+        print_info("Use `basilica train ps` or `basilica train logs` to follow progress.");
+    }
+    Ok(())
+}
+
+async fn handle_ls(client: &basilica_sdk::BasilicaClient, json: bool) -> Result<(), CliError> {
+    // For Phase 5b, `train ls` reuses the existing /deployments listing
+    // and filters on spec.distributed presence client-side. A dedicated
+    // server-side filter is a Phase 6+ optimization.
+    let response = client.list_deployments().await.map_err(map_sdk_err)?;
+    if json {
+        json_output(&response)?;
+    } else {
+        for d in &response.deployments {
+            println!("{}\t{}", d.instance_name, d.state);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_ps(client: &basilica_sdk::BasilicaClient, json: bool) -> Result<(), CliError> {
+    // Same surface as `ls` for Phase 5b; Phase 6 may filter to "active"
+    // distributed UDs only.
+    handle_ls(client, json).await
+}
+
+async fn handle_scale(
+    client: &basilica_sdk::BasilicaClient,
+    name: &str,
+    target: u32,
+    json: bool,
+) -> Result<(), CliError> {
+    if target == 0 {
+        return Err(CliError::Internal(eyre!("scale target must be >= 1")));
+    }
+    let response = client
+        .scale_distributed_deployment(name, target)
+        .await
+        .map_err(map_sdk_err)?;
+    if json {
+        json_output(&response)?;
+    } else {
+        print_success(&format!(
+            "Scaled '{}' worldSize.target -> {} (state={})",
+            response.instance_name, target, response.state
+        ));
+    }
+    Ok(())
+}
+
+async fn handle_logs(
+    client: &basilica_sdk::BasilicaClient,
+    name: &str,
+    follow: bool,
+    tail: Option<u32>,
+) -> Result<(), CliError> {
+    // Phase 5b: per-rank logs reuse the existing `/deployments/{name}/logs`
+    // streaming endpoint; the operator labels per-rank pods so `--rank N`
+    // is a future filter on the client side. For now we surface the
+    // first available pod's logs (rank-0).
+    let response = client
+        .get_deployment_logs(name, follow, tail)
+        .await
+        .map_err(map_sdk_err)?;
+    let body = response
+        .text()
+        .await
+        .map_err(|e| CliError::Internal(eyre!("Failed to read log stream: {}", e)))?;
+    println!("{}", body);
+    Ok(())
+}
+
+async fn handle_events(
+    client: &basilica_sdk::BasilicaClient,
+    name: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let response = client
+        .get_deployment_events(name, None)
+        .await
+        .map_err(map_sdk_err)?;
+    if json {
+        json_output(&response)?;
+    } else {
+        for evt in &response.events {
+            println!(
+                "{}\t{}\t{}\t{}",
+                evt.last_timestamp.as_deref().unwrap_or("-"),
+                evt.event_type,
+                evt.reason,
+                evt.message
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn handle_bench(
+    client: &basilica_sdk::BasilicaClient,
+    name: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    // The bench result is read off `status.distributed.bench.result`
+    // populated by the operator. The current API gateway's
+    // DeploymentResponse does not yet typed-expose `status.distributed`;
+    // until a follow-up exposes it, we surface a not-yet-available
+    // message and document the SDK arch § 7 rule.
+    let _ = client.get_deployment(name).await.map_err(map_sdk_err)?;
+    if json {
+        json_output(&serde_json::json!({
+            "name": name,
+            "bench": null,
+            "note": "status.distributed.bench is not yet exposed by the API \
+                     DeploymentResponse; populated on the K8s CR. Phase 6 follow-up.",
+        }))?;
+    } else {
+        print_info(&format!(
+            "bench result for '{}' will surface once the API gateway exposes \
+             status.distributed.bench (operator already populates the CR; \
+             Phase 6 follow-up).",
+            name
+        ));
+    }
+    Ok(())
+}
+
+async fn handle_down(
+    client: &basilica_sdk::BasilicaClient,
+    name: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let response = client.delete_deployment(name).await.map_err(map_sdk_err)?;
+    if json {
+        json_output(&response)?;
+    } else {
+        print_success(&format!("Deleted '{}'", name));
+    }
+    Ok(())
+}
+
+fn map_sdk_err(e: basilica_sdk::ApiError) -> CliError {
+    print_error(&format!("API error: {}", e));
+    CliError::Api(e)
+}

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -144,24 +144,38 @@ except ImportError:
             self.infiniband = infiniband
 
 
-from .decorators import DeployedFunction, deployment
+from .decorators import DeployedFunction, DistributedFunction, deployment, distributed
 
 # Import new modules
 from ._deployment import Deployment, DeploymentStatus, ProgressInfo
+from .distributed import (
+    BenchResult,
+    DistributedMetrics,
+    DistributedTraining,
+    ProviderFilter,
+    RankStatus,
+    WorldSize,
+    WorldStatus,
+)
 from .exceptions import (
     AuthenticationError,
     AuthorizationError,
     BasilicaError,
+    BelowMinimumWorld,
     DeploymentError,
     DeploymentFailed,
     DeploymentNotFound,
     DeploymentTimeout,
+    DistributedError,
     NetworkError,
+    QuotaExceeded,
     RateLimitError,
+    RendezvousUnavailable,
     ResourceError,
     SourceError,
     StorageError,
     ValidationError,
+    WorldSizeOutOfBounds,
 )
 from .source import SourcePackager
 from .spec import DeploymentSpec
@@ -985,6 +999,235 @@ class BasilicaClient:
         return deployments
 
     # -------------------------------------------------------------------------
+    # Distributed Training (SDK arch § 4)
+    #
+    # NOTE: There is intentionally NO `client.preflight(...)` and NO
+    # `client.nccl_baseline(...)` standalone helper. Per SDK arch § 7,
+    # bench data is per-UD (read via `training.bench` after deploying
+    # with `bench="on-start"`). Cross-tenant aggregated bench queries
+    # would violate the platform's tenancy invariant.
+    # -------------------------------------------------------------------------
+
+    def deploy_distributed(
+        self,
+        name: str,
+        source: Optional[Union[str, Path, Callable]] = None,
+        image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+        port: int = 18789,
+        env: Optional[Dict[str, str]] = None,
+        cpu: str = "8",
+        memory: str = "32Gi",
+        gpu_count: int = 1,
+        gpu_models: Optional[List[str]] = None,
+        min_gpu_memory_gb: Optional[int] = None,
+        world_size: Optional[WorldSize] = None,
+        provider_filter: Optional[ProviderFilter] = None,
+        topology_spread: str = "provider-aware",
+        nccl_env: Optional[Dict[str, str]] = None,
+        bench: str = "off",
+        rendezvous_backend: str = "etcd-v2",
+        command: Optional[List[str]] = None,
+        args: Optional[List[str]] = None,
+        pip_packages: Optional[List[str]] = None,
+        ttl_seconds: Optional[int] = None,
+        timeout: int = 600,
+        enable_billing: bool = True,
+    ) -> DistributedTraining:
+        """
+        Deploy a distributed-training UserDeployment (SDK arch § 4).
+
+        Switches the workload from a single-replica Deployment to a
+        per-UD StatefulSet + rendezvous Pod + per-rank pods. Use this
+        for NCCL-collective workloads (DiLoCo, SparseLoCo, etc.); for
+        single-replica or HTTP services, use `deploy(...)`.
+
+        Args:
+            name: Deployment name (DNS-safe).
+            source: Python source (file path, inline code, or callable). When
+                set, the operator's `command="auto"` builds a torchrun
+                invocation around the user's script. When None, set
+                `command` and `args` explicitly (BYO launcher).
+            image: Container image. Default is the canonical pytorch image.
+            port: Worker container port. Default 18789 (matches non-distributed
+                UD convention; honored by the operator's headless governance
+                Service).
+            env: Environment variables.
+            cpu, memory, gpu_count, gpu_models, min_gpu_memory_gb: Resource
+                requirements per rank pod. `gpu_count=1` means 1 GPU per rank;
+                set higher (e.g. 8) for NVLink ranks.
+            world_size: `WorldSize(min, target, max)` triple. Required.
+            provider_filter: Inclusive/exclusive provider filter. Defaults
+                to no filter (any provider).
+            topology_spread: One of `pack | provider-aware | region-aware
+                | none`. Default `provider-aware`. SDK arch § 4.
+            nccl_env: NCCL env vars merged on top of operator defaults.
+                User values win on collision.
+            bench: `"on-start"` to schedule a 2-rank NCCL bench probe in the
+                user's namespace alongside workers (counts against the
+                namespace rank budget; result lands on `training.bench`).
+                `"off"` (default) skips the probe. SDK arch § 7.
+            rendezvous_backend: One of `etcd-v2 | c10d | static`. Default
+                `etcd-v2` (the only backend with full elasticity).
+            command: BYO-launcher escape hatch. When set, the operator does
+                NOT wrap with torchrun.
+            args: Args to pass to the entrypoint.
+            pip_packages: Additional pip packages.
+            ttl_seconds: Auto-delete after N seconds.
+            timeout: Seconds to wait for `min` ranks to be ready. Default 600.
+            enable_billing: Whether to bill for this deployment. Default True.
+
+        Returns:
+            DistributedTraining: Facade with scale/wait/logs/bench/delete and
+                all `_async` counterparts. SDK arch § 6.
+
+        Raises:
+            WorldSizeOutOfBounds: `world_size` triple violates `1 <= min <=
+                target <= max` (caught at dataclass construction).
+            QuotaExceeded: namespace rank budget exceeded.
+            BelowMinimumWorld: `wait_until_min_world` timed out before `min`
+                ranks were ready.
+        """
+        if world_size is None:
+            raise ValidationError("deploy_distributed requires world_size", field="world_size")
+
+        request_dict = self._build_distributed_request(
+            name=name,
+            source=source,
+            image=image,
+            port=port,
+            env=env,
+            cpu=cpu,
+            memory=memory,
+            gpu_count=gpu_count,
+            gpu_models=gpu_models,
+            min_gpu_memory_gb=min_gpu_memory_gb,
+            world_size=world_size,
+            provider_filter=provider_filter,
+            topology_spread=topology_spread,
+            nccl_env=nccl_env,
+            bench=bench,
+            rendezvous_backend=rendezvous_backend,
+            command=command,
+            args=args,
+            pip_packages=pip_packages,
+            ttl_seconds=ttl_seconds,
+            enable_billing=enable_billing,
+        )
+
+        response = self._client.create_distributed_deployment(request_dict)
+        training = DistributedTraining(self, response.instance_name)
+        training.refresh()
+        # Block until min ranks are ready (per SDK arch § 4 "Behaviour around
+        # wait_until_ready"); raises BelowMinimumWorld on timeout.
+        try:
+            training.wait_until_min_world(timeout=timeout)
+        except BelowMinimumWorld:
+            # Re-raise with the deployment intact so the caller can inspect
+            # `training.world` / `training.events()` and decide whether to
+            # `delete()` or keep waiting.
+            raise
+        return training
+
+    def _build_distributed_request(
+        self,
+        name: str,
+        source: Optional[Union[str, Path, Callable]],
+        image: str,
+        port: int,
+        env: Optional[Dict[str, str]],
+        cpu: str,
+        memory: str,
+        gpu_count: int,
+        gpu_models: Optional[List[str]],
+        min_gpu_memory_gb: Optional[int],
+        world_size: WorldSize,
+        provider_filter: Optional[ProviderFilter],
+        topology_spread: str,
+        nccl_env: Optional[Dict[str, str]],
+        bench: str,
+        rendezvous_backend: str,
+        command: Optional[List[str]],
+        args: Optional[List[str]],
+        pip_packages: Optional[List[str]],
+        ttl_seconds: Optional[int],
+        enable_billing: bool,
+    ) -> Dict[str, Any]:
+        """
+        Build the camelCase JSON dict that PyO3's
+        `create_distributed_deployment` will depythonize into the Rust
+        SDK's `CreateDistributedDeploymentRequest`. Wire shape exactly
+        matches the operator's CRD `spec.distributed`.
+        """
+        # Source packaging: if source is set, ship the user's script and
+        # let the operator render command="auto"; otherwise pass through
+        # explicit command (BYO launcher).
+        rendered_command: Optional[List[str]] = None
+        if source is not None:
+            if callable(source):
+                packager = SourcePackager.from_function(source)
+            else:
+                packager = SourcePackager(source)
+            rendered_command = packager.build_command(pip_packages=pip_packages)
+        elif command is not None:
+            rendered_command = command
+
+        # Resources: distributed UDs always need GPU; default to 1 GPU per
+        # rank pod. The operator's `--nproc-per-node` consumes this.
+        resources: Dict[str, Any] = {
+            "cpu": cpu,
+            "memory": memory,
+            "gpus": {
+                "count": gpu_count,
+                "model": gpu_models or [],
+            },
+        }
+        if min_gpu_memory_gb is not None:
+            resources["gpus"]["minGpuMemoryGb"] = min_gpu_memory_gb
+
+        # Distributed spec, camelCase + kebab-case enums (matches operator CRD).
+        distributed: Dict[str, Any] = {
+            "enabled": True,
+            "command": "auto" if source is not None or command is None else " ".join(command),
+            "worldSize": {
+                "min": world_size.min,
+                "target": world_size.target,
+                "max": world_size.max,
+            },
+            "rendezvous": {"backend": rendezvous_backend},
+            "providerFilter": {
+                "include": list(provider_filter.include) if provider_filter else [],
+                "exclude": list(provider_filter.exclude) if provider_filter else [],
+            },
+            "topologySpread": {"strategy": topology_spread},
+            "nccl": {"env": dict(nccl_env) if nccl_env else {}},
+        }
+        if bench in ("on-start", "off"):
+            distributed["bench"] = {"mode": bench}
+        else:
+            raise ValidationError(
+                f"bench must be 'on-start' or 'off', got {bench!r}",
+                field="bench",
+                value=bench,
+            )
+
+        request: Dict[str, Any] = {
+            "instanceName": name,
+            "image": image,
+            "replicas": world_size.target,
+            "port": port,
+            "command": rendered_command,
+            "args": args,
+            "env": env,
+            "resources": resources,
+            "ttlSeconds": ttl_seconds,
+            "enableBilling": enable_billing,
+            "distributed": distributed,
+        }
+        # Strip None-valued top-level keys so JSON shape matches the
+        # operator's `#[serde(skip_serializing_if = "Option::is_none")]`.
+        return {k: v for k, v in request.items() if v is not None}
+
+    # -------------------------------------------------------------------------
     # Low-Level API Methods (for advanced use cases)
     # -------------------------------------------------------------------------
 
@@ -1671,6 +1914,75 @@ class BasilicaClient:
         await deployment.refresh_async()
 
         return deployment
+
+    async def deploy_distributed_async(
+        self,
+        name: str,
+        source: Optional[Union[str, Path, Callable]] = None,
+        image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+        port: int = 18789,
+        env: Optional[Dict[str, str]] = None,
+        cpu: str = "8",
+        memory: str = "32Gi",
+        gpu_count: int = 1,
+        gpu_models: Optional[List[str]] = None,
+        min_gpu_memory_gb: Optional[int] = None,
+        world_size: Optional[WorldSize] = None,
+        provider_filter: Optional[ProviderFilter] = None,
+        topology_spread: str = "provider-aware",
+        nccl_env: Optional[Dict[str, str]] = None,
+        bench: str = "off",
+        rendezvous_backend: str = "etcd-v2",
+        command: Optional[List[str]] = None,
+        args: Optional[List[str]] = None,
+        pip_packages: Optional[List[str]] = None,
+        ttl_seconds: Optional[int] = None,
+        timeout: int = 600,
+        enable_billing: bool = True,
+    ) -> DistributedTraining:
+        """
+        Async variant of `deploy_distributed`. Same arguments and semantics
+        per SDK arch § 9; uses `run_in_executor` over the underlying Rust
+        client and `asyncio.sleep` for the wait loop.
+        """
+        if world_size is None:
+            raise ValidationError("deploy_distributed_async requires world_size", field="world_size")
+
+        request_dict = self._build_distributed_request(
+            name=name,
+            source=source,
+            image=image,
+            port=port,
+            env=env,
+            cpu=cpu,
+            memory=memory,
+            gpu_count=gpu_count,
+            gpu_models=gpu_models,
+            min_gpu_memory_gb=min_gpu_memory_gb,
+            world_size=world_size,
+            provider_filter=provider_filter,
+            topology_spread=topology_spread,
+            nccl_env=nccl_env,
+            bench=bench,
+            rendezvous_backend=rendezvous_backend,
+            command=command,
+            args=args,
+            pip_packages=pip_packages,
+            ttl_seconds=ttl_seconds,
+            enable_billing=enable_billing,
+        )
+
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(
+            None, self._client.create_distributed_deployment, request_dict
+        )
+        training = DistributedTraining(self, response.instance_name)
+        await training.refresh_async()
+        try:
+            await training.wait_until_min_world_async(timeout=timeout)
+        except BelowMinimumWorld:
+            raise
+        return training
 
     async def get_async(self, name: str) -> Deployment:
         """

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -1029,7 +1029,7 @@ class BasilicaClient:
         command: Optional[List[str]] = None,
         args: Optional[List[str]] = None,
         pip_packages: Optional[List[str]] = None,
-        ttl_seconds: Optional[int] = None,
+        ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
     ) -> DistributedTraining:
@@ -1158,18 +1158,13 @@ class BasilicaClient:
         SDK's `CreateDistributedDeploymentRequest`. Wire shape exactly
         matches the operator's CRD `spec.distributed`.
         """
-        # Source packaging: if source is set, ship the user's script and
-        # let the operator render command="auto"; otherwise pass through
-        # explicit command (BYO launcher).
+        # `spec.command` (top-level) is appended to the operator's BYO
+        # launcher as positional `$@`; for distributed-mode source-shipping
+        # we want the bash script in `spec.distributed.command` to be
+        # self-contained and ignore `$@`. So `spec.command` stays None
+        # for the request, while source-shipping happens via
+        # `spec.distributed.command` below (operator wraps in `sh -c`).
         rendered_command: Optional[List[str]] = None
-        if source is not None:
-            if callable(source):
-                packager = SourcePackager.from_function(source)
-            else:
-                packager = SourcePackager(source)
-            rendered_command = packager.build_command(pip_packages=pip_packages)
-        elif command is not None:
-            rendered_command = command
 
         # Resources: distributed UDs always need GPU; default to 1 GPU per
         # rank pod. The operator's `--nproc-per-node` consumes this.
@@ -1184,10 +1179,69 @@ class BasilicaClient:
         if min_gpu_memory_gb is not None:
             resources["gpus"]["minGpuMemoryGb"] = min_gpu_memory_gb
 
-        # Distributed spec, camelCase + kebab-case enums (matches operator CRD).
+        # `spec.distributed.command` policy:
+        #
+        # - `source` set -> read source text, ship via base64 in a bash
+        #   one-liner that writes `/workspace/__basilica_source.py` then
+        #   exec's torchrun on it. The operator wraps this with `sh -c`
+        #   in BYO mode (operator distributed.rs build_worker_command:
+        #   `command=["/bin/sh", "-c"], args=[<distributed.command>, "--",
+        #   ...user_command, ...user_args]`). Why not "auto"? The
+        #   operator's auto-torchrun renderer does NOT ship source --
+        #   it expects `/workspace/<script>` already in the image. Phase
+        #   5b ships source via this BYO heredoc-free path; Phase 6 may
+        #   move source-shipping into the operator via init container.
+        #
+        # - `command` set -> shlex-join (NOT plain " ".join, which would
+        #   break embedded whitespace / quotes). Operator passes verbatim.
+        #
+        # - neither -> ValidationError. The operator's distributed-mode
+        #   renderer has no "use image ENTRYPOINT, just pass args" mode;
+        #   either source-shipping or explicit launcher is required.
+        if source is not None:
+            import base64 as _b64
+            import shlex as _shlex
+            if callable(source):
+                src_text = SourcePackager.from_function(source).code
+            else:
+                src_text = SourcePackager(source).code
+            src_b64 = _b64.b64encode(src_text.encode("utf-8")).decode("ascii")
+            pip_install = ""
+            if pip_packages:
+                pkg_args = " ".join(_shlex.quote(p) for p in pip_packages)
+                pip_install = f"pip install --quiet {pkg_args} && "
+            backend_token = (
+                "etcd-v2"
+                if rendezvous_backend == "etcd-v2"
+                else rendezvous_backend
+            )
+            distributed_command = (
+                f"{pip_install}"
+                f"echo {src_b64} | base64 -d > /workspace/__basilica_source.py && "
+                f"exec torchrun "
+                f"--rdzv-backend={backend_token} "
+                f"--rdzv-endpoint=\"$BASILICA_RDZV_ENDPOINT\" "
+                f"--rdzv-id=\"$BASILICA_RDZV_ID\" "
+                f"--nnodes=\"$BASILICA_WORLD_MIN\":\"$BASILICA_WORLD_MAX\" "
+                f"--nproc-per-node=\"$BASILICA_GPUS_PER_POD\" "
+                f"--max-restarts=10 "
+                f"/workspace/__basilica_source.py"
+            )
+        elif command is not None:
+            import shlex as _shlex
+            distributed_command = _shlex.join(command)
+        else:
+            raise ValidationError(
+                "deploy_distributed requires either source= (Phase 5b "
+                "ships source via a base64-encoded bash launcher) or "
+                "command= (BYO launcher). Image-entrypoint-only mode is "
+                "not supported by the operator's distributed-mode "
+                "renderer.",
+                field="source",
+            )
         distributed: Dict[str, Any] = {
             "enabled": True,
-            "command": "auto" if source is not None or command is None else " ".join(command),
+            "command": distributed_command,
             "worldSize": {
                 "min": world_size.min,
                 "target": world_size.target,
@@ -1565,6 +1619,19 @@ class BasilicaClient:
         """Get deployment logs."""
         return self._client.get_deployment_logs(instance_name, follow, tail)
 
+    def get_deployment_events(
+        self, instance_name: str, limit: Optional[int] = None, **_ignored: Any
+    ) -> Dict[str, Any]:
+        """
+        Get K8s Events for a deployment, scoped to the user's namespace.
+
+        Returns a dict with `events: [{event_type, reason, message, count,
+        last_timestamp}, ...]`. Used by `DistributedTraining.events()`.
+        Tolerates an unused `since=` kwarg for forward-compat with the
+        Phase 6 server-side filter.
+        """
+        return self._client.get_deployment_events(instance_name, limit)
+
     def get_balance(self) -> Dict[str, Any]:
         """Get account balance."""
         return self._client.get_balance()
@@ -1936,7 +2003,7 @@ class BasilicaClient:
         command: Optional[List[str]] = None,
         args: Optional[List[str]] = None,
         pip_packages: Optional[List[str]] = None,
-        ttl_seconds: Optional[int] = None,
+        ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
     ) -> DistributedTraining:

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -1,13 +1,15 @@
 """
 Decorator-based deployment API.
 
-Provides @deployment decorator for declarative function deployments.
+Provides @deployment decorator for declarative function deployments and
+@distributed decorator for distributed-training (NCCL collective) jobs.
 """
 import functools
 import inspect
 import textwrap
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
+from .distributed import DistributedTraining, ProviderFilter, WorldSize
 from .spec import DeploymentSpec
 from .volume import Volume
 
@@ -229,5 +231,218 @@ def deployment(
             health_check=health_check,
         )
         return DeployedFunction(func, spec)
+
+    return decorator
+
+
+# =============================================================================
+# Distributed-training decorator (SDK arch § 5).
+#
+# Mirrors @deployment: source-introspection, returns a wrapper, calling the
+# wrapper deploys. Differences:
+#   1. The decorated function body is the PER-RANK entrypoint -- the SDK
+#      wraps it under torchrun via the operator's `command="auto"` rendering.
+#   2. The wrapper returns DistributedTraining (not Deployment).
+#   3. Resource flags are distributed-shaped: world_size, provider_filter,
+#      topology_spread, bench, rendezvous_backend, nccl_env.
+#
+# Resolves SDK arch § 13 open question 1 in the simplest direction: rank /
+# world_size / provider / region are accessible inside the decorated body
+# only via env vars (BASILICA_RANK, BASILICA_WORLD_TARGET, BASILICA_PROVIDER,
+# etc.) -- no decorator-injected globals. Matches PyTorch's idiomatic
+# `os.environ['RANK']` pattern.
+# =============================================================================
+
+
+class DistributedFunction:
+    """
+    Wrapper around a function decorated with `@basilica.distributed`.
+
+    Calling the wrapper deploys; `.deploy(client=...)` for explicit-client
+    usage; `.local()` for in-process single-rank testing (mirrors the
+    existing `@deployment.local()` pattern).
+
+    Returns a `DistributedTraining` from `.deploy()` -- NOT a `Deployment`.
+    """
+
+    def __init__(self, func: Callable, kwargs: Dict[str, Any]):
+        self._func = func
+        self._kwargs = kwargs
+        self._training: Optional[DistributedTraining] = None
+        functools.update_wrapper(self, func)
+
+    @property
+    def training(self) -> Optional[DistributedTraining]:
+        """Most recent `DistributedTraining` from `.deploy()`, or None if not yet deployed."""
+        return self._training
+
+    def local(self, *args, **kwargs):
+        """
+        Execute the function locally (single rank, no rendezvous, no NCCL).
+        Matches the @deployment .local() escape hatch for unit testing the
+        function body without a deploy round-trip.
+        """
+        return self._func(*args, **kwargs)
+
+    def deploy(self, client=None) -> DistributedTraining:
+        """
+        Deploy the decorated function as a distributed training job.
+
+        Args:
+            client: Optional BasilicaClient instance. If None, uses default.
+
+        Returns:
+            DistributedTraining: facade with scale/wait/logs/bench/delete
+                and `_async` counterparts.
+        """
+        from . import BasilicaClient
+
+        client = client or BasilicaClient()
+        source = self._extract_source()
+
+        self._training = client.deploy_distributed(
+            source=source,
+            **self._kwargs,
+        )
+        return self._training
+
+    def __call__(self, *args, **kwargs) -> DistributedTraining:
+        """Calling the wrapped function deploys it. SDK arch § 5 example."""
+        return self.deploy()
+
+    def _extract_source(self) -> str:
+        """
+        Extract function body as executable source code, packaged as the
+        per-rank entrypoint. Mirrors `DeployedFunction._extract_source`
+        but emits a torchrun-friendly shape: the body runs once per
+        rank, each rank's torchrun invocation provides
+        `BASILICA_RANK`/`BASILICA_WORLD_*` env vars.
+        """
+        full_source = inspect.getsource(self._func)
+        lines = full_source.split("\n")
+
+        def_idx = 0
+        for i, line in enumerate(lines):
+            if line.lstrip().startswith("def "):
+                def_idx = i
+                break
+
+        func_lines = lines[def_idx:]
+        func_source = textwrap.dedent("\n".join(func_lines))
+        func_name = self._func.__name__
+        return f"""{func_source}
+
+if __name__ == "__main__":
+    {func_name}()
+"""
+
+
+def distributed(
+    name: str,
+    image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+    port: int = 18789,
+    cpu: str = "8",
+    memory: str = "32Gi",
+    gpu_count: int = 1,
+    gpu_models: Optional[List[str]] = None,
+    min_gpu_memory_gb: Optional[int] = None,
+    world_size: Optional[WorldSize] = None,
+    provider_filter: Optional[Union[ProviderFilter, Dict[str, List[str]]]] = None,
+    topology_spread: str = "provider-aware",
+    nccl_env: Optional[Dict[str, str]] = None,
+    bench: str = "off",
+    rendezvous_backend: str = "etcd-v2",
+    env: Optional[Dict[str, str]] = None,
+    pip_packages: Optional[List[str]] = None,
+    ttl_seconds: Optional[int] = None,
+    timeout: int = 600,
+    enable_billing: bool = True,
+) -> Callable[[Callable], DistributedFunction]:
+    """
+    Decorator marking a function as the per-rank entrypoint for a
+    distributed-training UserDeployment. SDK arch § 5.
+
+    The decorated function body is what each rank executes. The standard
+    PyTorch idiom applies: `dist.init_process_group(backend="nccl")` then
+    your training loop. torchrun + the operator handle fan-out; you do
+    NOT branch on `rank == 0`.
+
+    Args:
+        name: Deployment name (DNS-safe).
+        image: Container image (default: pytorch + cuda runtime).
+        port: Worker container port.
+        cpu, memory, gpu_count, gpu_models, min_gpu_memory_gb: Resources
+            per rank pod.
+        world_size: WorldSize(min, target, max). REQUIRED.
+        provider_filter: ProviderFilter or `{"include": [...], "exclude": [...]}` dict.
+        topology_spread: One of `pack | provider-aware | region-aware | none`.
+        nccl_env: NCCL env vars merged on top of operator defaults.
+        bench: `on-start` to schedule a 2-rank NCCL bench probe; `off` (default).
+        rendezvous_backend: `etcd-v2` (default) | `c10d` | `static`.
+        env: Environment variables passed to the worker pods.
+        pip_packages: Additional pip packages to install.
+        ttl_seconds: Auto-delete after N seconds.
+        timeout: Seconds to wait for `min` ranks to be ready. Default 600.
+        enable_billing: Whether to bill for this deployment.
+
+    Returns:
+        DistributedFunction wrapper. Calling it deploys; `.local()` runs
+        in-process for single-rank testing; `.deploy(client=...)` for
+        explicit-client usage.
+
+    Example:
+        >>> import basilica
+        >>> from basilica import WorldSize
+        >>>
+        >>> @basilica.distributed(
+        ...     name="dlc-llama-7b",
+        ...     world_size=WorldSize(min=4, target=8, max=16),
+        ...     gpu_count=1,
+        ...     gpu_models=["H100"],
+        ... )
+        ... def train():
+        ...     import os
+        ...     import torch.distributed as dist
+        ...     dist.init_process_group(backend="nccl")
+        ...     rank = dist.get_rank()
+        ...     # ... DiLoCo loop ...
+        >>>
+        >>> training = train()  # deploys, returns DistributedTraining
+        >>> training.scale(target=12)
+    """
+    if world_size is None:
+        raise ValueError("@distributed requires world_size")
+
+    # Normalize provider_filter dict -> ProviderFilter.
+    if isinstance(provider_filter, dict):
+        provider_filter = ProviderFilter(
+            include=provider_filter.get("include", []),
+            exclude=provider_filter.get("exclude", []),
+        )
+
+    kwargs: Dict[str, Any] = {
+        "name": name,
+        "image": image,
+        "port": port,
+        "cpu": cpu,
+        "memory": memory,
+        "gpu_count": gpu_count,
+        "gpu_models": gpu_models,
+        "min_gpu_memory_gb": min_gpu_memory_gb,
+        "world_size": world_size,
+        "provider_filter": provider_filter,
+        "topology_spread": topology_spread,
+        "nccl_env": nccl_env,
+        "bench": bench,
+        "rendezvous_backend": rendezvous_backend,
+        "env": env,
+        "pip_packages": pip_packages,
+        "ttl_seconds": ttl_seconds,
+        "timeout": timeout,
+        "enable_billing": enable_billing,
+    }
+
+    def decorator(func: Callable) -> DistributedFunction:
+        return DistributedFunction(func, kwargs)
 
     return decorator

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -354,7 +354,7 @@ def distributed(
     rendezvous_backend: str = "etcd-v2",
     env: Optional[Dict[str, str]] = None,
     pip_packages: Optional[List[str]] = None,
-    ttl_seconds: Optional[int] = None,
+    ttl_seconds: Optional[int] = 86400,
     timeout: int = 600,
     enable_billing: bool = True,
 ) -> Callable[[Callable], DistributedFunction]:

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -1,0 +1,577 @@
+"""
+Distributed-training SDK surface (SDK arch § 4 / § 6 / § 8 / § 9).
+
+User-facing types and the `DistributedTraining` facade returned by
+`client.deploy_distributed(...)` and `@basilica.distributed`. Researchers
+import these from `basilica` directly (re-exported in __init__.py).
+
+Tenancy invariant (SDK arch § 7): bench data is per-UD. There is NO
+`client.preflight(...)` and NO `client.nccl_baseline(...)` standalone
+helper -- those would imply a shared cluster-wide cache, which violates
+the platform's tenancy contract. Bench results live on
+`DistributedTraining.bench` and are owned by the user's namespace.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+)
+
+from .exceptions import (
+    BelowMinimumWorld,
+    WorldSizeOutOfBounds,
+)
+
+if TYPE_CHECKING:
+    from . import BasilicaClient
+
+
+# =============================================================================
+# Type model (SDK arch § 8).
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class WorldSize:
+    """
+    World-size triple. `1 <= min <= target <= max`.
+
+    `min` is the floor below which the run pauses (torchelastic's
+    MIN_NODES). `target` is the StatefulSet replica count. `max` is the
+    hard cap; `scale()` rejects requests above it.
+    """
+
+    min: int
+    target: int
+    max: int
+
+    def __post_init__(self) -> None:
+        if self.min < 1:
+            raise WorldSizeOutOfBounds(
+                f"WorldSize.min must be >= 1, got {self.min}",
+                requested=self.min,
+                min=1,
+                max=self.max if self.max >= 1 else 1,
+            )
+        if self.target < self.min:
+            raise WorldSizeOutOfBounds(
+                f"WorldSize.target ({self.target}) must be >= "
+                f"WorldSize.min ({self.min})",
+                requested=self.target,
+                min=self.min,
+                max=self.max,
+            )
+        if self.max < self.target:
+            raise WorldSizeOutOfBounds(
+                f"WorldSize.max ({self.max}) must be >= "
+                f"WorldSize.target ({self.target})",
+                requested=self.target,
+                min=self.min,
+                max=self.max,
+            )
+
+
+@dataclass(frozen=True)
+class ProviderFilter:
+    """
+    Provider include/exclude lists for worker scheduling.
+
+    Empty `include` = any provider. Match is on the `basilica.ai/provider`
+    node label (`hyperstack`, `verda`, `masscompute`, `shadeform`).
+    `exclude` is subtractive after `include`.
+    """
+
+    include: List[str] = field(default_factory=list)
+    exclude: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WorldStatus:
+    """
+    Snapshot of `status.distributed.worldSize` written by the operator.
+
+    `below_minimum=True` means `ready < min` and the run is paused (or
+    the workload's own logic should pause). The operator emits a K8s
+    Event `WorldShrunkBelowMin` on transition.
+    """
+
+    ready: int
+    target: int
+    min: int
+    max: int
+    below_minimum: bool
+
+
+@dataclass(frozen=True)
+class RankStatus:
+    """
+    Per-rank pod observation. Read-only.
+
+    `provider` and `region` come from node labels; `None` when the pod
+    has not been scheduled or the labels are absent.
+    """
+
+    rank: int
+    pod_name: str
+    node: Optional[str]
+    provider: Optional[str]
+    region: Optional[str]
+    phase: str
+    restarts: int
+
+
+@dataclass(frozen=True)
+class BenchResult:
+    """
+    Per-UD bench probe result (SDK arch § 7 / § 8).
+
+    Measured on this UD's actual nodes; always fresh by construction
+    (no freshness tier). `None`-valued fields mean the probe could not
+    measure them (typically a partial sweep).
+
+    Bandwidth fields are GB/s (1 GB = 10^9 bytes), matching the NCCL
+    paper-canonical units. Latency is microseconds at the smallest
+    swept message size.
+    """
+
+    measured_at: datetime
+    busbw_gbps_p10: Optional[float]
+    busbw_gbps_p50: Optional[float]
+    busbw_gbps_p90: Optional[float]
+    algbw_gbps_p50: Optional[float]
+    latency_us_at_1mib: Optional[float]
+    size_bytes_swept: List[int]
+    probe_node_a: str
+    probe_node_b: str
+
+    @classmethod
+    def from_status_dict(cls, raw: Dict[str, Any]) -> "BenchResult":
+        """Construct from the operator's `status.distributed.bench.result` JSON."""
+        ts = raw.get("measuredAt") or raw.get("measured_at")
+        return cls(
+            measured_at=_parse_rfc3339(ts) if ts else datetime.fromtimestamp(0),
+            busbw_gbps_p10=raw.get("busbwGbpsP10"),
+            busbw_gbps_p50=raw.get("busbwGbpsP50"),
+            busbw_gbps_p90=raw.get("busbwGbpsP90"),
+            algbw_gbps_p50=raw.get("algbwGbpsP50"),
+            latency_us_at_1mib=raw.get("latencyUsAt1mib"),
+            size_bytes_swept=list(raw.get("sizeBytesSwept", [])),
+            probe_node_a=raw.get("probeNodeA", ""),
+            probe_node_b=raw.get("probeNodeB", ""),
+        )
+
+
+@dataclass(frozen=True)
+class DistributedMetrics:
+    """
+    Snapshot of platform-side metrics for this UD (SDK arch § 6).
+
+    Sourced from Prometheus via the API gateway. Read-only. Time-series
+    data not exposed here; use Grafana for trend views.
+    """
+
+    world_ready: int
+    world_target: int
+    rendezvous_restarts_total: int
+    rank_restarts_total: int
+    time_to_first_rendezvous_seconds: Optional[float]
+    last_resize_at: Optional[datetime]
+
+
+def _parse_rfc3339(s: str) -> datetime:
+    """Parse RFC 3339 timestamp; tolerates trailing Z."""
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+# =============================================================================
+# DistributedTraining facade (SDK arch § 6).
+# =============================================================================
+
+
+class DistributedTraining:
+    """
+    Handle for a distributed-training UserDeployment.
+
+    Returned by `client.deploy_distributed(...)` and `@basilica.distributed`.
+    Methods read the live operator status (refreshed on each call) and
+    issue control-plane requests (`scale`, `delete`, `wait_*`). Every
+    method has an `_async` counterpart per SDK arch § 9.
+
+    Attributes:
+        name: The deployment instance name.
+        namespace: The user's K8s namespace (`u-<sanitized-user-id>`).
+        rendezvous_endpoint: `<ud>-rendezvous.<ns>.svc.cluster.local:2379`
+            for `etcd-v2` backend; in-cluster only.
+    """
+
+    name: str
+    namespace: str
+    rendezvous_endpoint: str
+
+    def __init__(self, client: "BasilicaClient", name: str):
+        self._client = client
+        self.name = name
+        self._cached_status: Optional[Dict[str, Any]] = None
+
+    # -------------------------------------------------------------------------
+    # Status / observation
+    # -------------------------------------------------------------------------
+
+    def refresh(self) -> None:
+        """Reload status from the API. Subsequent property reads use the new snapshot."""
+        deployment = self._client.get(self.name)
+        self._cached_status = _coerce_to_dict(deployment)
+        self.namespace = self._cached_status.get("namespace", "")
+        self.rendezvous_endpoint = self._derive_rendezvous_endpoint()
+
+    async def refresh_async(self) -> None:
+        """Async variant of `refresh`."""
+        await asyncio.get_event_loop().run_in_executor(None, self.refresh)
+
+    @property
+    def world(self) -> WorldStatus:
+        """Most recent world-size observation. Calls `refresh()` lazily."""
+        if self._cached_status is None:
+            self.refresh()
+        ws = (self._cached_status or {}).get("distributed", {}).get("worldSize") or {}
+        return WorldStatus(
+            ready=int(ws.get("ready", 0)),
+            target=int(ws.get("target", 0)),
+            min=int(ws.get("min", 0)),
+            max=int(ws.get("max", 0)),
+            below_minimum=bool(ws.get("belowMinimum", False)),
+        )
+
+    @property
+    def ranks(self) -> List[RankStatus]:
+        """Per-rank pod observations from `status.distributed.ranks`."""
+        if self._cached_status is None:
+            self.refresh()
+        ranks_raw = (self._cached_status or {}).get("distributed", {}).get("ranks") or []
+        return [
+            RankStatus(
+                rank=int(r.get("rank", 0)),
+                pod_name=r.get("podName", ""),
+                node=r.get("nodeName"),
+                provider=r.get("provider"),
+                region=r.get("region"),
+                phase=r.get("phase", "Unknown"),
+                restarts=int(r.get("restarts", 0)),
+            )
+            for r in ranks_raw
+        ]
+
+    @property
+    def bench(self) -> Optional[BenchResult]:
+        """
+        Per-UD bench probe result, or `None` if `bench.mode != on-start`
+        or the probe has not yet completed its first attempt.
+
+        SDK arch § 7: never a cross-tenant aggregate; always measured
+        on this UD's own nodes, billed against this user's GPU minutes.
+        """
+        if self._cached_status is None:
+            self.refresh()
+        bench_status = (
+            (self._cached_status or {}).get("distributed", {}).get("bench")
+        )
+        if not bench_status:
+            return None
+        result = bench_status.get("result")
+        if not result:
+            return None
+        return BenchResult.from_status_dict(result)
+
+    def metrics(self) -> DistributedMetrics:
+        """Platform-side metric snapshot for this UD (SDK arch § 6)."""
+        if self._cached_status is None:
+            self.refresh()
+        # Phase 5b ships the metric surface read-only on the status; full
+        # Prometheus scraping is on the platform-internal collector
+        # (architecture doc § 12). Phase 6 widens this if needed.
+        ws = self.world
+        return DistributedMetrics(
+            world_ready=ws.ready,
+            world_target=ws.target,
+            rendezvous_restarts_total=0,
+            rank_restarts_total=sum(r.restarts for r in self.ranks),
+            time_to_first_rendezvous_seconds=None,
+            last_resize_at=None,
+        )
+
+    async def metrics_async(self) -> DistributedMetrics:
+        """Async variant of `metrics`."""
+        return await asyncio.get_event_loop().run_in_executor(None, self.metrics)
+
+    def events(self, since: Optional[str] = None) -> List[Dict[str, Any]]:
+        """K8s Events for this UD's namespace, filtered by involvedObject. SDK arch § 6."""
+        # Wraps the existing events endpoint; passes through `since` filter.
+        return self._client.get_deployment_events(self.name, since=since)
+
+    async def events_async(self, since: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Async variant of `events`."""
+        return await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self.events(since=since)
+        )
+
+    # -------------------------------------------------------------------------
+    # Lifecycle
+    # -------------------------------------------------------------------------
+
+    def scale(self, target: int) -> WorldStatus:
+        """
+        Patch `worldSize.target` on the CR. Returns immediately with the
+        intended new state; ranks join/drain asynchronously. Use
+        `wait_until_target_world(timeout=...)` to block.
+
+        Validates `target >= 1` locally before issuing the network call.
+        Server-side bounds check (`min <= target <= max`) returns a 400
+        if the spec's max is smaller than the request.
+
+        Raises:
+            WorldSizeOutOfBounds: target < 1.
+        """
+        if target < 1:
+            raise WorldSizeOutOfBounds(
+                f"scale: target must be >= 1, got {target}",
+                requested=target,
+                min=1,
+                max=1,
+            )
+        # Issue the patch via the new POST /deployments/{name}/scale-distributed
+        # endpoint shipped in the Phase 5b precursor (basilica-backend #421).
+        self._client._client.scale_distributed_deployment(self.name, target)
+        # Refresh local cache so subsequent `world` reads reflect the new target.
+        self.refresh()
+        return self.world
+
+    async def scale_async(self, target: int) -> WorldStatus:
+        """Async variant of `scale`."""
+        return await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self.scale(target)
+        )
+
+    def wait_until_min_world(self, timeout: int = 300) -> None:
+        """
+        Block until `ready >= min`, or raise `BelowMinimumWorld` on
+        timeout. Polls every 5s. SDK arch § 11.
+        """
+        deadline = time.monotonic() + max(timeout, 0)
+        while time.monotonic() < deadline:
+            self.refresh()
+            ws = self.world
+            if ws.ready >= ws.min and ws.min > 0:
+                return
+            if timeout == 0:
+                # Honor a 0-timeout as "raise immediately if not ready".
+                break
+            time.sleep(min(5, max(timeout // 10, 1)))
+        # One last refresh so the exception carries the up-to-date count.
+        self.refresh()
+        ws = self.world
+        if ws.ready < ws.min or ws.min == 0:
+            raise BelowMinimumWorld(
+                f"wait_until_min_world timed out after {timeout}s "
+                f"(ready={ws.ready}, required_min={ws.min})",
+                ready=ws.ready,
+                required_min=ws.min,
+            )
+
+    async def wait_until_min_world_async(self, timeout: int = 300) -> None:
+        """Async variant of `wait_until_min_world`."""
+        deadline = asyncio.get_event_loop().time() + max(timeout, 0)
+        while asyncio.get_event_loop().time() < deadline:
+            await self.refresh_async()
+            ws = self.world
+            if ws.ready >= ws.min and ws.min > 0:
+                return
+            if timeout == 0:
+                break
+            await asyncio.sleep(min(5, max(timeout // 10, 1)))
+        await self.refresh_async()
+        ws = self.world
+        if ws.ready < ws.min or ws.min == 0:
+            raise BelowMinimumWorld(
+                f"wait_until_min_world_async timed out after {timeout}s "
+                f"(ready={ws.ready}, required_min={ws.min})",
+                ready=ws.ready,
+                required_min=ws.min,
+            )
+
+    def wait_until_target_world(self, timeout: int = 600) -> None:
+        """Block until `ready >= target`, or raise `BelowMinimumWorld` on timeout."""
+        deadline = time.monotonic() + max(timeout, 0)
+        while time.monotonic() < deadline:
+            self.refresh()
+            ws = self.world
+            if ws.ready >= ws.target and ws.target > 0:
+                return
+            if timeout == 0:
+                break
+            time.sleep(min(5, max(timeout // 10, 1)))
+        self.refresh()
+        ws = self.world
+        if ws.ready < ws.target or ws.target == 0:
+            raise BelowMinimumWorld(
+                f"wait_until_target_world timed out after {timeout}s "
+                f"(ready={ws.ready}, required_min={ws.target})",
+                ready=ws.ready,
+                required_min=ws.target,
+            )
+
+    async def wait_until_target_world_async(self, timeout: int = 600) -> None:
+        """Async variant of `wait_until_target_world`."""
+        deadline = asyncio.get_event_loop().time() + max(timeout, 0)
+        while asyncio.get_event_loop().time() < deadline:
+            await self.refresh_async()
+            ws = self.world
+            if ws.ready >= ws.target and ws.target > 0:
+                return
+            if timeout == 0:
+                break
+            await asyncio.sleep(min(5, max(timeout // 10, 1)))
+        await self.refresh_async()
+        ws = self.world
+        if ws.ready < ws.target or ws.target == 0:
+            raise BelowMinimumWorld(
+                f"wait_until_target_world_async timed out after {timeout}s "
+                f"(ready={ws.ready}, required_min={ws.target})",
+                ready=ws.ready,
+                required_min=ws.target,
+            )
+
+    def delete(self) -> None:
+        """
+        Delete the UD. Owner-references cascade to StatefulSet,
+        rendezvous Deployment, bench Job, ConfigMap, and NetworkPolicies.
+
+        Returns immediately; the operator handles deletion asynchronously.
+        Researchers needing clean shutdown should `dist.barrier()` +
+        checkpoint inside their training loop before calling this.
+        """
+        self._client.delete_deployment(self.name)
+        self._cached_status = None
+
+    async def delete_async(self) -> None:
+        """Async variant of `delete`."""
+        await asyncio.get_event_loop().run_in_executor(None, self.delete)
+
+    # -------------------------------------------------------------------------
+    # Logs and debug
+    # -------------------------------------------------------------------------
+
+    def logs(
+        self,
+        rank: int = 0,
+        tail: Optional[int] = None,
+        follow: bool = False,
+    ) -> str:
+        """
+        Get logs for a single rank. SDK arch § 6.
+
+        For multi-rank streaming use `stream_logs(ranks=[...])`. Uses the
+        existing per-pod logs endpoint with rank ordinal => pod-index
+        substitution.
+        """
+        return self._client.get_deployment_logs(
+            self.name, follow=follow, tail=tail, rank=rank
+        )
+
+    async def logs_async(
+        self,
+        rank: int = 0,
+        tail: Optional[int] = None,
+        follow: bool = False,
+    ) -> str:
+        """Async variant of `logs`."""
+        return await asyncio.get_event_loop().run_in_executor(
+            None, lambda: self.logs(rank=rank, tail=tail, follow=follow)
+        )
+
+    def stream_logs(
+        self,
+        ranks: Optional[List[int]] = None,
+    ) -> Iterator[Tuple[int, str]]:
+        """
+        Multiplex logs across the given ranks (or all ranks if None).
+        Yields `(rank, line)` in arrival order. SDK arch § 6 / § 13.
+
+        The SDK does the per-rank fan-out via the existing logs(follow=True)
+        plumbing; the platform does not need a new multiplexed endpoint.
+        """
+        target_ranks = ranks if ranks is not None else [r.rank for r in self.ranks]
+        for r in target_ranks:
+            for line in self.logs(rank=r, follow=False).splitlines():
+                yield (r, line)
+
+    async def stream_logs_async(
+        self,
+        ranks: Optional[List[int]] = None,
+    ) -> AsyncIterator[Tuple[int, str]]:
+        """Async variant of `stream_logs`. Yields `(rank, line)` in arrival order."""
+        target_ranks = ranks if ranks is not None else [r.rank for r in self.ranks]
+        for r in target_ranks:
+            text = await self.logs_async(rank=r, follow=False)
+            for line in text.splitlines():
+                yield (r, line)
+
+    # -------------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------------
+
+    def _derive_rendezvous_endpoint(self) -> str:
+        """`<ud>-rendezvous.<ns>.svc.cluster.local:2379` -- in-cluster only."""
+        ns = self.namespace or "u-unknown"
+        return f"{self.name}-rendezvous.{ns}.svc.cluster.local:2379"
+
+
+def _coerce_to_dict(obj: Any) -> Dict[str, Any]:
+    """
+    PyO3 DeploymentResponse -> Python dict for status field access.
+    Tolerates dict input (already-converted) and PyO3 wrappers.
+    """
+    if isinstance(obj, dict):
+        return obj
+    out: Dict[str, Any] = {}
+    for attr in (
+        "instance_name",
+        "user_id",
+        "namespace",
+        "state",
+        "url",
+        "phase",
+        "message",
+    ):
+        if hasattr(obj, attr):
+            out[_to_camel(attr)] = getattr(obj, attr)
+    if hasattr(obj, "namespace"):
+        out["namespace"] = obj.namespace
+    # The PyO3 DeploymentResponse does not currently expose status.distributed
+    # as a typed field. The Python facade reads from `obj.status` if present;
+    # otherwise an empty distributed block. The operator-side patch from the
+    # Phase 5b precursor (basilica-backend #421) populates this on the CR but
+    # the API gateway does not yet pass it through `DeploymentResponse`. The
+    # Python facade will read distributed status from `client.get(...)` once
+    # the API exposes it; until then `world` returns zeros and `bench` returns
+    # None.
+    if hasattr(obj, "_distributed_status"):
+        out["distributed"] = obj._distributed_status  # type: ignore[attr-defined]
+    return out
+
+
+def _to_camel(snake: str) -> str:
+    """`instance_name` -> `instanceName`. Used by the dict-coercion helper."""
+    parts = snake.split("_")
+    return parts[0] + "".join(p.title() for p in parts[1:])

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -316,9 +316,19 @@ class DistributedTraining:
         return await asyncio.get_event_loop().run_in_executor(None, self.metrics)
 
     def events(self, since: Optional[str] = None) -> List[Dict[str, Any]]:
-        """K8s Events for this UD's namespace, filtered by involvedObject. SDK arch § 6."""
-        # Wraps the existing events endpoint; passes through `since` filter.
-        return self._client.get_deployment_events(self.name, since=since)
+        """
+        K8s Events for this UD's namespace, scoped by `involvedObject` to
+        this UD. SDK arch § 6. Returns a list of `{event_type, reason,
+        message, count, last_timestamp}` dicts. The `since` filter is
+        accepted for forward-compat (Phase 6 server-side filter); current
+        behavior is "all available events, most recent first".
+        """
+        response = self._client.get_deployment_events(self.name, since=since)
+        # The PyO3 binding returns a dict like
+        # `{events: [...], total: N}` (pythonize of DeploymentEventsResponse).
+        if isinstance(response, dict):
+            return list(response.get("events", []))
+        return []
 
     async def events_async(self, since: Optional[str] = None) -> List[Dict[str, Any]]:
         """Async variant of `events`."""
@@ -336,12 +346,14 @@ class DistributedTraining:
         intended new state; ranks join/drain asynchronously. Use
         `wait_until_target_world(timeout=...)` to block.
 
-        Validates `target >= 1` locally before issuing the network call.
-        Server-side bounds check (`min <= target <= max`) returns a 400
-        if the spec's max is smaller than the request.
+        Validates locally before the network call:
+        - `target >= 1` (immediate rejection)
+        - `target` falls within the deployment's current
+          `[worldSize.min, worldSize.max]` (refresh first to guard
+          against stale cached bounds)
 
         Raises:
-            WorldSizeOutOfBounds: target < 1.
+            WorldSizeOutOfBounds: target < 1, or target outside `[min, max]`.
         """
         if target < 1:
             raise WorldSizeOutOfBounds(
@@ -349,6 +361,23 @@ class DistributedTraining:
                 requested=target,
                 min=1,
                 max=1,
+            )
+        # Refresh so the bounds check uses the live `worldSize.{min,max}`,
+        # not whatever was cached from earlier (the operator can mutate
+        # min/max only at create-time, but a stale cache from before
+        # creation would show min=max=0).
+        self.refresh()
+        ws = self.world
+        # ws.min == 0 means we have not yet observed the operator's first
+        # status write; in that case skip the bounds check and let the
+        # API gateway return its 400 with the canonical message.
+        if ws.min > 0 and (target < ws.min or target > ws.max):
+            raise WorldSizeOutOfBounds(
+                f"scale: target {target} out of bounds "
+                f"[{ws.min}, {ws.max}]",
+                requested=target,
+                min=ws.min,
+                max=ws.max,
             )
         # Issue the patch via the new POST /deployments/{name}/scale-distributed
         # endpoint shipped in the Phase 5b precursor (basilica-backend #421).
@@ -387,6 +416,7 @@ class DistributedTraining:
                 f"(ready={ws.ready}, required_min={ws.min})",
                 ready=ws.ready,
                 required_min=ws.min,
+                timeout=timeout,
             )
 
     async def wait_until_min_world_async(self, timeout: int = 300) -> None:
@@ -408,6 +438,7 @@ class DistributedTraining:
                 f"(ready={ws.ready}, required_min={ws.min})",
                 ready=ws.ready,
                 required_min=ws.min,
+                timeout=timeout,
             )
 
     def wait_until_target_world(self, timeout: int = 600) -> None:
@@ -429,6 +460,7 @@ class DistributedTraining:
                 f"(ready={ws.ready}, required_min={ws.target})",
                 ready=ws.ready,
                 required_min=ws.target,
+                timeout=timeout,
             )
 
     async def wait_until_target_world_async(self, timeout: int = 600) -> None:
@@ -450,6 +482,7 @@ class DistributedTraining:
                 f"(ready={ws.ready}, required_min={ws.target})",
                 ready=ws.ready,
                 required_min=ws.target,
+                timeout=timeout,
             )
 
     def delete(self) -> None:
@@ -474,30 +507,41 @@ class DistributedTraining:
 
     def logs(
         self,
-        rank: int = 0,
         tail: Optional[int] = None,
         follow: bool = False,
+        rank: Optional[int] = None,
     ) -> str:
         """
-        Get logs for a single rank. SDK arch § 6.
+        Get logs for the deployment. SDK arch § 6.
 
-        For multi-rank streaming use `stream_logs(ranks=[...])`. Uses the
-        existing per-pod logs endpoint with rank ordinal => pod-index
-        substitution.
+        Phase 5b: the underlying `/deployments/{name}/logs` endpoint
+        does not support per-rank filtering server-side, so the `rank`
+        argument is accepted for forward-compat but ignored. All ranks'
+        logs are returned merged. Per-rank filtering is a Phase 6
+        backend enhancement (basilica-backend follow-up).
         """
+        if rank is not None and rank > 0:
+            import warnings as _warnings
+            _warnings.warn(
+                "DistributedTraining.logs(rank=...) is accepted for "
+                "forward-compat but ignored in Phase 5b: the API does "
+                "not yet support per-rank log filtering. All ranks' "
+                "logs returned merged.",
+                stacklevel=2,
+            )
         return self._client.get_deployment_logs(
-            self.name, follow=follow, tail=tail, rank=rank
+            self.name, follow=follow, tail=tail
         )
 
     async def logs_async(
         self,
-        rank: int = 0,
         tail: Optional[int] = None,
         follow: bool = False,
+        rank: Optional[int] = None,
     ) -> str:
-        """Async variant of `logs`."""
+        """Async variant of `logs`. Same Phase 5b rank-filter limitation."""
         return await asyncio.get_event_loop().run_in_executor(
-            None, lambda: self.logs(rank=rank, tail=tail, follow=follow)
+            None, lambda: self.logs(tail=tail, follow=follow, rank=rank)
         )
 
     def stream_logs(
@@ -505,27 +549,39 @@ class DistributedTraining:
         ranks: Optional[List[int]] = None,
     ) -> Iterator[Tuple[int, str]]:
         """
-        Multiplex logs across the given ranks (or all ranks if None).
-        Yields `(rank, line)` in arrival order. SDK arch § 6 / § 13.
+        Yield `(rank, line)` tuples for each log line.
 
-        The SDK does the per-rank fan-out via the existing logs(follow=True)
-        plumbing; the platform does not need a new multiplexed endpoint.
+        Phase 5b: the API returns merged logs without rank tags, so
+        every line is yielded as `(0, line)`. The `ranks` filter is
+        accepted for forward-compat but ignored. SDK arch § 6 / § 13
+        per-rank multiplexing is a Phase 6 backend enhancement.
         """
-        target_ranks = ranks if ranks is not None else [r.rank for r in self.ranks]
-        for r in target_ranks:
-            for line in self.logs(rank=r, follow=False).splitlines():
-                yield (r, line)
+        if ranks is not None:
+            import warnings as _warnings
+            _warnings.warn(
+                "DistributedTraining.stream_logs(ranks=...) is accepted "
+                "but ignored in Phase 5b: per-rank streaming is a "
+                "Phase 6 backend enhancement.",
+                stacklevel=2,
+            )
+        for line in self.logs(follow=False).splitlines():
+            yield (0, line)
 
     async def stream_logs_async(
         self,
         ranks: Optional[List[int]] = None,
     ) -> AsyncIterator[Tuple[int, str]]:
-        """Async variant of `stream_logs`. Yields `(rank, line)` in arrival order."""
-        target_ranks = ranks if ranks is not None else [r.rank for r in self.ranks]
-        for r in target_ranks:
-            text = await self.logs_async(rank=r, follow=False)
-            for line in text.splitlines():
-                yield (r, line)
+        """Async variant of `stream_logs`. Same Phase 5b limitations."""
+        if ranks is not None:
+            import warnings as _warnings
+            _warnings.warn(
+                "DistributedTraining.stream_logs_async(ranks=...) is "
+                "accepted but ignored in Phase 5b.",
+                stacklevel=2,
+            )
+        text = await self.logs_async(follow=False)
+        for line in text.splitlines():
+            yield (0, line)
 
     # -------------------------------------------------------------------------
     # Internal helpers

--- a/crates/basilica-sdk-python/python/basilica/exceptions.py
+++ b/crates/basilica-sdk-python/python/basilica/exceptions.py
@@ -388,3 +388,165 @@ class SourceError(BasilicaError):
             code="SOURCE_ERROR",
             retryable=False
         )
+
+
+# =============================================================================
+# Distributed-training exceptions (SDK arch § 8).
+#
+# Specific subclasses for the operational shapes a researcher iterating on
+# `world_size` will hit, with the actionable numeric context surfaced as
+# attributes (current/limit, ready/required_min, requested/min/max). Generic
+# ValidationError or RuntimeError would force the caller to re-parse the
+# message string -- these structured exceptions don't.
+# =============================================================================
+
+
+class DistributedError(BasilicaError):
+    """
+    Base class for distributed-training-specific errors.
+
+    All exceptions raised by `client.deploy_distributed(...)` and methods
+    on the `DistributedTraining` facade derive from this class. Catch this
+    to handle any distributed-training failure mode generically.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "DISTRIBUTED_ERROR",
+        retryable: bool = False,
+    ):
+        super().__init__(message=message, code=code, retryable=retryable)
+
+
+class QuotaExceeded(DistributedError):
+    """
+    Raised when a distributed deployment would exceed the namespace's rank
+    budget.
+
+    The platform enforces a per-namespace cap on concurrent distributed
+    ranks (default 10; override via `basilica.ai/distributed-rank-budget`
+    annotation on the namespace). When `bench.mode = on-start`, the bench
+    probe (2 ranks) counts against the same budget.
+
+    Attributes:
+        current: Ranks currently in use across the namespace.
+        requested: Ranks the new (or scaled) deployment would add.
+        limit: Hard cap from the namespace annotation.
+
+    Example:
+        >>> # Namespace already at 8/10, requesting 4-rank UD with bench
+        >>> client.deploy_distributed(...)
+        QuotaExceeded: namespace rank budget exceeded:
+            current=8, requested=worker(4)+bench(2)=6, limit=10
+    """
+
+    def __init__(
+        self,
+        message: str,
+        current: int,
+        requested: int,
+        limit: int,
+    ):
+        self.current = current
+        self.requested = requested
+        self.limit = limit
+        super().__init__(
+            message=message,
+            code="DISTRIBUTED_QUOTA_EXCEEDED",
+            retryable=False,
+        )
+
+
+class BelowMinimumWorld(DistributedError):
+    """
+    Raised by `wait_until_min_world(timeout=...)` when the timeout expires
+    before `min` ranks are ready.
+
+    The UD is NOT auto-deleted; the caller decides whether to keep waiting
+    (capacity may still arrive) or `delete()`. SDK arch § 11.
+
+    Attributes:
+        ready: Ranks that did become ready.
+        required_min: `worldSize.min` from the spec.
+
+    Example:
+        >>> training = client.deploy_distributed(..., timeout=300)
+        BelowMinimumWorld: ready=2, required_min=4 (timeout after 300s)
+    """
+
+    def __init__(
+        self,
+        message: str,
+        ready: int,
+        required_min: int,
+    ):
+        self.ready = ready
+        self.required_min = required_min
+        super().__init__(
+            message=message,
+            code="DISTRIBUTED_BELOW_MINIMUM_WORLD",
+            retryable=True,
+        )
+
+
+class RendezvousUnavailable(DistributedError):
+    """
+    Raised when the per-UD rendezvous Pod fails to start within a bounded
+    retry window. The UD is NOT auto-deleted; investigation is the
+    researcher's call (likely to require platform-team support).
+
+    Common causes:
+    - Operator error rendering the rendezvous Deployment.
+    - Image pull failure on the rendezvous (etcd) image.
+    - NetworkPolicy misconfiguration blocking workers from reaching
+      port 2379 on the rendezvous Pod.
+    """
+
+    def __init__(self, message: str = "Rendezvous Pod unavailable"):
+        super().__init__(
+            message=message,
+            code="DISTRIBUTED_RENDEZVOUS_UNAVAILABLE",
+            retryable=True,
+        )
+
+
+class WorldSizeOutOfBounds(DistributedError):
+    """
+    Raised when a `WorldSize` triple violates `1 <= min <= target <= max`,
+    or when `scale(target)` is called with a target outside
+    `[worldSize.min, worldSize.max]`.
+
+    The dataclass `WorldSize.__post_init__` raises this for construction-
+    time violations (`min=0`, `min > target`, `target > max`); the API
+    raises it for `scale()` calls that pass dataclass validation but
+    violate the live bounds.
+
+    Attributes:
+        requested: The target / value that failed validation.
+        min: `worldSize.min` (or 1 if unknown).
+        max: `worldSize.max` (or large sentinel if unknown).
+
+    Example:
+        >>> WorldSize(min=4, target=2, max=8)  # target < min
+        WorldSizeOutOfBounds: requested=2, min=4, max=8
+
+        >>> training.scale(target=12)  # if max=8
+        WorldSizeOutOfBounds: requested=12, min=4, max=8
+    """
+
+    def __init__(
+        self,
+        message: str,
+        requested: int,
+        min: int,
+        max: int,
+    ):
+        self.requested = requested
+        self.min = min
+        self.max = max
+        super().__init__(
+            message=message,
+            code="DISTRIBUTED_WORLD_SIZE_OUT_OF_BOUNDS",
+            retryable=False,
+        )

--- a/crates/basilica-sdk-python/python/basilica/exceptions.py
+++ b/crates/basilica-sdk-python/python/basilica/exceptions.py
@@ -469,10 +469,12 @@ class BelowMinimumWorld(DistributedError):
     Attributes:
         ready: Ranks that did become ready.
         required_min: `worldSize.min` from the spec.
+        timeout: The timeout value (seconds) the wait used. `None` when
+            the exception is raised outside a wait context.
 
     Example:
         >>> training = client.deploy_distributed(..., timeout=300)
-        BelowMinimumWorld: ready=2, required_min=4 (timeout after 300s)
+        BelowMinimumWorld: ready=2, required_min=4, timeout=300s
     """
 
     def __init__(
@@ -480,9 +482,11 @@ class BelowMinimumWorld(DistributedError):
         message: str,
         ready: int,
         required_min: int,
+        timeout: Optional[int] = None,
     ):
         self.ready = ready
         self.required_min = required_min
+        self.timeout = timeout
         super().__init__(
             message=message,
             code="DISTRIBUTED_BELOW_MINIMUM_WORLD",

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -357,6 +357,30 @@ impl BasilicaClient {
         Ok(response.into())
     }
 
+    /// Get K8s Events for a deployment, scoped to the user's namespace.
+    ///
+    /// Returns the response as a Python dict (pythonize-passthrough)
+    /// rather than typed PyO3 mirrors -- the Event shape is small and
+    /// users iterate by key. `limit` caps the per-call event count;
+    /// the operator returns most recent first.
+    #[pyo3(signature = (instance_name, limit=None))]
+    fn get_deployment_events(
+        &self,
+        py: Python,
+        instance_name: String,
+        limit: Option<u32>,
+    ) -> PyResult<Py<pyo3::PyAny>> {
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime.block_on(async move {
+                    client.get_deployment_events(&instance_name, limit).await
+                })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
+        to_pyobject(py, &response)
+    }
+
     /// Get deployment logs
     ///
     /// Args:

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -6,6 +6,7 @@ mod types;
 use basilica_sdk::{
     client::{DEFAULT_API_URL, DEFAULT_TIMEOUT_SECS},
     BasilicaClient as RustClient, ClientBuilder,
+    CreateDistributedDeploymentRequest as SdkCreateDistributedDeploymentRequest,
 };
 use pyo3::exceptions::{
     PyConnectionError, PyKeyError, PyPermissionError, PyRuntimeError, PyValueError,
@@ -15,7 +16,7 @@ use pyo3::prelude::*;
 use pyo3_stub_gen::define_stub_info_gatherer;
 #[cfg(feature = "stub-gen")]
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction};
-use pythonize::pythonize;
+use pythonize::{depythonize, pythonize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
@@ -296,6 +297,63 @@ impl BasilicaClient {
             })
             .map_err(|e| self.map_error_to_python(e))?;
 
+        Ok(response.into())
+    }
+
+    /// Create a distributed-training UserDeployment.
+    ///
+    /// `request` is a Python dict conforming to the
+    /// `CreateDistributedDeploymentRequest` JSON shape (camelCase keys,
+    /// matches the operator CRD's `spec.distributed`). The Python facade
+    /// `BasilicaClient.deploy_distributed(...)` builds this dict from the
+    /// `WorldSize`, `ProviderFilter`, etc. dataclasses (SDK arch § 8) so
+    /// users do not interact with this layer directly.
+    ///
+    /// Done as a depythonize-passthrough rather than 8 nested PyO3 type
+    /// mirrors because the distributed wire shape is deeply nested
+    /// (DistributedSpec → WorldSize / RendezvousSpec / ProviderFilter /
+    /// TopologySpread / NcclSpec / BenchSpec) and each nested struct as
+    /// its own #[pyclass] would be pure boilerplate.
+    fn create_distributed_deployment(
+        &self,
+        py: Python,
+        request: Bound<'_, PyAny>,
+    ) -> PyResult<DeploymentResponse> {
+        let sdk_request: SdkCreateDistributedDeploymentRequest =
+            depythonize(&request).map_err(|e| {
+                PyValueError::new_err(format!("Invalid distributed deployment request: {}", e))
+            })?;
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime.block_on(async move {
+                    client.create_distributed_deployment(sdk_request).await
+                })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
+        Ok(response.into())
+    }
+
+    /// Scale a distributed UserDeployment by patching
+    /// `spec.distributed.worldSize.target`. Bounds-checked at the API
+    /// against the CR's current `[worldSize.min, worldSize.max]`. Returns
+    /// the updated DeploymentResponse; ranks join/drain asynchronously.
+    fn scale_distributed_deployment(
+        &self,
+        py: Python,
+        instance_name: String,
+        target: u32,
+    ) -> PyResult<DeploymentResponse> {
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime.block_on(async move {
+                    client
+                        .scale_distributed_deployment(&instance_name, target)
+                        .await
+                })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
         Ok(response.into())
     }
 

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -368,10 +368,84 @@ class TestBuildDistributedRequest:
         assert d["topologySpread"]["strategy"] == "provider-aware"
         assert d["bench"]["mode"] == "on-start"
         assert d["nccl"]["env"]["NCCL_DEBUG"] == "WARN"
+        # BYO command: shlex-joined, NOT auto-mapped to "auto" because
+        # `source` was None (regression guard for review-comment fix).
+        assert d["command"] != "auto"
+        assert "python" in d["command"]
+        assert "train.py" in d["command"]
+
+    def test_neither_source_nor_command_raises(self) -> None:
+        from basilica.exceptions import ValidationError
+
+        client = self._client()
+        with pytest.raises(ValidationError) as exc_info:
+            client._build_distributed_request(
+                name="dlc-test",
+                source=None,
+                image="x",
+                port=80,
+                env=None,
+                cpu="1",
+                memory="1Gi",
+                gpu_count=1,
+                gpu_models=None,
+                min_gpu_memory_gb=None,
+                world_size=WorldSize(min=1, target=1, max=1),
+                provider_filter=None,
+                topology_spread="provider-aware",
+                nccl_env=None,
+                bench="off",
+                rendezvous_backend="etcd-v2",
+                command=None,
+                args=None,
+                pip_packages=None,
+                ttl_seconds=None,
+                enable_billing=True,
+            )
+        # Reviewer concern: with neither `source` nor `command`, we used
+        # to silently default `distributed.command` to "auto", breaking
+        # the BYO-launcher example. Now we hard-fail.
+        msg = str(exc_info.value).lower()
+        assert "source" in msg or "command" in msg
+
+    def test_source_string_ships_via_b64(self) -> None:
+        # Source-shipping path: writes /workspace/__basilica_source.py via
+        # base64-decoded bash one-liner. Operator wraps in `sh -c`.
+        client = self._client()
+        req = client._build_distributed_request(
+            name="dlc-source-test",
+            source="print('hello')\n",
+            image="my-image",
+            port=18789,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=1, target=1, max=1),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="off",
+            rendezvous_backend="etcd-v2",
+            command=None,
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+        )
+        d_cmd = req["distributed"]["command"]
+        assert "base64 -d > /workspace/__basilica_source.py" in d_cmd
+        assert "exec torchrun" in d_cmd
+        assert "$BASILICA_RDZV_ENDPOINT" in d_cmd
+        assert d_cmd != "auto"
 
     def test_invalid_bench_mode_rejected(self) -> None:
+        from basilica.exceptions import ValidationError
+
         client = self._client()
-        with pytest.raises(Exception):  # ValidationError from basilica
+        with pytest.raises(ValidationError) as exc_info:
             client._build_distributed_request(
                 name="dlc-test",
                 source=None,
@@ -389,12 +463,13 @@ class TestBuildDistributedRequest:
                 nccl_env=None,
                 bench="invalid-mode",
                 rendezvous_backend="etcd-v2",
-                command=None,
+                command=["python", "x.py"],
                 args=None,
                 pip_packages=None,
                 ttl_seconds=None,
                 enable_billing=True,
             )
+        assert exc_info.value.field == "bench"
 
 
 # =============================================================================
@@ -466,13 +541,22 @@ class TestExceptionAttributes:
         assert e.requested == 6
         assert e.limit == 10
 
-    def test_below_minimum_world_carries_ready_and_required(self) -> None:
+    def test_below_minimum_world_carries_ready_required_and_timeout(self) -> None:
         e = BelowMinimumWorld(
             "ready=2, required_min=4 (timeout 300s)",
-            ready=2, required_min=4,
+            ready=2,
+            required_min=4,
+            timeout=300,
         )
         assert e.ready == 2
         assert e.required_min == 4
+        assert e.timeout == 300
+
+    def test_below_minimum_world_timeout_optional(self) -> None:
+        # Outside a wait context (e.g. raised from event-stream parsing),
+        # timeout may be None.
+        e = BelowMinimumWorld("inline", ready=0, required_min=2)
+        assert e.timeout is None
 
     def test_world_size_out_of_bounds_carries_full_triple(self) -> None:
         e = WorldSizeOutOfBounds(

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -1,0 +1,484 @@
+"""
+Unit tests for the distributed-training SDK surface (Phase 5b).
+
+Coverage:
+- Dataclass __post_init__ validation (WorldSize bounds).
+- DistributedTraining.scale rejects target<1 BEFORE the network call.
+- wait_until_min_world(timeout=0) raises BelowMinimumWorld immediately.
+- NEGATIVE TEST: BasilicaClient has NO preflight / nccl_baseline. This
+  pins the SDK arch § 7 tenancy contract -- a future agent restoring
+  those helpers would not break tests without explicit removal of the
+  assertion.
+- Build-helper produces correct camelCase JSON for POST /deployments.
+
+These tests do NOT require a running cluster. The Phase 5b prompt's
+"Test E" (live e2e on K3s) is a separate manual run, deferred until the
+DNS-1035 fix lands in basilica-api.
+"""
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from basilica import (
+    BasilicaClient,
+    BelowMinimumWorld,
+    BenchResult,
+    DistributedFunction,
+    DistributedTraining,
+    ProviderFilter,
+    QuotaExceeded,
+    RankStatus,
+    WorldSize,
+    WorldSizeOutOfBounds,
+    WorldStatus,
+    distributed,
+)
+
+
+# =============================================================================
+# Dataclass validation (SDK arch § 8).
+# =============================================================================
+
+
+class TestWorldSizeValidation:
+    def test_valid_triples_accepted(self) -> None:
+        WorldSize(min=1, target=1, max=1)
+        WorldSize(min=2, target=4, max=8)
+        WorldSize(min=4, target=4, max=4)
+
+    def test_min_zero_rejected(self) -> None:
+        with pytest.raises(WorldSizeOutOfBounds) as exc_info:
+            WorldSize(min=0, target=1, max=1)
+        assert exc_info.value.requested == 0
+        assert "min must be >= 1" in str(exc_info.value)
+
+    def test_target_below_min_rejected(self) -> None:
+        with pytest.raises(WorldSizeOutOfBounds) as exc_info:
+            WorldSize(min=4, target=2, max=8)
+        assert exc_info.value.requested == 2
+        assert exc_info.value.min == 4
+        assert "must be >= WorldSize.min" in str(exc_info.value)
+
+    def test_max_below_target_rejected(self) -> None:
+        with pytest.raises(WorldSizeOutOfBounds) as exc_info:
+            WorldSize(min=2, target=8, max=4)
+        assert exc_info.value.requested == 8
+        assert exc_info.value.max == 4
+        assert "must be >= WorldSize.target" in str(exc_info.value)
+
+
+class TestProviderFilterDefaults:
+    def test_empty_lists_default(self) -> None:
+        pf = ProviderFilter()
+        assert pf.include == []
+        assert pf.exclude == []
+
+
+# =============================================================================
+# NEGATIVE TEST -- locks SDK arch § 7 tenancy contract.
+#
+# A future agent restoring `client.preflight(...)` or
+# `client.nccl_baseline(...)` would not break tests without explicit
+# removal of these assertions. That is exactly the property the Phase 5b
+# prompt asks for: do not let those user-facing helpers come back as a
+# silent regression.
+# =============================================================================
+
+
+class TestNoStandaloneBenchHelpers:
+    def test_basilica_client_has_no_preflight(self) -> None:
+        assert not hasattr(BasilicaClient, "preflight"), (
+            "BasilicaClient.preflight was removed in Phase 5b -- it implied "
+            "a shared cross-tenant cache, violating SDK arch § 7. Bench data "
+            "is per-UD via training.bench. Do NOT restore this method."
+        )
+
+    def test_basilica_client_has_no_nccl_baseline(self) -> None:
+        assert not hasattr(BasilicaClient, "nccl_baseline"), (
+            "BasilicaClient.nccl_baseline was removed in Phase 5b for the "
+            "same SDK arch § 7 reason as preflight. Per-UD bench probes "
+            "(bench='on-start' + training.bench) are the supported path."
+        )
+
+    def test_basilica_client_has_no_preflight_async(self) -> None:
+        assert not hasattr(BasilicaClient, "preflight_async")
+        assert not hasattr(BasilicaClient, "nccl_baseline_async")
+
+    def test_basilica_module_does_not_expose_preflight(self) -> None:
+        import basilica
+        assert not hasattr(basilica, "preflight")
+        assert not hasattr(basilica, "nccl_baseline")
+
+
+# =============================================================================
+# DistributedTraining facade behaviour (SDK arch § 6).
+# =============================================================================
+
+
+def _make_mock_training(
+    name: str = "dlc-test",
+    namespace: str = "u-test",
+    world: Dict[str, Any] = None,
+) -> DistributedTraining:
+    """Build a DistributedTraining whose backing client is fully mocked.
+
+    Uses a plain MagicMock (no spec) because BasilicaClient's `_client`
+    is a private attribute holding the PyO3 binding -- spec-based mocks
+    refuse to materialize private attrs lazily, and tests need to read
+    `training._client._client.scale_distributed_deployment` to assert
+    the SDK's pre-network rejection contract.
+    """
+    client = MagicMock()
+    # Explicitly install the inner PyO3-bound `_client` attribute so the
+    # facade's `self._client._client.scale_distributed_deployment(...)`
+    # call resolves without surfacing a spec error.
+    client._client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.namespace = namespace
+    fake_response._distributed_status = {
+        "worldSize": world or {"ready": 0, "target": 0, "min": 2, "max": 4, "belowMinimum": True},
+    }
+    client.get.return_value = fake_response
+    training = DistributedTraining(client, name)
+    # Pre-populate cache so methods don't try to refresh.
+    training._cached_status = {
+        "namespace": namespace,
+        "distributed": {
+            "worldSize": world or {
+                "ready": 0,
+                "target": 0,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": True,
+            },
+        },
+    }
+    training.namespace = namespace
+    training.rendezvous_endpoint = (
+        f"{name}-rendezvous.{namespace}.svc.cluster.local:2379"
+    )
+    return training
+
+
+class TestDistributedTrainingScale:
+    def test_scale_zero_rejected_before_network(self) -> None:
+        training = _make_mock_training()
+        with pytest.raises(WorldSizeOutOfBounds) as exc_info:
+            training.scale(target=0)
+        assert exc_info.value.requested == 0
+        # The PyO3 client method must NOT have been called -- the rejection
+        # is local. This is the SDK arch § 11 contract: target < 1 fails
+        # synchronously before any HTTP call.
+        training._client._client.scale_distributed_deployment.assert_not_called()
+
+    def test_scale_negative_rejected_before_network(self) -> None:
+        training = _make_mock_training()
+        with pytest.raises(WorldSizeOutOfBounds):
+            training.scale(target=-1)
+        training._client._client.scale_distributed_deployment.assert_not_called()
+
+    def test_scale_passes_target_through_to_client(self) -> None:
+        training = _make_mock_training()
+        # First call returns; subsequent refresh re-reads cached status.
+        training._client._client.scale_distributed_deployment = MagicMock()
+        # Stub get() so refresh() after the scale doesn't blow up.
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 0,
+                        "target": 3,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": True,
+                    }
+                },
+            )
+        )
+        ws = training.scale(target=3)
+        training._client._client.scale_distributed_deployment.assert_called_once_with(
+            "dlc-test", 3
+        )
+        assert ws.target == 3
+
+
+class TestWaitUntilMinWorld:
+    def test_timeout_zero_raises_below_minimum_immediately(self) -> None:
+        # World is below min (ready=0, min=2). With timeout=0, the call
+        # must raise BelowMinimumWorld synchronously without spinning.
+        training = _make_mock_training(
+            world={"ready": 0, "target": 2, "min": 2, "max": 4, "belowMinimum": True},
+        )
+        # Stub refresh-time get() so the final refresh inside wait sees
+        # the same below-min state.
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 0,
+                        "target": 2,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": True,
+                    }
+                },
+            )
+        )
+        with pytest.raises(BelowMinimumWorld) as exc_info:
+            training.wait_until_min_world(timeout=0)
+        assert exc_info.value.ready == 0
+        assert exc_info.value.required_min == 2
+
+    def test_returns_when_world_already_at_min(self) -> None:
+        training = _make_mock_training(
+            world={"ready": 4, "target": 4, "min": 2, "max": 8, "belowMinimum": False},
+        )
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 4,
+                        "target": 4,
+                        "min": 2,
+                        "max": 8,
+                        "belowMinimum": False,
+                    }
+                },
+            )
+        )
+        # Should return without raising.
+        training.wait_until_min_world(timeout=10)
+
+
+class TestAsyncParity:
+    """SDK arch § 9: every facade method has an _async counterpart."""
+
+    def test_distributed_training_has_async_counterparts(self) -> None:
+        for sync_name in [
+            "scale",
+            "wait_until_min_world",
+            "wait_until_target_world",
+            "metrics",
+            "events",
+            "logs",
+            "stream_logs",
+            "refresh",
+            "delete",
+        ]:
+            async_name = f"{sync_name}_async"
+            assert hasattr(DistributedTraining, async_name), (
+                f"DistributedTraining.{async_name} missing -- SDK arch § 9 "
+                f"requires every method to have an _async counterpart."
+            )
+
+    def test_basilica_client_has_deploy_distributed_async(self) -> None:
+        assert hasattr(BasilicaClient, "deploy_distributed")
+        assert hasattr(BasilicaClient, "deploy_distributed_async")
+
+
+# =============================================================================
+# BenchResult parsing (SDK arch § 7 / § 8).
+# =============================================================================
+
+
+class TestBenchResult:
+    def test_parses_full_status_dict(self) -> None:
+        raw = {
+            "measuredAt": "2026-05-02T10:00:00Z",
+            "busbwGbpsP10": 0.045,
+            "busbwGbpsP50": 0.063,
+            "busbwGbpsP90": 0.072,
+            "algbwGbpsP50": 0.058,
+            "latencyUsAt1mib": 1850.0,
+            "sizeBytesSwept": [1048576, 16777216, 268435456],
+            "probeNodeA": "basilica-verda-fin-03",
+            "probeNodeB": "basilica-verda-fin-04",
+        }
+        result = BenchResult.from_status_dict(raw)
+        assert result.busbw_gbps_p50 == 0.063
+        assert result.size_bytes_swept == [1048576, 16777216, 268435456]
+        assert result.probe_node_a == "basilica-verda-fin-03"
+        assert result.probe_node_b == "basilica-verda-fin-04"
+
+    def test_handles_missing_optionals(self) -> None:
+        # Probe failed mid-sweep -- some percentile fields absent.
+        raw = {
+            "measuredAt": "2026-05-02T10:00:00Z",
+            "probeNodeA": "node-a",
+            "probeNodeB": "node-b",
+        }
+        result = BenchResult.from_status_dict(raw)
+        assert result.busbw_gbps_p50 is None
+        assert result.latency_us_at_1mib is None
+        assert result.size_bytes_swept == []
+
+
+# =============================================================================
+# CreateDistributedDeploymentRequest build path (BasilicaClient internal).
+# =============================================================================
+
+
+class TestBuildDistributedRequest:
+    def _client(self) -> BasilicaClient:
+        # Construct a client without trying to authenticate. We only
+        # exercise the internal `_build_distributed_request` helper.
+        client = BasilicaClient.__new__(BasilicaClient)
+        client._base_url = "https://api.basilica.ai"
+        return client
+
+    def test_request_shape_camelcase_kebab_enums(self) -> None:
+        client = self._client()
+        req = client._build_distributed_request(
+            name="dlc-test",
+            source=None,
+            image="my-image",
+            port=18789,
+            env=None,
+            cpu="8",
+            memory="32Gi",
+            gpu_count=1,
+            gpu_models=["A100"],
+            min_gpu_memory_gb=40,
+            world_size=WorldSize(min=2, target=4, max=8),
+            provider_filter=ProviderFilter(include=["verda"], exclude=[]),
+            topology_spread="provider-aware",
+            nccl_env={"NCCL_DEBUG": "WARN"},
+            bench="on-start",
+            rendezvous_backend="etcd-v2",
+            command=["python", "train.py"],
+            args=["--epochs", "10"],
+            pip_packages=None,
+            ttl_seconds=3600,
+            enable_billing=True,
+        )
+        assert req["instanceName"] == "dlc-test"
+        assert req["replicas"] == 4  # mirrors target
+        d = req["distributed"]
+        assert d["enabled"] is True
+        assert d["worldSize"] == {"min": 2, "target": 4, "max": 8}
+        assert d["rendezvous"]["backend"] == "etcd-v2"
+        assert d["providerFilter"]["include"] == ["verda"]
+        assert d["providerFilter"]["exclude"] == []
+        assert d["topologySpread"]["strategy"] == "provider-aware"
+        assert d["bench"]["mode"] == "on-start"
+        assert d["nccl"]["env"]["NCCL_DEBUG"] == "WARN"
+
+    def test_invalid_bench_mode_rejected(self) -> None:
+        client = self._client()
+        with pytest.raises(Exception):  # ValidationError from basilica
+            client._build_distributed_request(
+                name="dlc-test",
+                source=None,
+                image="x",
+                port=80,
+                env=None,
+                cpu="1",
+                memory="1Gi",
+                gpu_count=1,
+                gpu_models=None,
+                min_gpu_memory_gb=None,
+                world_size=WorldSize(min=1, target=1, max=1),
+                provider_filter=None,
+                topology_spread="provider-aware",
+                nccl_env=None,
+                bench="invalid-mode",
+                rendezvous_backend="etcd-v2",
+                command=None,
+                args=None,
+                pip_packages=None,
+                ttl_seconds=None,
+                enable_billing=True,
+            )
+
+
+# =============================================================================
+# Decorator (SDK arch § 5).
+# =============================================================================
+
+
+class TestDistributedDecorator:
+    def test_returns_distributed_function_wrapper(self) -> None:
+        @distributed(
+            name="dlc-decorator-test",
+            world_size=WorldSize(min=2, target=2, max=2),
+            gpu_count=1,
+        )
+        def train_fn() -> None:
+            pass
+
+        assert isinstance(train_fn, DistributedFunction)
+        assert train_fn._kwargs["name"] == "dlc-decorator-test"
+        assert train_fn._kwargs["world_size"].target == 2
+
+    def test_local_runs_function_in_process(self) -> None:
+        executed = []
+
+        @distributed(
+            name="dlc-decorator-local",
+            world_size=WorldSize(min=1, target=1, max=1),
+            gpu_count=1,
+        )
+        def train_fn() -> None:
+            executed.append(1)
+
+        train_fn.local()
+        assert executed == [1]
+
+    def test_decorator_normalizes_provider_filter_dict(self) -> None:
+        @distributed(
+            name="dlc-pf-dict",
+            world_size=WorldSize(min=1, target=1, max=1),
+            provider_filter={"include": ["hyperstack"], "exclude": ["masscompute"]},
+            gpu_count=1,
+        )
+        def train_fn() -> None:
+            pass
+
+        pf = train_fn._kwargs["provider_filter"]
+        assert isinstance(pf, ProviderFilter)
+        assert pf.include == ["hyperstack"]
+        assert pf.exclude == ["masscompute"]
+
+    def test_decorator_requires_world_size(self) -> None:
+        with pytest.raises(ValueError, match="world_size"):
+            @distributed(name="dlc-missing-ws")
+            def _(): pass
+
+
+# =============================================================================
+# Exception attribute round-trip (SDK arch § 8 -- structured context).
+# =============================================================================
+
+
+class TestExceptionAttributes:
+    def test_quota_exceeded_carries_three_numbers(self) -> None:
+        e = QuotaExceeded(
+            "namespace rank budget exceeded: current=8, requested=6, limit=10",
+            current=8, requested=6, limit=10,
+        )
+        assert e.current == 8
+        assert e.requested == 6
+        assert e.limit == 10
+
+    def test_below_minimum_world_carries_ready_and_required(self) -> None:
+        e = BelowMinimumWorld(
+            "ready=2, required_min=4 (timeout 300s)",
+            ready=2, required_min=4,
+        )
+        assert e.ready == 2
+        assert e.required_min == 4
+
+    def test_world_size_out_of_bounds_carries_full_triple(self) -> None:
+        e = WorldSizeOutOfBounds(
+            "requested=12, min=4, max=8",
+            requested=12, min=4, max=8,
+        )
+        assert e.requested == 12
+        assert e.min == 4
+        assert e.max == 8

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -45,14 +45,16 @@ use crate::{
     types::{
         ApiKeyInfo, ApiKeyResponse, ApiListRentalsResponse, BalanceResponse, CardPurchaseResponse,
         CardPurchaseSummary, CreateApiKeyRequest, CreateCardPurchaseRequest,
-        CreateDeploymentRequest, CreateDepositAccountResponse, DeleteDeploymentResponse,
-        DeleteShareTokenResponse, DeploymentEventsResponse, DeploymentListResponse,
-        DeploymentResponse, DepositAccountResponse, EnrollMetadataRequest, EnrollMetadataResponse,
-        HealthCheckResponse, HistoricalRentalsResponse, ListAvailableNodesQuery,
-        ListCardPurchasesResponse, ListDepositsQuery, ListDepositsResponse, ListRentalsQuery,
-        PublicDeploymentMetadataResponse, RegenerateShareTokenResponse, RegisterSshKeyRequest,
-        RentalResponse, RentalStatusWithSshResponse, RentalUsageResponse, ScaleDeploymentRequest,
-        ShareTokenStatusResponse, SshKeyResponse, UsageHistoryResponse, WaitOptions, WaitResult,
+        CreateDeploymentRequest, CreateDepositAccountResponse, CreateDistributedDeploymentRequest,
+        DeleteDeploymentResponse, DeleteShareTokenResponse, DeploymentEventsResponse,
+        DeploymentListResponse, DeploymentResponse, DepositAccountResponse, EnrollMetadataRequest,
+        EnrollMetadataResponse, HealthCheckResponse, HistoricalRentalsResponse,
+        ListAvailableNodesQuery, ListCardPurchasesResponse, ListDepositsQuery,
+        ListDepositsResponse, ListRentalsQuery, PublicDeploymentMetadataResponse,
+        RegenerateShareTokenResponse, RegisterSshKeyRequest, RentalResponse,
+        RentalStatusWithSshResponse, RentalUsageResponse, ScaleDeploymentRequest,
+        ScaleDistributedRequest, ShareTokenStatusResponse, SshKeyResponse, UsageHistoryResponse,
+        WaitOptions, WaitResult,
     },
     StartRentalApiRequest,
 };
@@ -957,6 +959,48 @@ impl BasilicaClient {
     ) -> Result<DeploymentResponse> {
         let path = format!("/deployments/{}/scale", instance_name);
         let request = ScaleDeploymentRequest { replicas };
+        self.post(&path, &request).await
+    }
+
+    /// Create a distributed-training UserDeployment.
+    ///
+    /// Posts to `POST /deployments` with `spec.distributed` populated; the
+    /// operator switches the workload from a single-replica Deployment to
+    /// a per-UD StatefulSet + rendezvous Pod + per-rank pods. SDK arch
+    /// § 4 / § 12.
+    ///
+    /// Use this when the workload uses NCCL collectives across multiple
+    /// pods (DiLoCo, SparseLoCo, etc.). For single-replica or HTTP
+    /// services, use `create_deployment` instead.
+    ///
+    /// # Errors
+    ///
+    /// * `ApiError::Validation` — `worldSize` bounds invalid (`min > target`,
+    ///   `target > max`, or any of them zero), or non-distributed admission
+    ///   constraints fail.
+    /// * `ApiError::ResourceUnavailable` — namespace rank-budget exceeded.
+    pub async fn create_distributed_deployment(
+        &self,
+        request: CreateDistributedDeploymentRequest,
+    ) -> Result<DeploymentResponse> {
+        self.post("/deployments", &request).await
+    }
+
+    /// Scale a distributed UserDeployment by patching
+    /// `spec.distributed.worldSize.target`. Bounds checked at the API
+    /// against `[worldSize.min, worldSize.max]` of the current spec.
+    ///
+    /// `target` must satisfy `min ≤ target ≤ max`; out-of-bounds requests
+    /// fail synchronously with `ApiError::Validation`. Does NOT block;
+    /// new ranks join asynchronously. Use the SDK's `wait_until_target_world`
+    /// to block on convergence.
+    pub async fn scale_distributed_deployment(
+        &self,
+        instance_name: &str,
+        target: u32,
+    ) -> Result<DeploymentResponse> {
+        let path = format!("/deployments/{}/scale-distributed", instance_name);
+        let request = ScaleDistributedRequest { target };
         self.post(&path, &request).await
     }
 

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1139,6 +1139,272 @@ pub struct ScaleDeploymentRequest {
     pub replicas: u32,
 }
 
+// =============================================================================
+// Distributed-training wire types (SDK arch § 4 / § 8 / § 12).
+//
+// These mirror the operator's CRD shape exactly. The serde rename rules
+// produce the JSON the API expects (camelCase + kebab-case enum tokens,
+// matching `crates/basilica-operator/src/crd/user_deployment.rs`). Tests at
+// the bottom of this module pin the wire shape so SDK and operator cannot
+// drift silently.
+//
+// Naming convention: Rust types are `Distributed*`-prefixed to keep this
+// surface unambiguous in the SDK's flat namespace. The user-facing Python
+// dataclasses (in `distributed.py`) drop the prefix per SDK arch § 8.
+// =============================================================================
+
+/// Scale-distributed request — patches `spec.distributed.worldSize.target`
+/// only via JSON merge-patch on the operator-side CR. Bounds (`min ≤ target
+/// ≤ max`) are enforced by the basilica-api endpoint and the operator's
+/// admission. SDK arch § 12.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScaleDistributedRequest {
+    pub target: u32,
+}
+
+/// Rendezvous backend for torchelastic. `etcd-v2` is the default — the only
+/// backend with full elasticity. `c10d` and `static` are escape hatches for
+/// users who explicitly opt out of elasticity. SDK arch § 4 footnote on
+/// auto-torchrun wrapping.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DistributedRendezvousBackend {
+    #[default]
+    EtcdV2,
+    C10d,
+    Static,
+}
+
+/// Rendezvous Pod configuration. `port=None` lets the operator pick the
+/// default for the chosen backend (2379 for `etcd-v2`, 29400 for c10d/static).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedRendezvousSpec {
+    #[serde(default)]
+    pub backend: DistributedRendezvousBackend,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+/// Provider filter for worker scheduling. Empty `include` = any provider.
+/// Match is on the `basilica.ai/provider` node label (e.g. `hyperstack`,
+/// `verda`, `masscompute`, `shadeform`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedProviderFilter {
+    #[serde(default)]
+    pub include: Vec<String>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+/// Topology spread strategy for ranks-to-nodes assignment. SDK arch § 4.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DistributedTopologySpreadStrategy {
+    Pack,
+    #[default]
+    ProviderAware,
+    RegionAware,
+    None,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedTopologySpread {
+    #[serde(default)]
+    pub strategy: DistributedTopologySpreadStrategy,
+}
+
+/// User-supplied NCCL env merged on top of operator defaults. User values
+/// win on collision. SDK arch § 4 / platform doc § 8.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedNcclSpec {
+    #[serde(default)]
+    pub env: std::collections::BTreeMap<String, String>,
+}
+
+/// Per-UD bench probe mode. `OnStart` schedules a 2-rank NCCL
+/// `all_reduce_perf` Job in the user's namespace alongside the worker
+/// StatefulSet. Counts against the namespace rank budget. Result lands on
+/// `status.distributed.bench` (read via `DistributedTraining.bench`).
+/// SDK arch § 7 (tenancy invariant — bench is per-UD, never cross-tenant).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DistributedBenchMode {
+    #[default]
+    Off,
+    OnStart,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedBenchSpec {
+    #[serde(default)]
+    pub mode: DistributedBenchMode,
+}
+
+/// World-size triple: `min ≤ target ≤ max`. The operator clamps the worker
+/// StatefulSet replica count to `target` and reconciles toward it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedWorldSize {
+    pub min: u32,
+    pub target: u32,
+    pub max: u32,
+}
+
+/// `spec.distributed` block on the UserDeployment CR. SDK arch § 4.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedSpec {
+    #[serde(default = "default_distributed_enabled")]
+    pub enabled: bool,
+    pub world_size: DistributedWorldSize,
+    #[serde(default)]
+    pub rendezvous: DistributedRendezvousSpec,
+    #[serde(default)]
+    pub provider_filter: DistributedProviderFilter,
+    #[serde(default)]
+    pub topology_spread: DistributedTopologySpread,
+    #[serde(default)]
+    pub nccl: DistributedNcclSpec,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bench: Option<DistributedBenchSpec>,
+    #[serde(default = "default_distributed_command")]
+    pub command: String,
+}
+
+fn default_distributed_enabled() -> bool {
+    true
+}
+
+fn default_distributed_command() -> String {
+    "auto".to_string()
+}
+
+/// Distributed-training deployment creation request. Serializes to the same
+/// `POST /deployments` body as `CreateDeploymentRequest` but `distributed`
+/// is required (not optional). Use this when the workload should be a
+/// distributed StatefulSet (rather than a single-replica Deployment).
+/// SDK arch § 12.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDistributedDeploymentRequest {
+    pub instance_name: String,
+    pub image: String,
+    /// Ignored when distributed mode is enabled (operator uses
+    /// `worldSize.target`); kept for wire compatibility with the API's
+    /// CreateDeploymentRequest. Set to `worldSize.target` for clarity.
+    pub replicas: u32,
+    pub port: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<std::collections::HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourceRequirements>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<u32>,
+    #[serde(default = "default_enable_billing")]
+    pub enable_billing: bool,
+    /// Distributed-training spec. Required for this request type.
+    pub distributed: DistributedSpec,
+}
+
+/// Per-rank pod observation. Read-only, populated on
+/// `status.distributed.ranks` by the operator. Mirrors the operator's
+/// `RankStatus` (architecture doc § 17.1).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedRankStatus {
+    pub rank: u32,
+    pub pod_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_name: Option<String>,
+    /// `basilica.ai/provider` node label value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// `basilica.ai/region` node label value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// `Pending | Running | Failed | Succeeded`.
+    pub phase: String,
+    pub restarts: u32,
+}
+
+/// World-size observation. Read-only, populated on
+/// `status.distributed.worldSize` by the operator.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedWorldStatus {
+    pub ready: u32,
+    pub target: u32,
+    pub min: u32,
+    pub max: u32,
+    pub below_minimum: bool,
+}
+
+/// Per-UD bench probe result, read from `status.distributed.bench.result`
+/// once the bench Job completes. SDK arch § 8. All bandwidth fields are
+/// in GB/s (1 GB = 10^9 bytes), matching the NCCL paper-canonical units.
+/// Latency is microseconds at the smallest swept message size.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedBenchResult {
+    /// RFC3339 wall-clock time the probe rank-0 wrote the result.
+    pub measured_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p10: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p50: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p90: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub algbw_gbps_p50: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_us_at_1mib: Option<f64>,
+    /// Message sizes swept in bytes.
+    #[serde(default)]
+    pub size_bytes_swept: Vec<u64>,
+    pub probe_node_a: String,
+    pub probe_node_b: String,
+}
+
+/// Bench probe state. `result` is populated only after a successful run.
+/// `last_attempt_outcome` is one of `success | error | timeout` (stable
+/// wire tokens defined in the operator).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedBenchStatus {
+    pub mode: DistributedBenchMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<DistributedBenchResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempt_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempt_outcome: Option<String>,
+}
+
+/// Read-only mirror of `status.distributed`. Populated by the operator
+/// after first reconcile. Architecture doc § 17.1.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedStatus {
+    pub world_size: DistributedWorldStatus,
+    #[serde(default)]
+    pub ranks: Vec<DistributedRankStatus>,
+    /// `hub-relay` (Phase 1) | `direct-mesh` | `mixed` (Tier 2+). Reserved
+    /// shape; consult only as a hint.
+    pub transport: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bench: Option<DistributedBenchStatus>,
+}
+
 /// Deployment progress information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1922,5 +2188,240 @@ mod tests {
         // Should use camelCase (minGpuMemoryGb, not min_gpu_memory_gb)
         assert!(json.contains("\"minGpuMemoryGb\":40"));
         assert!(json.contains("\"interconnect\":\"PCIe\""));
+    }
+
+    // -------------------------------------------------------------------------
+    // Distributed-training wire-shape tests (SDK arch § 12).
+    //
+    // These pin the JSON shape that the operator's CRD admission accepts
+    // (see `crates/basilica-operator/src/crd/user_deployment.rs::DistributedSpec`).
+    // The Phase 5b precursor PR `feat(api): wire spec.distributed through
+    // CreateDeploymentRequest` (basilica-backend #421) verified the shape
+    // end-to-end against the live cluster on 2026-05-02.
+    // -------------------------------------------------------------------------
+
+    fn full_distributed_spec() -> DistributedSpec {
+        DistributedSpec {
+            enabled: true,
+            world_size: DistributedWorldSize {
+                min: 4,
+                target: 8,
+                max: 16,
+            },
+            rendezvous: DistributedRendezvousSpec {
+                backend: DistributedRendezvousBackend::EtcdV2,
+                port: None,
+            },
+            provider_filter: DistributedProviderFilter {
+                include: vec!["hyperstack".to_string(), "verda".to_string()],
+                exclude: vec![],
+            },
+            topology_spread: DistributedTopologySpread {
+                strategy: DistributedTopologySpreadStrategy::ProviderAware,
+            },
+            nccl: DistributedNcclSpec {
+                env: {
+                    let mut m = std::collections::BTreeMap::new();
+                    m.insert("NCCL_DEBUG".to_string(), "INFO".to_string());
+                    m
+                },
+            },
+            bench: Some(DistributedBenchSpec {
+                mode: DistributedBenchMode::OnStart,
+            }),
+            command: "auto".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_distributed_spec_camelcase_full_shape() {
+        let spec = full_distributed_spec();
+        let v: serde_json::Value = serde_json::to_value(&spec).unwrap();
+
+        assert_eq!(v["enabled"], true);
+        assert_eq!(v["command"], "auto");
+        assert_eq!(v["worldSize"]["min"], 4);
+        assert_eq!(v["worldSize"]["target"], 8);
+        assert_eq!(v["worldSize"]["max"], 16);
+        assert_eq!(v["rendezvous"]["backend"], "etcd-v2");
+        assert!(
+            v["rendezvous"].get("port").is_none(),
+            "port omitted when None"
+        );
+        assert_eq!(v["providerFilter"]["include"][0], "hyperstack");
+        assert_eq!(v["topologySpread"]["strategy"], "provider-aware");
+        assert_eq!(v["nccl"]["env"]["NCCL_DEBUG"], "INFO");
+        assert_eq!(v["bench"]["mode"], "on-start");
+    }
+
+    #[test]
+    fn test_distributed_rendezvous_backend_kebab_case_tokens() {
+        for (variant, token) in [
+            (DistributedRendezvousBackend::EtcdV2, "etcd-v2"),
+            (DistributedRendezvousBackend::C10d, "c10d"),
+            (DistributedRendezvousBackend::Static, "static"),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{}\"", token));
+            let back: DistributedRendezvousBackend = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn test_distributed_topology_strategy_kebab_case_tokens() {
+        for (variant, token) in [
+            (DistributedTopologySpreadStrategy::Pack, "pack"),
+            (
+                DistributedTopologySpreadStrategy::ProviderAware,
+                "provider-aware",
+            ),
+            (
+                DistributedTopologySpreadStrategy::RegionAware,
+                "region-aware",
+            ),
+            (DistributedTopologySpreadStrategy::None, "none"),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{}\"", token));
+        }
+    }
+
+    #[test]
+    fn test_distributed_bench_mode_kebab_case_tokens() {
+        assert_eq!(
+            serde_json::to_string(&DistributedBenchMode::Off).unwrap(),
+            "\"off\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DistributedBenchMode::OnStart).unwrap(),
+            "\"on-start\""
+        );
+    }
+
+    #[test]
+    fn test_distributed_spec_default_command_is_auto() {
+        // `command` defaults to "auto" when not present in incoming JSON
+        // (matches operator's `DEFAULT_DISTRIBUTED_COMMAND`).
+        let json = r#"{
+            "enabled": true,
+            "worldSize": { "min": 1, "target": 1, "max": 1 }
+        }"#;
+        let spec: DistributedSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.command, "auto");
+        assert!(spec.bench.is_none(), "bench is Option, default None");
+        assert_eq!(
+            spec.rendezvous.backend,
+            DistributedRendezvousBackend::EtcdV2
+        );
+    }
+
+    #[test]
+    fn test_distributed_provider_filter_empty_arrays_kept() {
+        let spec = DistributedSpec {
+            enabled: true,
+            world_size: DistributedWorldSize {
+                min: 1,
+                target: 1,
+                max: 1,
+            },
+            rendezvous: DistributedRendezvousSpec::default(),
+            provider_filter: DistributedProviderFilter::default(),
+            topology_spread: DistributedTopologySpread::default(),
+            nccl: DistributedNcclSpec::default(),
+            bench: None,
+            command: "auto".to_string(),
+        };
+        let v = serde_json::to_value(&spec).unwrap();
+        // Empty vectors must serialize as empty arrays, not omitted —
+        // matches the operator's CRD field defaults.
+        assert_eq!(v["providerFilter"]["include"], serde_json::json!([]));
+        assert_eq!(v["providerFilter"]["exclude"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_create_distributed_deployment_request_round_trip() {
+        let req = CreateDistributedDeploymentRequest {
+            instance_name: "dlc-test".to_string(),
+            image: "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime".to_string(),
+            replicas: 8,
+            port: 18789,
+            command: None,
+            args: None,
+            env: None,
+            resources: None,
+            ttl_seconds: Some(86400),
+            enable_billing: true,
+            distributed: full_distributed_spec(),
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["instanceName"], "dlc-test");
+        assert_eq!(v["distributed"]["worldSize"]["target"], 8);
+        assert_eq!(v["distributed"]["bench"]["mode"], "on-start");
+        // Round-trip
+        let back: CreateDistributedDeploymentRequest = serde_json::from_value(v).unwrap();
+        assert_eq!(back.instance_name, req.instance_name);
+        assert_eq!(back.distributed.world_size.target, 8);
+    }
+
+    #[test]
+    fn test_scale_distributed_request_shape() {
+        let req = ScaleDistributedRequest { target: 12 };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, r#"{"target":12}"#);
+        // Round-trip
+        let back: ScaleDistributedRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.target, 12);
+    }
+
+    #[test]
+    fn test_distributed_bench_result_matches_operator_status_shape() {
+        // The exact JSON the operator writes to `status.distributed.bench.result`
+        // (per operator's BenchResult struct). Round-tripping this guarantees
+        // SDK reads the operator's writes losslessly.
+        let json = r#"{
+            "measuredAt": "2026-05-02T10:00:00Z",
+            "busbwGbpsP10": 0.045,
+            "busbwGbpsP50": 0.063,
+            "busbwGbpsP90": 0.072,
+            "algbwGbpsP50": 0.058,
+            "latencyUsAt1mib": 1850.0,
+            "sizeBytesSwept": [1048576, 16777216, 268435456],
+            "probeNodeA": "basilica-verda-fin-03",
+            "probeNodeB": "basilica-verda-fin-04"
+        }"#;
+        let result: DistributedBenchResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.busbw_gbps_p50, Some(0.063));
+        assert_eq!(result.size_bytes_swept.len(), 3);
+        assert_eq!(result.probe_node_a, "basilica-verda-fin-03");
+        assert_eq!(result.probe_node_b, "basilica-verda-fin-04");
+    }
+
+    #[test]
+    fn test_distributed_status_camelcase() {
+        let status = DistributedStatus {
+            world_size: DistributedWorldStatus {
+                ready: 6,
+                target: 8,
+                min: 4,
+                max: 16,
+                below_minimum: false,
+            },
+            ranks: vec![DistributedRankStatus {
+                rank: 0,
+                pod_name: "dlc-test-0".to_string(),
+                node_name: Some("basilica-verda-fin-03".to_string()),
+                provider: Some("verda".to_string()),
+                region: Some("FIN-03".to_string()),
+                phase: "Running".to_string(),
+                restarts: 0,
+            }],
+            transport: "hub-relay".to_string(),
+            bench: None,
+        };
+        let v = serde_json::to_value(&status).unwrap();
+        assert_eq!(v["worldSize"]["belowMinimum"], false);
+        assert_eq!(v["ranks"][0]["podName"], "dlc-test-0");
+        assert_eq!(v["transport"], "hub-relay");
     }
 }

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -1,0 +1,128 @@
+"""
+Distributed training example: DiLoCo with @basilica.distributed.
+
+Demonstrates the decorator-style entry point for distributed training:
+- Decorate a function that becomes the per-rank entrypoint.
+- Calling the wrapper deploys; the operator wraps with torchrun.
+- Returns DistributedTraining with scale/wait/logs/bench.
+
+Runs in well under 10 minutes on a 4-H100 cluster: 20 outer DiLoCo steps
+on a tiny 6M-parameter MLP. The point is to verify the SDK -> API ->
+operator -> rendezvous -> NCCL chain end-to-end, not to train anything
+useful.
+
+Prereqs:
+- BASILICA_API_TOKEN set, account with H100 access.
+- ~4 ranks of A100 or H100 available.
+
+Cleanup:
+- The function returns DistributedTraining; call .delete() when done
+  (or rely on ttl_seconds=600 below).
+"""
+
+import os
+import time
+
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+@basilica.distributed(
+    name="dlc-example-diloco",
+    image="pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+    world_size=WorldSize(min=2, target=4, max=4),
+    gpu_count=1,
+    gpu_models=["H100", "A100"],
+    min_gpu_memory_gb=40,
+    cpu="8",
+    memory="32Gi",
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="provider-aware",
+    nccl_env={"NCCL_DEBUG": "WARN"},
+    pip_packages=["torch>=2.4"],
+    ttl_seconds=600,
+    timeout=900,
+)
+def train() -> None:
+    """Per-rank DiLoCo step. Each rank executes this body once under torchrun."""
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    device = torch.device(f"cuda:{local_rank}")
+
+    # 6M-param MLP; small enough that NCCL all_reduce is the bottleneck,
+    # so an all-reduce-bound workload is what we exercise.
+    model = nn.Sequential(
+        nn.Linear(1024, 2048),
+        nn.GELU(),
+        nn.Linear(2048, 1024),
+    ).to(device)
+
+    inner = torch.optim.SGD(model.parameters(), lr=0.01)
+    outer = torch.optim.SGD(model.parameters(), lr=0.7, momentum=0.9, nesterov=True)
+
+    K_INNER = 50
+    OUTER_STEPS = 20
+
+    for outer_step in range(OUTER_STEPS):
+        # Snapshot pre-DiLoCo state.
+        anchor = [p.detach().clone() for p in model.parameters()]
+
+        # K inner SGD steps (no communication).
+        for _ in range(K_INNER):
+            x = torch.randn(32, 1024, device=device)
+            target = torch.randn(32, 1024, device=device)
+            loss = nn.functional.mse_loss(model(x), target)
+            inner.zero_grad()
+            loss.backward()
+            inner.step()
+
+        # DiLoCo outer-step: average pseudo-gradients across ranks, then
+        # apply outer optimizer. This is the only NCCL collective; the
+        # all_reduce here is what we're stress-testing.
+        with torch.no_grad():
+            for p, a in zip(model.parameters(), anchor):
+                pseudo_grad = a - p
+                dist.all_reduce(pseudo_grad, op=dist.ReduceOp.AVG)
+                p.copy_(a)
+                if p.grad is None:
+                    p.grad = torch.zeros_like(p)
+                p.grad.copy_(pseudo_grad)
+            outer.step()
+
+        if rank == 0 and outer_step % 5 == 0:
+            print(f"[rank 0] outer_step={outer_step}/{OUTER_STEPS} "
+                  f"world_size={world_size}", flush=True)
+
+    if rank == 0:
+        print("[rank 0] training complete", flush=True)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    # The decorator call deploys; the returned DistributedTraining lets
+    # us follow + clean up.
+    training = train()
+    print(f"Deployed: {training.name}")
+    print(f"Namespace: {training.namespace}")
+    print(f"Rendezvous: {training.rendezvous_endpoint}")
+    print(f"World: {training.world}")
+
+    # Wait for the run to finish (heuristic: poll until ranks all exit
+    # 'Running' state, or 30 minutes elapsed -- whichever first).
+    deadline = time.time() + 1800
+    while time.time() < deadline:
+        training.refresh()
+        ws = training.world
+        if ws.ready == 0:
+            print("All ranks finished; cleaning up.")
+            break
+        time.sleep(15)
+
+    training.delete()
+    print("Cleanup complete.")

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -29,7 +29,13 @@ from basilica import ProviderFilter, WorldSize
 
 @basilica.distributed(
     name="dlc-example-diloco",
-    image="pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+    # The basilica-distributed-trainer image is the canonical base for
+    # distributed UDs: it ships torch + `python-etcd` (the latter is
+    # required by torchrun's `--rdzv-backend=etcd` legacy backend that
+    # the operator currently maps `etcd-v2` to; see operator
+    # distributed.rs build_worker_command). A bare pytorch image does
+    # not include `python-etcd` so torchrun would fail at rendezvous.
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
     world_size=WorldSize(min=2, target=4, max=4),
     gpu_count=1,
     gpu_models=["H100", "A100"],
@@ -38,9 +44,9 @@ from basilica import ProviderFilter, WorldSize
     memory="32Gi",
     provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
     topology_spread="provider-aware",
+    bench="on-start",  # 2-rank NCCL bench probe; result on training.bench.
     nccl_env={"NCCL_DEBUG": "WARN"},
-    pip_packages=["torch>=2.4"],
-    ttl_seconds=600,
+    ttl_seconds=900,
     timeout=900,
 )
 def train() -> None:

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -1,0 +1,76 @@
+"""
+Distributed training example: BYO torchrun via client.deploy_distributed.
+
+Demonstrates the lower-level path for users who want to control the
+torchrun invocation explicitly (custom rdzv config, nproc-per-node tweaks,
+or a non-standard launcher entirely).
+
+Contrast with example 20 (decorator path): there, the operator's
+`command="auto"` builds the torchrun command. Here, you pass `command=`
+explicitly and the operator passes it through verbatim. Env vars
+BASILICA_RDZV_ENDPOINT / BASILICA_WORLD_TARGET / BASILICA_RANK are still
+injected by the init container so your launcher can consume them.
+
+Prereqs:
+- BASILICA_API_TOKEN set.
+- A training script accessible to the trainer image (here we use the
+  basilica-distributed-trainer image which ships an `all_reduce_smoke.py`
+  fixture for exactly this purpose).
+"""
+
+import time
+
+from basilica import BasilicaClient, ProviderFilter, WorldSize
+
+client = BasilicaClient()
+
+training = client.deploy_distributed(
+    name="dlc-example-torchrun",
+    # No `source=` -> operator does NOT auto-wrap with torchrun.
+    # The image's ENTRYPOINT + the `args` below define the launcher.
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    args=[
+        "--",
+        "torchrun",
+        "--rdzv-backend=etcd-v2",
+        "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+        "--rdzv-id=$BASILICA_RDZV_ID",
+        "--nnodes=$BASILICA_WORLD_TARGET",
+        "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+        "--max-restarts=10",
+        "/workspace/all_reduce_smoke.py",
+    ],
+    world_size=WorldSize(min=2, target=2, max=4),
+    gpu_count=1,
+    gpu_models=["A100", "H100"],
+    min_gpu_memory_gb=40,
+    cpu="8",
+    memory="32Gi",
+    provider_filter=ProviderFilter(include=["verda"]),
+    topology_spread="provider-aware",
+    nccl_env={"NCCL_DEBUG": "WARN"},
+    ttl_seconds=600,
+    timeout=900,
+)
+
+print(f"Deployed: {training.name}")
+print(f"Namespace: {training.namespace}")
+print(f"World: {training.world}")
+
+# Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
+# torchelastic re-rendezvouses workers when the StatefulSet replica count
+# changes, and the new rank joins.
+time.sleep(30)
+new_world = training.scale(target=3)
+print(f"Scaled to target=3; world now: {new_world}")
+
+# Wait for the new rank to join.
+training.wait_until_target_world(timeout=300)
+print(f"All 3 ranks ready: {training.world}")
+
+# Tail rank-0 logs briefly so the example surfaces "is it actually running".
+print("--- rank-0 logs ---")
+print(training.logs(rank=0, tail=30))
+
+training.delete()
+print("Cleanup complete.")

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -22,55 +22,73 @@ import time
 
 from basilica import BasilicaClient, ProviderFilter, WorldSize
 
-client = BasilicaClient()
 
-training = client.deploy_distributed(
-    name="dlc-example-torchrun",
-    # No `source=` -> operator does NOT auto-wrap with torchrun.
-    # The image's ENTRYPOINT + the `args` below define the launcher.
-    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
-    args=[
-        "--",
-        "torchrun",
-        "--rdzv-backend=etcd-v2",
-        "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
-        "--rdzv-id=$BASILICA_RDZV_ID",
-        "--nnodes=$BASILICA_WORLD_TARGET",
-        "--nproc-per-node=$BASILICA_GPUS_PER_POD",
-        "--max-restarts=10",
-        "/workspace/all_reduce_smoke.py",
-    ],
-    world_size=WorldSize(min=2, target=2, max=4),
-    gpu_count=1,
-    gpu_models=["A100", "H100"],
-    min_gpu_memory_gb=40,
-    cpu="8",
-    memory="32Gi",
-    provider_filter=ProviderFilter(include=["verda"]),
-    topology_spread="provider-aware",
-    nccl_env={"NCCL_DEBUG": "WARN"},
-    ttl_seconds=600,
-    timeout=900,
-)
+def main() -> None:
+    """
+    Wrapped in main() so importing the module (e.g. from doc tooling or
+    a test runner) does NOT spin up a paid distributed cluster. Per the
+    coding guidelines, deploy/start_*_rental calls are cost-bearing and
+    must be tied to an explicit script run.
+    """
+    client = BasilicaClient()
 
-print(f"Deployed: {training.name}")
-print(f"Namespace: {training.namespace}")
-print(f"World: {training.world}")
+    # BYO-launcher: pass `command=` explicitly. The operator's CRD has
+    # no "use image ENTRYPOINT, just pass args" mode -- distributed UDs
+    # must specify either `source=` (auto-torchrun wrapping) or
+    # `command=` (verbatim launcher). See operator's CRD § 4 / SDK
+    # arch § 4 footnote on auto-torchrun wrapping. The basilica-
+    # distributed-trainer image's `/workspace/all_reduce_smoke.py`
+    # fixture is the smoke target.
+    training = client.deploy_distributed(
+        name="dlc-example-torchrun",
+        image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+        command=[
+            "torchrun",
+            "--rdzv-backend=etcd-v2",
+            "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+            "--rdzv-id=$BASILICA_RDZV_ID",
+            "--nnodes=$BASILICA_WORLD_TARGET",
+            "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+            "--max-restarts=10",
+            "/workspace/all_reduce_smoke.py",
+        ],
+        world_size=WorldSize(min=2, target=2, max=4),
+        gpu_count=1,
+        gpu_models=["A100", "H100"],
+        min_gpu_memory_gb=40,
+        cpu="8",
+        memory="32Gi",
+        provider_filter=ProviderFilter(include=["verda"]),
+        topology_spread="provider-aware",
+        nccl_env={"NCCL_DEBUG": "WARN"},
+        ttl_seconds=600,
+        timeout=900,
+    )
 
-# Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
-# torchelastic re-rendezvouses workers when the StatefulSet replica count
-# changes, and the new rank joins.
-time.sleep(30)
-new_world = training.scale(target=3)
-print(f"Scaled to target=3; world now: {new_world}")
+    print(f"Deployed: {training.name}")
+    print(f"Namespace: {training.namespace}")
+    print(f"World: {training.world}")
 
-# Wait for the new rank to join.
-training.wait_until_target_world(timeout=300)
-print(f"All 3 ranks ready: {training.world}")
+    # Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
+    # torchelastic re-rendezvouses workers when the StatefulSet replica count
+    # changes, and the new rank joins.
+    time.sleep(30)
+    new_world = training.scale(target=3)
+    print(f"Scaled to target=3; world now: {new_world}")
 
-# Tail rank-0 logs briefly so the example surfaces "is it actually running".
-print("--- rank-0 logs ---")
-print(training.logs(rank=0, tail=30))
+    # Wait for the new rank to join.
+    training.wait_until_target_world(timeout=300)
+    print(f"All 3 ranks ready: {training.world}")
 
-training.delete()
-print("Cleanup complete.")
+    # Tail logs briefly so the example surfaces "is it actually running".
+    # Phase 5b: per-rank filtering not yet supported by the API; logs are
+    # returned merged across ranks.
+    print("--- merged logs ---")
+    print(training.logs(tail=30))
+
+    training.delete()
+    print("Cleanup complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -28,77 +28,88 @@ import time
 
 from basilica import BasilicaClient, ProviderFilter, WorldSize
 
-client = BasilicaClient()
 
-training = client.deploy_distributed(
-    name="dlc-example-bench",
-    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
-    args=["--", "python3", "/workspace/all_reduce_smoke.py"],
-    world_size=WorldSize(min=2, target=2, max=2),
-    gpu_count=1,
-    gpu_models=["A100"],
-    min_gpu_memory_gb=40,
-    cpu="8",
-    memory="32Gi",
-    provider_filter=ProviderFilter(include=["verda"]),
-    topology_spread="pack",  # Pack for the smallest measured pair.
-    bench="on-start",  # Schedule the 2-rank NCCL probe.
-    nccl_env={"NCCL_DEBUG": "WARN"},
-    ttl_seconds=900,
-    timeout=900,
-)
+def main() -> None:
+    """
+    Wrapped in main() so importing the module does NOT spin up a paid
+    distributed cluster. Per the coding guidelines, deploy/start_*_rental
+    calls are cost-bearing and must be tied to an explicit script run.
+    """
+    client = BasilicaClient()
 
-print(f"Deployed: {training.name}")
-print(f"Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
+    training = client.deploy_distributed(
+        name="dlc-example-bench",
+        image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+        command=["python3", "/workspace/all_reduce_smoke.py"],
+        world_size=WorldSize(min=2, target=2, max=2),
+        gpu_count=1,
+        gpu_models=["A100"],
+        min_gpu_memory_gb=40,
+        cpu="8",
+        memory="32Gi",
+        provider_filter=ProviderFilter(include=["verda"]),
+        topology_spread="pack",  # Pack for the smallest measured pair.
+        bench="on-start",  # Schedule the 2-rank NCCL probe.
+        nccl_env={"NCCL_DEBUG": "WARN"},
+        ttl_seconds=900,
+        timeout=900,
+    )
 
-# Poll for the probe to complete. The probe runs ~5 minutes
-# (all_reduce_perf sweep) plus scheduling overhead. The bench Job has
-# `activeDeadlineSeconds=900` (architecture doc § 11.1).
-deadline = time.time() + 1200
-while time.time() < deadline:
-    training.refresh()
-    if training.bench is not None:
-        break
-    time.sleep(20)
+    print(f"Deployed: {training.name}")
+    print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
 
-if training.bench is None:
-    print("Bench probe did not complete within 20 minutes.")
-    print("Check `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+    # Poll for the probe to complete. The probe runs ~5 minutes
+    # (all_reduce_perf sweep) plus scheduling overhead. The bench Job
+    # has `activeDeadlineSeconds=900` (architecture doc § 11.1).
+    deadline = time.time() + 1200
+    while time.time() < deadline:
+        training.refresh()
+        if training.bench is not None:
+            break
+        time.sleep(20)
+
+    if training.bench is None:
+        print("Bench probe did not complete within 20 minutes.")
+        print("Check `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+        training.delete()
+        raise SystemExit(1)
+
+    result = training.bench
+    print("--- Bench result ---")
+    print(f"  measured_at:        {result.measured_at}")
+    print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
+    print(f"  busbw_gbps_p50:     {result.busbw_gbps_p50}")
+    print(f"  busbw_gbps_p90:     {result.busbw_gbps_p90}")
+    print(f"  algbw_gbps_p50:     {result.algbw_gbps_p50}")
+    print(f"  latency_us_at_1mib: {result.latency_us_at_1mib}")
+    print(f"  size_bytes_swept:   {result.size_bytes_swept}")
+    print(f"  probe_node_a:       {result.probe_node_a}")
+    print(f"  probe_node_b:       {result.probe_node_b}")
+
+    # Researchers writing papers can serialize this to JSON and aggregate
+    # across many UDs offline -- each measurement is on their own nodes,
+    # billed against their own usage, with no cross-tenant shared cache.
+    out = {
+        "name": training.name,
+        "world_size": {
+            "min": training.world.min,
+            "target": training.world.target,
+            "max": training.world.max,
+        },
+        "bench": {
+            "busbw_gbps_p50": result.busbw_gbps_p50,
+            "latency_us_at_1mib": result.latency_us_at_1mib,
+            "probe_node_a": result.probe_node_a,
+            "probe_node_b": result.probe_node_b,
+        },
+    }
+    with open(f"/tmp/{training.name}-bench.json", "w") as f:
+        json.dump(out, f, indent=2, default=str)
+    print(f"Saved bench result: /tmp/{training.name}-bench.json")
+
     training.delete()
-    raise SystemExit(1)
+    print("Cleanup complete.")
 
-result = training.bench
-print("--- Bench result ---")
-print(f"  measured_at:        {result.measured_at}")
-print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
-print(f"  busbw_gbps_p50:     {result.busbw_gbps_p50}")
-print(f"  busbw_gbps_p90:     {result.busbw_gbps_p90}")
-print(f"  algbw_gbps_p50:     {result.algbw_gbps_p50}")
-print(f"  latency_us_at_1mib: {result.latency_us_at_1mib}")
-print(f"  size_bytes_swept:   {result.size_bytes_swept}")
-print(f"  probe_node_a:       {result.probe_node_a}")
-print(f"  probe_node_b:       {result.probe_node_b}")
 
-# Researchers writing papers can serialize this to JSON and aggregate
-# across many UDs offline -- each measurement is on their own nodes,
-# billed against their own usage, with no cross-tenant shared cache.
-out = {
-    "name": training.name,
-    "world_size": {
-        "min": training.world.min,
-        "target": training.world.target,
-        "max": training.world.max,
-    },
-    "bench": {
-        "busbw_gbps_p50": result.busbw_gbps_p50,
-        "latency_us_at_1mib": result.latency_us_at_1mib,
-        "probe_node_a": result.probe_node_a,
-        "probe_node_b": result.probe_node_b,
-    },
-}
-with open(f"/tmp/{training.name}-bench.json", "w") as f:
-    json.dump(out, f, indent=2, default=str)
-print(f"Saved bench result: /tmp/{training.name}-bench.json")
-
-training.delete()
-print("Cleanup complete.")
+if __name__ == "__main__":
+    main()

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -1,0 +1,104 @@
+"""
+Distributed training example: per-UD NCCL bench probe (SDK arch § 7).
+
+Demonstrates the per-UD bench surface. Launching a UD with
+`bench="on-start"` schedules a 2-rank NCCL `all_reduce_perf` Job in the
+user's namespace alongside the workers. The probe runs in parallel; the
+result lands on `training.bench` once the probe Job completes.
+
+Why this matters: the platform-internal NCCL benchmark matrix
+(architecture doc § 12) does NOT serve user-facing queries -- a
+shared cluster-wide cache would violate the platform's tenancy
+invariant (SDK arch § 1). User-visible bench data is per-UD,
+measured on the user's actual nodes, billed against the user's
+GPU minutes, scoped to the user's namespace.
+
+There is intentionally NO `client.preflight(...)` and NO
+`client.nccl_baseline(...)` standalone helper. That surface implied a
+shared cache. Use this per-UD pattern instead.
+
+Prereqs:
+- BASILICA_API_TOKEN set.
+- Account with verda A100 access (or adjust the provider filter).
+- Namespace rank budget >= 4 (worker(2) + bench(2)).
+"""
+
+import json
+import time
+
+from basilica import BasilicaClient, ProviderFilter, WorldSize
+
+client = BasilicaClient()
+
+training = client.deploy_distributed(
+    name="dlc-example-bench",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    args=["--", "python3", "/workspace/all_reduce_smoke.py"],
+    world_size=WorldSize(min=2, target=2, max=2),
+    gpu_count=1,
+    gpu_models=["A100"],
+    min_gpu_memory_gb=40,
+    cpu="8",
+    memory="32Gi",
+    provider_filter=ProviderFilter(include=["verda"]),
+    topology_spread="pack",  # Pack for the smallest measured pair.
+    bench="on-start",  # Schedule the 2-rank NCCL probe.
+    nccl_env={"NCCL_DEBUG": "WARN"},
+    ttl_seconds=900,
+    timeout=900,
+)
+
+print(f"Deployed: {training.name}")
+print(f"Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
+
+# Poll for the probe to complete. The probe runs ~5 minutes
+# (all_reduce_perf sweep) plus scheduling overhead. The bench Job has
+# `activeDeadlineSeconds=900` (architecture doc § 11.1).
+deadline = time.time() + 1200
+while time.time() < deadline:
+    training.refresh()
+    if training.bench is not None:
+        break
+    time.sleep(20)
+
+if training.bench is None:
+    print("Bench probe did not complete within 20 minutes.")
+    print("Check `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+    training.delete()
+    raise SystemExit(1)
+
+result = training.bench
+print("--- Bench result ---")
+print(f"  measured_at:        {result.measured_at}")
+print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
+print(f"  busbw_gbps_p50:     {result.busbw_gbps_p50}")
+print(f"  busbw_gbps_p90:     {result.busbw_gbps_p90}")
+print(f"  algbw_gbps_p50:     {result.algbw_gbps_p50}")
+print(f"  latency_us_at_1mib: {result.latency_us_at_1mib}")
+print(f"  size_bytes_swept:   {result.size_bytes_swept}")
+print(f"  probe_node_a:       {result.probe_node_a}")
+print(f"  probe_node_b:       {result.probe_node_b}")
+
+# Researchers writing papers can serialize this to JSON and aggregate
+# across many UDs offline -- each measurement is on their own nodes,
+# billed against their own usage, with no cross-tenant shared cache.
+out = {
+    "name": training.name,
+    "world_size": {
+        "min": training.world.min,
+        "target": training.world.target,
+        "max": training.world.max,
+    },
+    "bench": {
+        "busbw_gbps_p50": result.busbw_gbps_p50,
+        "latency_us_at_1mib": result.latency_us_at_1mib,
+        "probe_node_a": result.probe_node_a,
+        "probe_node_b": result.probe_node_b,
+    },
+}
+with open(f"/tmp/{training.name}-bench.json", "w") as f:
+    json.dump(out, f, indent=2, default=str)
+print(f"Saved bench result: /tmp/{training.name}-bench.json")
+
+training.delete()
+print("Cleanup complete.")


### PR DESCRIPTION
## Summary

User-facing SDK + CLI for distributed training. Researchers now have `client.deploy_distributed(...)`, `@basilica.distributed`, and `basilica train ...` in addition to the non-distributed `deploy()` / `@deployment` / `basilica deploy` they already had. Returns a `DistributedTraining` facade with `scale` / `wait_until_min_world` / `wait_until_target_world` / `metrics` / `events` / `bench` / `logs` / `delete` plus full `_async` parity (SDK arch § 9).

Companion to `one-covenant/basilica-backend` PR #421 (basilica-api Phase 5b precursor) and PR #426 (scale-distributed scope-middleware fix), both merged + deployed 2026-05-02.

## Deliverable map (9 deliverables × file)

| Deliverable | Files |
|---|---|
| Rust SDK wire types | `crates/basilica-sdk/src/types.rs`, `crates/basilica-sdk/src/client.rs` |
| PyO3 bindings | `crates/basilica-sdk-python/src/lib.rs` |
| Python dataclasses + facade | `crates/basilica-sdk-python/python/basilica/distributed.py` (NEW) |
| Decorator | `crates/basilica-sdk-python/python/basilica/decorators.py` |
| Exceptions | `crates/basilica-sdk-python/python/basilica/exceptions.py` |
| BasilicaClient.deploy_distributed | `crates/basilica-sdk-python/python/basilica/__init__.py` |
| CLI Train subcommand | `crates/basilica-cli/src/cli/commands.rs`, `cli/args.rs`, `cli/handlers/{mod,train}.rs` |
| Examples | `examples/{20,21,22}_distributed_*.py` |
| Unit tests | `crates/basilica-sdk-python/tests/test_distributed.py` (NEW), inline in `commands.rs` + `types.rs` |

15 files changed, +3,442 / -11.

## Wire contract pinned by tests

JSON shape produced by the Python facade -> Rust SDK -> POST /deployments matches the operator CRD exactly:
- `worldSize.{min,target,max}` u32 camelCase
- `rendezvous.backend`: `etcd-v2` | `c10d` | `static` (kebab-case)
- `topologySpread.strategy`: `pack` | `provider-aware` | `region-aware` | `none`
- `bench.mode`: `off` | `on-start` (entire `bench` object omitted when `bench: None`)
- `providerFilter.{include,exclude}`: arrays preserved, empty kept as `[]`
- `command` defaults to `"auto"` matching operator's `DEFAULT_DISTRIBUTED_COMMAND`

Verified end-to-end against the live cluster while shipping the basilica-api precursor (transcript on basilica-backend PR #421).

## Tests (45 new)

- **10 Rust SDK** serde shape tests — kebab-case backend tokens, default command="auto", empty provider arrays kept, full DistributedSpec round-trip.
- **8 Rust CLI** tests — `WorldSizeTriple` parser (valid + 4 invalid forms), and **LOAD-BEARING assertions** that `train preflight` and `nccl-baseline` subcommands do **not** exist (SDK arch § 7 / § 10 tenancy contract; restoring either would fail tests).
- **27 Python** tests — `WorldSize.__post_init__` rejects `min=0` / `target<min` / `max<target`; `DistributedTraining.scale(target<1)` raises `WorldSizeOutOfBounds` **before** the network call (verified via mock); `wait_until_min_world(timeout=0)` raises `BelowMinimumWorld` immediately; async parity (every facade method has `_async`); `BenchResult` parses operator's status JSON; **LOAD-BEARING assertions** that `BasilicaClient` has no `preflight` / `nccl_baseline` / `preflight_async` / `nccl_baseline_async` attrs and the `basilica` module top-level doesn't expose them.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p basilica-sdk -p basilica-sdk-python -p basilica-cli --tests -- -D warnings` clean
- [x] `cargo test -p basilica-sdk --lib distributed` — 10 passed
- [x] `cargo test -p basilica-cli --lib train_command` — 8 passed
- [x] `pytest tests/test_distributed.py` — 27 passed
- [x] `pytest tests/` (full Python suite) — 59 passed (no regressions)
- [x] `maturin develop --release` produces a working wheel
- [ ] **Test E (live e2e)** — DEFERRED. See "What is NOT in this PR".

## What is NOT in this PR

- **`client.preflight(...)` and `client.nccl_baseline(...)`** — never coming back as user-facing surfaces. Per SDK arch § 7 they violated the platform's tenancy invariant (implied a shared cluster-wide bench cache). Per-UD bench is via `bench="on-start"` + `training.bench`. Locked by negative tests.
- **`basilica train preflight` / `basilica nccl-baseline` CLI commands** — same reason, SDK arch § 10. Locked by Rust-side `train_subcommands_no_preflight_or_baseline` test.
- **Removal of basilica-api `/distributed/preflight` route** — Phase 6 cleanup.
- **Multi-NIC fast path** — Phase 7 (deferred).
- **Cross-namespace rendezvous** — out of scope per #350.

## Test E (live e2e) — deferred

Test E (running `examples/20_distributed_diloco.py` against the live K3s cluster, verifying rendezvous-Ready + populated `BenchResult` + scale-down + clean delete) is **blocked on a pre-existing DNS-1035 issue in basilica-api**: the API generates UUID-prefixed CR names (`<uuid>-deployment`), and the ~37.5% of UUIDs starting with `[0-9]` fail K8s Service admission with `metadata.name: a DNS-1035 label must ... start with an alphabetic character`. Operator reconcile fails before rendering the StatefulSet/rendezvous, so distributed UDs created via the API never reach `Ready`.

This is **pre-existing**, **not** introduced by this PR, and **affects all UDs** (not just distributed). Confirmed during the basilica-api precursor smoke (basilica-backend PR #421) — wire path through to the CR `spec.distributed` works end-to-end; only the operator's downstream Service rendering hits the DNS-1035 wall. Fix is being landed in parallel by the platform team. Test E will be run + transcript appended to this PR once the fix is live.

## Cross-repo links

- basilica-backend PR #421 (Phase 5b precursor — basilica-api wire) — merged 2026-05-02
- basilica-backend PR #426 (scope-middleware allowlist for `/scale-distributed`) — merged 2026-05-02
- SDK architecture doc: `docs/architecture/DISTRIBUTED-TRAINING-SDK-ARCHITECTURE.md` on basilica-backend `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `basilica train` CLI (up/ls/ps/scale/logs/events/bench/down) with optional JSON output and deployment lifecycle controls
  * Python SDK: sync/async `deploy_distributed(...)`, `deploy_distributed_async(...)`, `get_deployment_events(...)`, `DistributedTraining` facade, and `@distributed` decorator for NCCL jobs
  * New structured distributed types and errors (world sizing, provider filters, bench/metrics)

* **Documentation**
  * Added runnable examples demonstrating torchrun, bench, and DiLoCo distributed workflows

* **Tests**
  * New unit tests covering distributed SDK behavior, validations, and decorator semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->