### PR TITLE
fix(sdk): write source-shipping payload to /tmp instead of /workspace (closes #448)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -1182,7 +1182,7 @@ class BasilicaClient:
         # `spec.distributed.command` policy:
         #
         # - `source` set -> read source text, ship via base64 in a bash
-        #   one-liner that writes `/workspace/__basilica_source.py` then
+        #   one-liner that writes `/tmp/__basilica_source.py` then
         #   exec's torchrun on it. The operator wraps this with `sh -c`
         #   in BYO mode (operator distributed.rs build_worker_command:
         #   `command=["/bin/sh", "-c"], args=[<distributed.command>, "--",
@@ -1215,9 +1215,14 @@ class BasilicaClient:
                 if rendezvous_backend == "etcd-v2"
                 else rendezvous_backend
             )
+            # /tmp/ used because /workspace/ in pytorch base images is
+            # root-owned and pods run as uid=1000 (operator
+            # distributed.rs build_security_contexts: runAsUser=1000,
+            # no /workspace emptyDir mounted). /tmp/ is the standard
+            # tmpfs scratch location writable by any uid. See issue #448.
             distributed_command = (
                 f"{pip_install}"
-                f"echo {src_b64} | base64 -d > /workspace/__basilica_source.py && "
+                f"echo {src_b64} | base64 -d > /tmp/__basilica_source.py && "
                 f"exec torchrun "
                 f"--rdzv-backend={backend_token} "
                 f"--rdzv-endpoint=\"$BASILICA_RDZV_ENDPOINT\" "
@@ -1225,7 +1230,7 @@ class BasilicaClient:
                 f"--nnodes=\"$BASILICA_WORLD_MIN\":\"$BASILICA_WORLD_MAX\" "
                 f"--nproc-per-node=\"$BASILICA_GPUS_PER_POD\" "
                 f"--max-restarts=10 "
-                f"/workspace/__basilica_source.py"
+                f"/tmp/__basilica_source.py"
             )
         elif command is not None:
             import shlex as _shlex

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -409,8 +409,10 @@ class TestBuildDistributedRequest:
         assert "source" in msg or "command" in msg
 
     def test_source_string_ships_via_b64(self) -> None:
-        # Source-shipping path: writes /workspace/__basilica_source.py via
+        # Source-shipping path: writes /tmp/__basilica_source.py via
         # base64-decoded bash one-liner. Operator wraps in `sh -c`.
+        # /tmp/ (not /workspace/) because the operator pod template
+        # runs as uid=1000 with no writable /workspace mount. See #448.
         client = self._client()
         req = client._build_distributed_request(
             name="dlc-source-test",
@@ -436,10 +438,55 @@ class TestBuildDistributedRequest:
             enable_billing=True,
         )
         d_cmd = req["distributed"]["command"]
-        assert "base64 -d > /workspace/__basilica_source.py" in d_cmd
+        assert "base64 -d > /tmp/__basilica_source.py" in d_cmd
         assert "exec torchrun" in d_cmd
         assert "$BASILICA_RDZV_ENDPOINT" in d_cmd
         assert d_cmd != "auto"
+
+    def test_source_shipping_writes_to_tmp_not_workspace(self) -> None:
+        # Issue #448 regression guard. The pytorch base image has
+        # /workspace owned by uid=0; pods run as uid=1000 with no
+        # writable /workspace mount, so writing the source there
+        # crashes every rank with "Permission denied" and CrashLoopBackoff.
+        # /tmp/ is writable by any uid in any standard base image.
+        # NEGATIVE assertion locks the contract: a regression that
+        # restores /workspace/ would fail this test loudly.
+        client = self._client()
+        req = client._build_distributed_request(
+            name="dlc-issue-448",
+            source="print('rank-up')\n",
+            image="pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime",
+            port=18789,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=2, target=2, max=2),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="off",
+            rendezvous_backend="etcd-v2",
+            command=None,
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+        )
+        d_cmd = req["distributed"]["command"]
+        # Positive: write target + torchrun arg both reference /tmp/.
+        assert d_cmd.count("/tmp/__basilica_source.py") == 2, (
+            f"expected /tmp/__basilica_source.py to appear twice (write "
+            f"target + torchrun arg), got command: {d_cmd!r}"
+        )
+        # Negative: no /workspace/ anywhere -- locks the #448 fix.
+        assert "/workspace/" not in d_cmd, (
+            f"command must not write to /workspace/ -- pytorch base "
+            f"image's /workspace is root-owned and pods run as uid=1000. "
+            f"See issue #448. command: {d_cmd!r}"
+        )
 
     def test_invalid_bench_mode_rejected(self) -> None:
         from basilica.exceptions import ValidationError


