### PR TITLE
fix(sdk): expose status.distributed (and other fields) through PyO3 DeploymentResponse (closes #449)

### DIFF
--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -26,6 +26,7 @@ pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-stub-gen-derive = { workspace = true, optional = true }
 tokio = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 pythonize = { workspace = true }
 
 [build-dependencies]

--- a/crates/basilica-sdk-python/python/basilica/_basilica.pyi
+++ b/crates/basilica-sdk-python/python/basilica/_basilica.pyi
@@ -233,6 +233,12 @@ class DeploymentProgress:
 class DeploymentResponse:
     r"""
     Deployment response
+
+    Issue #449: previously the PyO3 binding was missing `image` and
+    `distributed`. The Python facade `_coerce_to_dict` consequently saw
+    only 4 attributes (`namespace`, `state`, `url`, `userId`) so every
+    `DistributedTraining.world` / `.ranks` / `.bench` / `.metrics` read
+    returned zeros. Both fields are now exposed end-to-end.
     """
     @property
     def instance_name(self) -> builtins.str: ...
@@ -240,6 +246,12 @@ class DeploymentResponse:
     def user_id(self) -> builtins.str: ...
     @property
     def namespace(self) -> builtins.str: ...
+    @property
+    def image(self) -> builtins.str:
+        r"""
+        Container image. Issue #449: missing from PyO3 binding before this
+        PR even though the API has always returned it.
+        """
     @property
     def state(self) -> builtins.str: ...
     @property
@@ -272,6 +284,15 @@ class DeploymentResponse:
     def websocket(self) -> typing.Optional[WebSocketConfig]: ...
     @property
     def public_metadata(self) -> builtins.bool: ...
+    @property
+    def distributed(self) -> typing.Optional[typing.Dict[builtins.str, typing.Any]]:
+        r"""
+        Read-only mirror of `status.distributed` from the operator. Returns
+        a Python dict with camelCase keys (`worldSize`, `ranks`, `bench`,
+        ...) or `None` for non-distributed UDs (issue #449). Consumed by
+        the `DistributedTraining` facade in
+        `crates/basilica-sdk-python/python/basilica/distributed.py`.
+        """
 
 class DeploymentSummary:
     r"""

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -597,32 +597,55 @@ def _coerce_to_dict(obj: Any) -> Dict[str, Any]:
     """
     PyO3 DeploymentResponse -> Python dict for status field access.
     Tolerates dict input (already-converted) and PyO3 wrappers.
+
+    Issue #449: the dict produced here MUST include the `distributed`
+    block end-to-end. Earlier SDK builds dropped it because the PyO3
+    binding had no `distributed` getter; the read properties on
+    `DistributedTraining` walked an absent key and returned zeros.
+
+    The PyO3 `DeploymentResponse` exposes attributes in snake_case
+    (Rust convention); this helper maps them to the camelCase keys
+    the operator emits on the wire. `distributed` is already a
+    camelCase Python dict on the binding side (built via
+    `pythonize` from the strongly-typed `DistributedStatus` JSON), so
+    it is copied through verbatim.
     """
     if isinstance(obj, dict):
         return obj
     out: Dict[str, Any] = {}
+    # Scalar / Optional[str] / Optional[bool] fields. Each maps to its
+    # camelCase wire key.
     for attr in (
         "instance_name",
         "user_id",
         "namespace",
+        "image",
         "state",
         "url",
+        "created_at",
+        "updated_at",
         "phase",
         "message",
+        "share_token",
+        "share_url",
+        "public_metadata",
     ):
         if hasattr(obj, attr):
             out[_to_camel(attr)] = getattr(obj, attr)
-    if hasattr(obj, "namespace"):
-        out["namespace"] = obj.namespace
-    # The PyO3 DeploymentResponse does not currently expose status.distributed
-    # as a typed field. The Python facade reads from `obj.status` if present;
-    # otherwise an empty distributed block. The operator-side patch from the
-    # Phase 5b precursor (basilica-backend #421) populates this on the CR but
-    # the API gateway does not yet pass it through `DeploymentResponse`. The
-    # Python facade will read distributed status from `client.get(...)` once
-    # the API exposes it; until then `world` returns zeros and `bench` returns
-    # None.
-    if hasattr(obj, "_distributed_status"):
+    # Pass-through dict (from PyO3 `pythonize` on the Rust side). The
+    # operator emits camelCase, so this dict is already in the shape the
+    # `world` / `ranks` / `bench` / `metrics` properties expect. Type-check
+    # against `dict` so MagicMock auto-attrs (which are truthy but not
+    # dicts) do not silently leak into the output and shadow the
+    # `_distributed_status` test-mock fallback below.
+    if hasattr(obj, "distributed"):
+        d = getattr(obj, "distributed", None)
+        if isinstance(d, dict):
+            out["distributed"] = d
+    # Test-mock back-compat: callers that build a MagicMock with a
+    # `_distributed_status` attribute (the pre-#449 mock pattern) keep
+    # working without rewrites.
+    if "distributed" not in out and hasattr(obj, "_distributed_status"):
         out["distributed"] = obj._distributed_status  # type: ignore[attr-defined]
     return out
 

--- a/crates/basilica-sdk-python/src/types.rs
+++ b/crates/basilica-sdk-python/src/types.rs
@@ -1443,6 +1443,12 @@ impl From<SdkDeploymentProgress> for DeploymentProgress {
 }
 
 /// Deployment response
+///
+/// Issue #449: previously the PyO3 binding was missing `image` and
+/// `distributed`. The Python facade `_coerce_to_dict` consequently saw
+/// only 4 attributes (`namespace`, `state`, `url`, `userId`) so every
+/// `DistributedTraining.world` / `.ranks` / `.bench` / `.metrics` read
+/// returned zeros. Both fields are now exposed end-to-end.
 #[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
 #[pyclass]
 #[derive(Clone)]
@@ -1453,6 +1459,10 @@ pub struct DeploymentResponse {
     pub user_id: String,
     #[pyo3(get)]
     pub namespace: String,
+    /// Container image. Issue #449: missing from PyO3 binding before this
+    /// PR even though the API has always returned it.
+    #[pyo3(get)]
+    pub image: String,
     #[pyo3(get)]
     pub state: String,
     #[pyo3(get)]
@@ -1481,14 +1491,54 @@ pub struct DeploymentResponse {
     pub websocket: Option<WebSocketConfig>,
     #[pyo3(get)]
     pub public_metadata: bool,
+    /// Read-only mirror of `status.distributed` from the operator.
+    /// Stored as JSON internally; exposed to Python as a dict via the
+    /// `distributed` getter (issue #449). The Python facade
+    /// `DistributedTraining` walks the dict's camelCase keys to
+    /// produce typed `WorldStatus`, `RankStatus`, `BenchResult` views.
+    /// Not annotated `#[pyo3(get)]` because `serde_json::Value` is not
+    /// `IntoPyObject`; see the `distributed` method on the impl block.
+    pub distributed: Option<serde_json::Value>,
+}
+
+#[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
+#[pymethods]
+impl DeploymentResponse {
+    /// Convert the cached `status.distributed` JSON into a Python dict
+    /// (or `None` for non-distributed UDs).
+    ///
+    /// `pythonize` is only available with a `Python<'_>` token, so this
+    /// must be a `#[pymethods]` getter rather than a `#[pyo3(get)]`
+    /// auto-getter on the field. Python access pattern is identical
+    /// (`response.distributed`).
+    #[getter]
+    fn distributed(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        match &self.distributed {
+            None => Ok(None),
+            Some(v) => Ok(Some(pythonize::pythonize(py, v)?.unbind())),
+        }
+    }
 }
 
 impl From<SdkDeploymentResponse> for DeploymentResponse {
     fn from(response: SdkDeploymentResponse) -> Self {
+        // Re-serialize the strongly-typed `DistributedStatus` to JSON so
+        // we can hand it to Python as a camelCase dict. This is cheap
+        // (a few hundred bytes per deployment) and keeps the Python
+        // facade's `_coerce_to_dict` walk identical to the operator's
+        // wire shape. `serde_json::to_value` cannot fail for any of the
+        // SDK's `Serialize`-deriving types, but we map the error through
+        // `Option` defensively rather than `expect`-panic on the SDK
+        // hot path.
+        let distributed = response
+            .distributed
+            .as_ref()
+            .and_then(|d| serde_json::to_value(d).ok());
         Self {
             instance_name: response.instance_name,
             user_id: response.user_id,
             namespace: response.namespace,
+            image: response.image,
             state: response.state,
             url: response.url,
             replicas: response.replicas.into(),
@@ -1504,6 +1554,7 @@ impl From<SdkDeploymentResponse> for DeploymentResponse {
             share_url: response.share_url,
             websocket: response.websocket.map(Into::into),
             public_metadata: response.public_metadata,
+            distributed,
         }
     }
 }

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -566,3 +566,182 @@ class TestExceptionAttributes:
         assert e.requested == 12
         assert e.min == 4
         assert e.max == 8
+
+
+# =============================================================================
+# Issue #449 regression tests: status.distributed is read end-to-end.
+#
+# Before #449 the PyO3 binding had no `distributed` getter; every read
+# property on `DistributedTraining` returned zeros / empty / None on a
+# healthy cluster, and `wait_until_min_world(timeout=N)` raised
+# BelowMinimumWorld immediately. These tests lock the contract: a
+# regression that drops `distributed` from the PyO3 binding (or from
+# `_coerce_to_dict`) would fail the negative test loudly.
+# =============================================================================
+
+
+class TestIssue449DeploymentResponseDistributed:
+    """Mocked end-to-end: `client.get` -> `_coerce_to_dict` -> facade reads."""
+
+    def _fake_pyo3_response(self) -> Any:
+        """Build a stand-in for the PyO3 `DeploymentResponse` that exposes
+        the full attribute set landed by issue #449.
+
+        Uses an explicit instance with declared attributes (rather than a
+        plain MagicMock) because the post-#449 `_coerce_to_dict` checks
+        `isinstance(d, dict)` to distinguish a real PyO3 `distributed`
+        attribute from a MagicMock auto-generated attribute.
+        """
+
+        class FakeDeployment:
+            instance_name = "dlc-449-mock"
+            user_id = "u-test"
+            namespace = "u-test"
+            image = "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime"
+            state = "running"
+            url = "https://dlc-449-mock.deployments.basilica.ai"
+            created_at = "2026-05-02T10:00:00Z"
+            updated_at = "2026-05-02T10:05:00Z"
+            phase = "Running"
+            message = None
+            share_token = None
+            share_url = None
+            public_metadata = False
+            distributed = {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 3,
+                    "belowMinimum": False,
+                },
+                "ranks": [
+                    {
+                        "rank": 0,
+                        "podName": "dlc-449-mock-0",
+                        "nodeName": "basilica-verda-fin-03",
+                        "provider": "verda",
+                        "region": "FIN-03",
+                        "phase": "Running",
+                        "restarts": 0,
+                    },
+                    {
+                        "rank": 1,
+                        "podName": "dlc-449-mock-1",
+                        "nodeName": "basilica-verda-fin-04",
+                        "provider": "verda",
+                        "region": "FIN-04",
+                        "phase": "Running",
+                        "restarts": 0,
+                    },
+                ],
+                "transport": "hub-relay",
+                "bench": {
+                    "mode": "on-start",
+                    "result": {
+                        "measuredAt": "2026-05-02T10:00:30Z",
+                        "busbwGbpsP50": 0.00897,
+                        "sizeBytesSwept": [1048576, 16777216],
+                        "probeNodeA": "basilica-verda-fin-03",
+                        "probeNodeB": "basilica-verda-fin-04",
+                    },
+                    "lastAttemptOutcome": "success",
+                },
+            }
+
+        return FakeDeployment()
+
+    def test_world_returns_real_values_not_zeros(self) -> None:
+        # The original bug: facade read zeros on a healthy cluster.
+        client = MagicMock()
+        client.get.return_value = self._fake_pyo3_response()
+        training = DistributedTraining(client, "dlc-449-mock")
+        ws = training.world
+        assert ws.ready == 2
+        assert ws.target == 2
+        assert ws.min == 2
+        assert ws.max == 3
+        assert ws.below_minimum is False
+
+    def test_ranks_returns_two_pods_with_provider_and_region(self) -> None:
+        client = MagicMock()
+        client.get.return_value = self._fake_pyo3_response()
+        training = DistributedTraining(client, "dlc-449-mock")
+        ranks = training.ranks
+        assert len(ranks) == 2
+        assert ranks[0].rank == 0
+        assert ranks[0].pod_name == "dlc-449-mock-0"
+        assert ranks[0].node == "basilica-verda-fin-03"
+        assert ranks[0].provider == "verda"
+        assert ranks[0].region == "FIN-03"
+        assert ranks[0].phase == "Running"
+        assert ranks[1].rank == 1
+        assert ranks[1].pod_name == "dlc-449-mock-1"
+        assert ranks[1].provider == "verda"
+
+    def test_bench_returns_populated_result(self) -> None:
+        client = MagicMock()
+        client.get.return_value = self._fake_pyo3_response()
+        training = DistributedTraining(client, "dlc-449-mock")
+        bench = training.bench
+        assert bench is not None
+        assert bench.busbw_gbps_p50 == 0.00897
+        assert bench.size_bytes_swept == [1048576, 16777216]
+        assert bench.probe_node_a == "basilica-verda-fin-03"
+        assert bench.probe_node_b == "basilica-verda-fin-04"
+
+    def test_metrics_returns_real_world_size(self) -> None:
+        client = MagicMock()
+        client.get.return_value = self._fake_pyo3_response()
+        training = DistributedTraining(client, "dlc-449-mock")
+        m = training.metrics()
+        assert m.world_ready == 2
+        assert m.world_target == 2
+        assert m.rank_restarts_total == 0
+
+    def test_wait_until_min_world_returns_immediately_when_at_min(self) -> None:
+        # Before #449, this raised BelowMinimumWorld(ready=0, required_min=0)
+        # because both zeros came from the dropped `distributed` block.
+        client = MagicMock()
+        client.get.return_value = self._fake_pyo3_response()
+        training = DistributedTraining(client, "dlc-449-mock")
+        # Should NOT raise (ready=2 >= min=2).
+        training.wait_until_min_world(timeout=10)
+
+    def test_NEGATIVE_coerce_to_dict_carries_distributed_and_image(self) -> None:
+        """Locks the bug from regressing.
+
+        Before #449: `_coerce_to_dict(client.get(name))` returned a dict
+        with only `[namespace, state, url, userId]` (4 keys). After #449
+        the dict MUST also carry `image`, `phase`, `createdAt`, and
+        crucially `distributed`. A regression that drops the PyO3
+        `distributed` getter (or stops walking it in `_coerce_to_dict`)
+        would fail this test loudly.
+        """
+        from basilica.distributed import _coerce_to_dict
+
+        d = _coerce_to_dict(self._fake_pyo3_response())
+        # The fields the original bug-report logged as missing:
+        for required_key in (
+            "instanceName",
+            "userId",
+            "namespace",
+            "image",
+            "state",
+            "url",
+            "createdAt",
+            "updatedAt",
+            "phase",
+            "distributed",
+        ):
+            assert required_key in d, (
+                f"_coerce_to_dict must carry '{required_key}' (issue #449); "
+                f"got keys: {sorted(d.keys())}"
+            )
+        # And the distributed block carries the operator's camelCase shape.
+        dist = d["distributed"]
+        assert dist["worldSize"]["ready"] == 2
+        assert dist["worldSize"]["belowMinimum"] is False
+        assert len(dist["ranks"]) == 2
+        assert dist["bench"]["mode"] == "on-start"
+        assert dist["bench"]["result"]["busbwGbpsP50"] == 0.00897

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -953,6 +953,10 @@ pub struct DeploymentResponse {
     pub instance_name: String,
     pub user_id: String,
     pub namespace: String,
+    /// Container image. Populated by basilica-api from the underlying
+    /// `UserDeployment.spec.image`.
+    #[serde(default)]
+    pub image: String,
     pub state: String,
     pub url: String,
     pub replicas: ReplicaStatus,
@@ -979,6 +983,15 @@ pub struct DeploymentResponse {
     /// Whether public metadata enrollment is enabled for this deployment.
     #[serde(default)]
     pub public_metadata: bool,
+    /// Read-only mirror of `status.distributed` from the `UserDeployment`
+    /// CR (issue #431, exposed end-to-end via #449). `None` for
+    /// non-distributed UDs; the JSON key is omitted entirely thanks to
+    /// `skip_serializing_if` so older API responses without `distributed`
+    /// continue to deserialize correctly. Populated by basilica-api's
+    /// `extract_distributed_status` helper from
+    /// `crates/basilica-api/src/api/routes/deployments/distributed_status.rs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub distributed: Option<DistributedStatus>,
 }
 
 /// Deployment summary for list responses
@@ -1390,19 +1403,162 @@ pub struct DistributedBenchStatus {
     pub last_attempt_outcome: Option<String>,
 }
 
+/// Structured condition on a distributed UD's status. Operator source:
+/// `crd::user_deployment::DistributedCondition`. Mirror of
+/// `basilica-api::DistributedCondition` (issue #449).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedCondition {
+    /// Stable token, e.g. `Admitted`, `BelowMinimum`, `MeshCapable`.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// `True` | `False` | `Unknown`.
+    pub status: String,
+    /// Stable machine-readable token, e.g. `QuotaExceeded`,
+    /// `DistributedShapeInvalid`, `RanksReady`.
+    pub reason: String,
+    pub message: String,
+    pub last_transition_time: String,
+}
+
+/// Read-only mirror of what the operator rendered for the rendezvous Pod.
+/// Operator source: `crd::user_deployment::RendezvousStatus`. Mirror of
+/// `basilica-api::RendezvousStatus` (issue #449).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedRendezvousStatus {
+    /// `etcd-v2` | `c10d` | `static`.
+    pub backend: String,
+    pub port: u16,
+    /// Container image rendered for the rendezvous Pod. Empty when
+    /// `backend=c10d`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub image: String,
+    /// Monotonic count of rendezvous-Pod restart events the operator has
+    /// observed.
+    #[serde(default)]
+    pub restart_count: u32,
+    /// Phase 2.1: RFC3339 timestamp of the last operator-mediated rendezvous
+    /// reset (resize, auto-recovery, or rank-loss).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reset_at: Option<String>,
+}
+
+/// A single transition in `worldSize.target`. Operator source:
+/// `crd::user_deployment::WorldSizeTransition`. Mirror of
+/// `basilica-api::WorldSizeTransition` (issue #449).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedWorldSizeTransition {
+    pub timestamp: String,
+    pub target: u32,
+    pub ready: u32,
+}
+
+/// Record of the most recent `worldSize.target` resize. Operator source:
+/// `crd::user_deployment::ResizeRecord`. Mirror of
+/// `basilica-api::ResizeRecord` (issue #449).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedResizeRecord {
+    pub from_target: u32,
+    pub to_target: u32,
+    pub timestamp: String,
+    pub reason: String,
+}
+
+/// One-shot lifecycle event recorded by the operator. Operator source:
+/// `crd::user_deployment::Milestone`. Mirror of `basilica-api::Milestone`
+/// (issue #449).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedMilestone {
+    pub name: String,
+    pub timestamp: String,
+}
+
+/// Phase 2.1 record of one operator-mediated rendezvous reset triggered by
+/// stuck-restarting worker ranks. Operator source:
+/// `crd::user_deployment::RankLossReset`. Mirror of
+/// `basilica-api::RankLossReset` (issue #449).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedRankLossReset {
+    pub timestamp: String,
+    pub ranks: Vec<u32>,
+}
+
+/// Phase 4b preflight band the operator pulled from the bench collector.
+/// Operator source: `crd::user_deployment::PreflightEstimate`. Mirror of
+/// `basilica-api::PreflightEstimate` (issue #449).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedPreflightEstimate {
+    pub freshness: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p10: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p50: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busbw_gbps_p90: Option<f64>,
+    #[serde(default)]
+    pub sample_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_sample_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_queried_at: Option<String>,
+}
+
 /// Read-only mirror of `status.distributed`. Populated by the operator
-/// after first reconcile. Architecture doc § 17.1.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// after first reconcile. Architecture doc § 17.1. Mirror of
+/// `basilica-api::DistributedStatus` -- field-for-field, byte-equal at the
+/// JSON layer (issue #449).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DistributedStatus {
     pub world_size: DistributedWorldStatus,
     #[serde(default)]
     pub ranks: Vec<DistributedRankStatus>,
+    /// Structured operator conditions (e.g. `Admitted`, `RanksReady`).
+    /// Populated by the operator's reconciler.
+    #[serde(default)]
+    pub conditions: Vec<DistributedCondition>,
     /// `hub-relay` (Phase 1) | `direct-mesh` | `mixed` (Tier 2+). Reserved
     /// shape; consult only as a hint.
     pub transport: String,
+    /// Read-only mirror of the rendezvous Pod the operator rendered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rendezvous: Option<DistributedRendezvousStatus>,
+    /// Append-only history of `worldSize.target` transitions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub world_size_history: Vec<DistributedWorldSizeTransition>,
+    /// Most recent `worldSize.target` resize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_resize: Option<DistributedResizeRecord>,
+    /// One-shot lifecycle events recorded by the operator.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub milestones: Vec<DistributedMilestone>,
+    /// Original `worldSize.max` at admission; preserved across resizes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_max: Option<u32>,
+    /// Phase 2.1: operator-mediated rendezvous resets due to stuck ranks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rank_loss_resets: Vec<DistributedRankLossReset>,
+    /// Phase 4b preflight band pulled from the bench collector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preflight: Option<DistributedPreflightEstimate>,
+    /// Phase 5a per-UD NCCL bench probe state. `None` when bench is off
+    /// or the probe has not yet completed its first attempt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bench: Option<DistributedBenchStatus>,
+    /// Phase 5a deprecation flag for the legacy preflight surface.
+    #[serde(default, skip_serializing_if = "is_false_status")]
+    pub preflight_deprecation_warned: bool,
+}
+
+#[inline]
+fn is_false_status(b: &bool) -> bool {
+    !*b
 }
 
 /// Deployment progress information
@@ -2417,11 +2573,238 @@ mod tests {
                 restarts: 0,
             }],
             transport: "hub-relay".to_string(),
-            bench: None,
+            ..Default::default()
         };
         let v = serde_json::to_value(&status).unwrap();
         assert_eq!(v["worldSize"]["belowMinimum"], false);
         assert_eq!(v["ranks"][0]["podName"], "dlc-test-0");
         assert_eq!(v["transport"], "hub-relay");
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #449 regression tests: status.distributed wired into
+    // DeploymentResponse end-to-end. The 4-test floor is the load-bearing
+    // gate that keeps the PyO3 deserializer from silently dropping the
+    // distributed block again.
+    // -------------------------------------------------------------------------
+
+    fn _sample_deployment_with_distributed() -> DeploymentResponse {
+        DeploymentResponse {
+            instance_name: "dlc-449".to_string(),
+            user_id: "u-test".to_string(),
+            namespace: "u-test".to_string(),
+            image: "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime".to_string(),
+            state: "running".to_string(),
+            url: "https://dlc-449.deployments.basilica.ai".to_string(),
+            replicas: ReplicaStatus {
+                desired: 2,
+                ready: 2,
+            },
+            created_at: "2026-05-02T10:00:00Z".to_string(),
+            updated_at: Some("2026-05-02T10:05:00Z".to_string()),
+            pods: None,
+            phase: Some("Running".to_string()),
+            message: None,
+            progress: None,
+            share_token: None,
+            share_url: None,
+            websocket: None,
+            public_metadata: false,
+            distributed: Some(DistributedStatus {
+                world_size: DistributedWorldStatus {
+                    ready: 2,
+                    target: 2,
+                    min: 2,
+                    max: 3,
+                    below_minimum: false,
+                },
+                ranks: vec![
+                    DistributedRankStatus {
+                        rank: 0,
+                        pod_name: "dlc-449-0".to_string(),
+                        node_name: Some("basilica-verda-fin-03".to_string()),
+                        provider: Some("verda".to_string()),
+                        region: Some("FIN-03".to_string()),
+                        phase: "Running".to_string(),
+                        restarts: 0,
+                    },
+                    DistributedRankStatus {
+                        rank: 1,
+                        pod_name: "dlc-449-1".to_string(),
+                        node_name: Some("basilica-verda-fin-04".to_string()),
+                        provider: Some("verda".to_string()),
+                        region: Some("FIN-04".to_string()),
+                        phase: "Running".to_string(),
+                        restarts: 0,
+                    },
+                ],
+                conditions: vec![],
+                transport: "hub-relay".to_string(),
+                rendezvous: None,
+                world_size_history: vec![],
+                last_resize: None,
+                milestones: vec![],
+                original_max: Some(3),
+                rank_loss_resets: vec![],
+                preflight: None,
+                bench: Some(DistributedBenchStatus {
+                    mode: DistributedBenchMode::OnStart,
+                    result: Some(DistributedBenchResult {
+                        measured_at: "2026-05-02T10:00:30Z".to_string(),
+                        busbw_gbps_p50: Some(0.00897),
+                        size_bytes_swept: vec![1_048_576, 16_777_216],
+                        probe_node_a: "basilica-verda-fin-03".to_string(),
+                        probe_node_b: "basilica-verda-fin-04".to_string(),
+                        ..Default::default()
+                    }),
+                    last_attempt_at: Some("2026-05-02T10:00:35Z".to_string()),
+                    last_attempt_outcome: Some("success".to_string()),
+                }),
+                preflight_deprecation_warned: false,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_deployment_response_with_distributed_round_trips() {
+        // Issue #449: full round-trip with the distributed block populated.
+        // This is the load-bearing test: a regression that drops `distributed`
+        // from the SDK's serde_json round-trip would fail this assertion.
+        let original = _sample_deployment_with_distributed();
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: DeploymentResponse = serde_json::from_str(&json).unwrap();
+        assert!(parsed.distributed.is_some());
+        let d = parsed.distributed.unwrap();
+        assert_eq!(d.world_size.ready, 2);
+        assert_eq!(d.world_size.target, 2);
+        assert_eq!(d.world_size.min, 2);
+        assert_eq!(d.world_size.max, 3);
+        assert!(!d.world_size.below_minimum);
+        assert_eq!(d.ranks.len(), 2);
+        assert_eq!(d.ranks[0].pod_name, "dlc-449-0");
+        assert_eq!(d.ranks[1].provider.as_deref(), Some("verda"));
+        assert_eq!(d.transport, "hub-relay");
+        assert_eq!(d.original_max, Some(3));
+        let bench = d.bench.expect("bench present");
+        assert_eq!(bench.mode, DistributedBenchMode::OnStart);
+        let result = bench.result.expect("bench.result present");
+        assert_eq!(result.busbw_gbps_p50, Some(0.00897));
+        assert_eq!(result.probe_node_a, "basilica-verda-fin-03");
+    }
+
+    #[test]
+    fn test_deployment_response_without_distributed_omits_key() {
+        // Issue #449 backwards-compat guard: when `distributed` is None, the
+        // JSON output must NOT include the `distributed` key. Older API
+        // responses without this field continue to deserialize correctly.
+        let mut resp = _sample_deployment_with_distributed();
+        resp.distributed = None;
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(
+            v.get("distributed").is_none(),
+            "distributed key must be omitted when None (skip_serializing_if), \
+             else older API responses without this field break: {v}"
+        );
+        // And the remaining fields still round-trip cleanly.
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: DeploymentResponse = serde_json::from_str(&json).unwrap();
+        assert!(parsed.distributed.is_none());
+        assert_eq!(
+            parsed.image,
+            "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime"
+        );
+    }
+
+    #[test]
+    fn test_distributed_status_json_is_camelcase() {
+        // Issue #449 wire-shape lock: the operator emits camelCase
+        // (`belowMinimum`, `worldSize`, `lastResize`, `originalMax`,
+        // `worldSizeHistory`, `rankLossResets`, `preflightDeprecationWarned`).
+        // The SDK's Python facade reads camelCase. A regression toward
+        // snake_case would silently break every read property.
+        let resp = _sample_deployment_with_distributed();
+        let v = serde_json::to_value(&resp).unwrap();
+        let d = &v["distributed"];
+        // Top-level: required `worldSize`, `ranks`, `transport`.
+        assert!(d.get("worldSize").is_some(), "worldSize key missing: {v}");
+        assert!(d.get("ranks").is_some(), "ranks key missing: {v}");
+        assert!(d.get("transport").is_some(), "transport key missing: {v}");
+        // Nested: `belowMinimum` (camelCase, not snake_case).
+        assert_eq!(d["worldSize"]["belowMinimum"], false);
+        // Optional but present here: `originalMax`. `lastResize`,
+        // `worldSizeHistory`, `rankLossResets`, `milestones`,
+        // `preflightDeprecationWarned` are skipped when empty/false.
+        assert_eq!(d["originalMax"], 3);
+        assert!(
+            d.get("lastResize").is_none(),
+            "lastResize must be omitted when None (got: {d})"
+        );
+        assert!(
+            d.get("worldSizeHistory").is_none(),
+            "worldSizeHistory must be omitted when empty (got: {d})"
+        );
+        assert!(
+            d.get("rankLossResets").is_none(),
+            "rankLossResets must be omitted when empty (got: {d})"
+        );
+        assert!(
+            d.get("milestones").is_none(),
+            "milestones must be omitted when empty (got: {d})"
+        );
+        assert!(
+            d.get("preflightDeprecationWarned").is_none(),
+            "preflightDeprecationWarned must be omitted when false (got: {d})"
+        );
+        // Rank fields: `podName`, `nodeName`.
+        assert_eq!(d["ranks"][0]["podName"], "dlc-449-0");
+        assert_eq!(d["ranks"][0]["nodeName"], "basilica-verda-fin-03");
+        // Bench: `lastAttemptAt`, `lastAttemptOutcome`, `probeNodeA`/`B`.
+        let bench = &d["bench"];
+        assert_eq!(bench["mode"], "on-start"); // kebab-case enum
+        assert_eq!(bench["lastAttemptOutcome"], "success");
+        assert_eq!(bench["result"]["busbwGbpsP50"], 0.00897);
+        assert_eq!(bench["result"]["probeNodeA"], "basilica-verda-fin-03");
+        assert_eq!(bench["result"]["probeNodeB"], "basilica-verda-fin-04");
+        assert_eq!(bench["result"]["measuredAt"], "2026-05-02T10:00:30Z");
+    }
+
+    #[test]
+    fn test_distributed_status_bench_result_round_trips() {
+        // Issue #449: bench sub-shape locks the wire contract for
+        // `BenchResult`. The SDK's Python facade calls
+        // `BenchResult.from_status_dict(raw)` with this exact JSON; a drift
+        // in field naming silently produces zero values on the Python side.
+        let json = r#"{
+            "worldSize": {"ready": 2, "target": 2, "min": 2, "max": 2, "belowMinimum": false},
+            "transport": "hub-relay",
+            "bench": {
+                "mode": "on-start",
+                "result": {
+                    "measuredAt": "2026-05-02T11:00:00Z",
+                    "busbwGbpsP10": 0.0042,
+                    "busbwGbpsP50": 0.00897,
+                    "busbwGbpsP90": 0.012,
+                    "algbwGbpsP50": 0.0085,
+                    "latencyUsAt1mib": 1820.5,
+                    "sizeBytesSwept": [1048576, 16777216, 268435456],
+                    "probeNodeA": "basilica-verda-fin-03",
+                    "probeNodeB": "basilica-verda-fin-04"
+                },
+                "lastAttemptAt": "2026-05-02T11:00:05Z",
+                "lastAttemptOutcome": "success"
+            }
+        }"#;
+        let status: DistributedStatus = serde_json::from_str(json).unwrap();
+        let bench = status.bench.expect("bench present");
+        let result = bench.result.expect("bench.result present");
+        assert_eq!(result.busbw_gbps_p50, Some(0.00897));
+        assert_eq!(result.busbw_gbps_p10, Some(0.0042));
+        assert_eq!(result.latency_us_at_1mib, Some(1820.5));
+        assert_eq!(
+            result.size_bytes_swept,
+            vec![1_048_576, 16_777_216, 268_435_456]
+        );
+        assert_eq!(result.probe_node_a, "basilica-verda-fin-03");
+        assert_eq!(bench.last_attempt_outcome.as_deref(), Some("success"));
     }
 }


### PR DESCRIPTION
## Bug analysis (issue #449)

The basilica-api correctly returns 11 fields on `DeploymentResponse` JSON including the full `distributed: {worldSize, ranks, bench, ...}` block (verified live by raw HTTP today on production, server-side wired by PR #433). But when read through the SDK, `_coerce_to_dict(client.get(name))` returned only 4 fields: `[namespace, state, url, userId]`.

Root cause was at TWO layers:

1. **`crates/basilica-sdk/src/types.rs:952` (`DeploymentResponse`)** — missing `image` and `distributed` fields. Serde silently dropped both during JSON deserialization because the struct didn't declare them.
2. **`crates/basilica-sdk-python/src/types.rs:1449` (PyO3 mirror)** — even if the Rust struct had carried them, the `#[pyclass]` mirror had no `#[pyo3(get)]` for them either, so the Python facade saw nothing.

Effect: every read property on `DistributedTraining` returned zeros / empty / None on a healthy cluster:
- `t.world` -> `WorldStatus(0, 0, 0, 0)`
- `t.ranks` -> `[]`
- `t.bench` -> `None`
- `t.metrics()` -> zeros
- `t.wait_until_min_world(timeout=N)` -> raised `BelowMinimumWorld(ready=0, required_min=0)` immediately

The SDK's writer paths (`deploy_distributed`, `scale`, `delete`) were unaffected because they only POST/DELETE; they don't deserialize the response body.

## What this PR changes

Four bisectable commits, each landing one milestone:

### 1. `fix(sdk): mirror status.distributed wire shape on DeploymentResponse` (42519a11)
- Extends `DistributedStatus` in `crates/basilica-sdk/src/types.rs` to mirror the canonical `basilica-api::DistributedStatus` (basilica-api/src/api/routes/deployments/types.rs:610) byte-for-byte at the JSON layer. New sub-types: `DistributedCondition`, `DistributedRendezvousStatus`, `DistributedWorldSizeTransition`, `DistributedResizeRecord`, `DistributedMilestone`, `DistributedRankLossReset`, `DistributedPreflightEstimate` (mirrors of basilica-api's `DistributedCondition` line 465, `RendezvousStatus` line 482, `WorldSizeTransition` line 504, `ResizeRecord` line 514, `Milestone` line 525, `RankLossReset` line 535, `PreflightEstimate` line 544).
- Adds `pub image: String` and `pub distributed: Option<DistributedStatus>` to `DeploymentResponse` (line 952). Both `#[serde(default)]` / `skip_serializing_if = "Option::is_none"` so older API responses without these keys continue to deserialize correctly.
- 4 new serde tests in `types::tests`:
  - Full round-trip with `distributed` populated (worldSize + 2 ranks + bench result with f64 fields).
  - Backwards-compat: `distributed = None` omits the JSON key.
  - Wire-shape lock: every JSON key is camelCase.
  - BenchResult sub-shape round-trips a populated probe.

### 2. `fix(sdk-python): expose image + status.distributed via PyO3` (9953ba4f)
- Adds `pub image: String` with `#[pyo3(get)]` on the PyO3 `DeploymentResponse`.
- Adds `pub distributed: Option<serde_json::Value>` (no `#[pyo3(get)]`) + `#[getter] fn distributed(&self, py)` that converts to a Python dict via `pythonize`. Uses the existing `pythonize`-passthrough pattern already established by `get_deployment_events`.
- Updates `_basilica.pyi` type stubs.
- Adds `serde_json` to the crate's deps (via workspace).

### 3. `fix(sdk-python): walk full DeploymentResponse in _coerce_to_dict` (4ad64c12)
- Walks `instance_name`, `user_id`, `namespace`, `image`, `state`, `url`, `created_at`, `updated_at`, `phase`, `message`, `share_token`, `share_url`, `public_metadata` -> camelCase wire keys.
- Passes `distributed` through verbatim (already camelCase from PyO3 `pythonize`).
- Type-checks against `dict` so MagicMock auto-attrs do not silently leak in.
- Keeps the legacy `_distributed_status` test-mock fallback for back-compat.

### 4. `test(sdk-python): lock end-to-end status.distributed read path` (60145f9f)
Six new tests under `TestIssue449DeploymentResponseDistributed`:
- `test_world_returns_real_values_not_zeros`
- `test_ranks_returns_two_pods_with_provider_and_region`
- `test_bench_returns_populated_result`
- `test_metrics_returns_real_world_size`
- `test_wait_until_min_world_returns_immediately_when_at_min`
- `test_NEGATIVE_coerce_to_dict_carries_distributed_and_image` — the regression lock; asserts the dict carries `instanceName`, `userId`, `namespace`, `image`, `state`, `url`, `createdAt`, `updatedAt`, `phase`, `distributed`.

## Test transcript

### Rust serde tests (`cargo test -p basilica-sdk --lib`)

```
test types::tests::test_deployment_response_with_distributed_round_trips ... ok
test types::tests::test_deployment_response_without_distributed_omits_key ... ok
test types::tests::test_distributed_status_json_is_camelcase ... ok
test types::tests::test_distributed_status_bench_result_round_trips ... ok
test types::tests::test_distributed_status_camelcase ... ok
[...77 total...]
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Python tests (`pytest crates/basilica-sdk-python/tests/test_distributed.py -v`)

```
TestIssue449DeploymentResponseDistributed::test_world_returns_real_values_not_zeros PASSED
TestIssue449DeploymentResponseDistributed::test_ranks_returns_two_pods_with_provider_and_region PASSED
TestIssue449DeploymentResponseDistributed::test_bench_returns_populated_result PASSED
TestIssue449DeploymentResponseDistributed::test_metrics_returns_real_world_size PASSED
TestIssue449DeploymentResponseDistributed::test_wait_until_min_world_returns_immediately_when_at_min PASSED
TestIssue449DeploymentResponseDistributed::test_NEGATIVE_coerce_to_dict_carries_distributed_and_image PASSED
[...36 total...]
============================== 36 passed in 0.12s ==============================
```

### Pre-push validation

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo test -p basilica-sdk --lib` 77/77 pass
- `maturin develop --quiet` succeeded
- `pytest crates/basilica-sdk-python/tests/test_distributed.py -v` 36/36 pass

Verified by mocked Python integration test; live verification deferred to a post-merge re-smoke (the user's call) since that requires API token + GPU capacity.

## What is NOT in this PR

- **No basilica-api changes** — server side is already correct per #433 (merged 2026-05-03).
- **No writer-path changes** — `deploy_distributed`, `scale`, `delete` always worked.
- **No `__init__.py:1220` `/workspace/` -> `/tmp/` change** — that's #448's scope, parallel agent.
- **No version bump** — neither `pyproject.toml` nor `Cargo.toml` was touched. No PyPI upload, no release tag, no `maturin publish`. The user explicitly said "do not release the sdk or cli".

Closes #449.