### PR DESCRIPTION
## Bug

`crates/basilica-sdk-python/python/basilica/__init__.py:1220` (and `:1228`) constructs a bash one-liner for the Phase 5b source-shipping path that writes the user's base64-encoded source to `/workspace/__basilica_source.py` and then `exec torchrun /workspace/__basilica_source.py`.

The pytorch base image's `/workspace` is root-owned (uid=0). The operator-rendered worker pod runs with `runAsUser: 1000` and does NOT mount a writable volume at `/workspace`:

- `crates/basilica-operator/src/controllers/distributed.rs::build_security_contexts` -> `PodSecurityContext { run_as_user: Some(1000), ... }`
- No `emptyDir` mounted at `/workspace` in the worker pod template.

Result: every rank fails with `cannot create /workspace/__basilica_source.py: Permission denied` and the pod enters CrashLoopBackoff. Verified live during the Phase 5b end-to-end smoke on 2026-05-03.

## Fix

`/workspace/` -> `/tmp/` for both the write target and the torchrun script arg in the source-shipping bash one-liner.

`/tmp/` is the standard tmpfs scratch location, writable by any uid in any standard base image. The fix is two literal-path replacements:

- `__init__.py:1220`: `... > /workspace/__basilica_source.py && ...` -> `... > /tmp/__basilica_source.py && ...`
- `__init__.py:1228`: `/workspace/__basilica_source.py` -> `/tmp/__basilica_source.py`

A surrounding comment is updated to cite the issue and the operator's pod securityContext.

## Test

Updated the existing `test_source_string_ships_via_b64` to assert on `/tmp/`, and added a dedicated regression guard `test_source_shipping_writes_to_tmp_not_workspace` in `crates/basilica-sdk-python/tests/test_distributed.py`:

```python
d_cmd = req["distributed"]["command"]
# Positive: write target + torchrun arg both reference /tmp/.
assert d_cmd.count("/tmp/__basilica_source.py") == 2, ...
# Negative: no /workspace/ anywhere -- locks the #448 fix.
assert "/workspace/" not in d_cmd, ...
```

Verified the negative assertion catches the bug: temporarily reverting `__init__.py` to `/workspace/` causes both `test_source_shipping_writes_to_tmp_not_workspace` and `test_source_string_ships_via_b64` to fail with explicit messages naming the regression. Restored the fix and all 31 tests in `test_distributed.py` pass.

## Validation

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --workspace --tests -- -D warnings` -- clean
- `pytest crates/basilica-sdk-python/tests/test_distributed.py -v` -- 31 passed
- `python -c "from basilica import BasilicaClient; print('import OK')"` -- clean

## What is NOT in this PR

- No operator changes. `crates/basilica-operator/src/controllers/distributed.rs` is untouched.
- No pod template / securityContext changes. `runAsUser: 1000` stays as-is.
- No `/workspace` `emptyDir` added to the pod template.
- No PyO3 / type-system / `_coerce_to_dict` changes (issue #449, separate PR).
- No version bump in `pyproject.toml` / `Cargo.toml`. No PyPI / release / tag.

Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved a file permission issue in distributed training deployments where script staging could fail in restricted environments. The system now uses a more reliable temporary location for script files during training job initialization, improving compatibility across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->