### PR TITLE
fix(sdk): Deployment wrapper carries distributed (and other fields) from PyO3 (closes #454, closes #453)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/_deployment.py
+++ b/crates/basilica-sdk-python/python/basilica/_deployment.py
@@ -24,7 +24,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from basilica.exceptions import DeploymentFailed, DeploymentTimeout
@@ -172,12 +172,28 @@ class Deployment:
         replicas_ready: int = 0,
         replicas_desired: int = 1,
         updated_at: Optional[str] = None,
+        image: str = "",
+        phase: Optional[str] = None,
+        message: Optional[str] = None,
+        share_token: Optional[str] = None,
+        share_url: Optional[str] = None,
+        public_metadata: bool = False,
+        distributed: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize a Deployment instance.
 
         Note: Users should not create Deployment objects directly.
         Use client.deploy() or client.get_deployment() instead.
+
+        Issues #453 / #454: prior to this fix the wrapper dropped
+        `image`, `phase`, `distributed` (and several other fields) that
+        the PyO3 layer exposes. The Python facade `_coerce_to_dict`
+        consequently saw a 4-key dict on the wrapper path
+        (`client.get(name)`) even after PR #451 fixed the PyO3 layer,
+        so every `DistributedTraining.world` / `.ranks` / `.bench`
+        read returned zeros. The wrapper now preserves the full
+        attribute surface the binding exposes.
         """
         self._client = client
         self._name = instance_name
@@ -189,10 +205,29 @@ class Deployment:
         self._updated_at = updated_at
         self._replicas_ready = replicas_ready
         self._replicas_desired = replicas_desired
+        self._image = image
+        self._phase = phase
+        self._message = message
+        self._share_token = share_token
+        self._share_url = share_url
+        self._public_metadata = public_metadata
+        self._distributed = distributed
 
     @property
     def name(self) -> str:
         """The deployment instance name."""
+        return self._name
+
+    @property
+    def instance_name(self) -> str:
+        """
+        The deployment instance name (alias of `name`, matches the PyO3
+        binding's snake_case attribute).
+
+        Issues #453 / #454: `_coerce_to_dict` walks `obj.instance_name`
+        (the binding-side name) so the wrapper must expose it for the
+        camelCase `instanceName` key to survive the round-trip.
+        """
         return self._name
 
     @property
@@ -229,6 +264,59 @@ class Deployment:
         Note: This may be stale. Call status() for the latest state.
         """
         return self._state
+
+    @property
+    def updated_at(self) -> Optional[str]:
+        """Timestamp when the deployment was last updated (ISO 8601)."""
+        return self._updated_at
+
+    @property
+    def image(self) -> str:
+        """Container image reference for this deployment."""
+        return self._image
+
+    @property
+    def phase(self) -> Optional[str]:
+        """Granular deployment phase (scheduling, pulling, ready, etc.)."""
+        return self._phase
+
+    @property
+    def message(self) -> Optional[str]:
+        """Human-readable status / error message, if any."""
+        return self._message
+
+    @property
+    def share_token(self) -> Optional[str]:
+        """Share token for private deployments (only set on creation)."""
+        return self._share_token
+
+    @property
+    def share_url(self) -> Optional[str]:
+        """Shareable URL with token query parameter for private deployments."""
+        return self._share_url
+
+    @property
+    def public_metadata(self) -> bool:
+        """Whether deployment metadata is publicly readable."""
+        return self._public_metadata
+
+    @property
+    def distributed(self) -> Optional[Dict[str, Any]]:
+        """
+        Operator-emitted `status.distributed` block for distributed-training
+        UDs. `None` for single-replica deployments.
+
+        The dict shape is the operator's camelCase wire format
+        (`worldSize`, `ranks`, `bench`, `transport`). Researchers
+        normally consume it via the `DistributedTraining` facade
+        (`client.deploy_distributed(...)`) rather than reading this
+        directly.
+
+        Issues #453 / #454: this attribute was dropped by the
+        `Deployment` wrapper before this fix, even though PR #451
+        landed it on the PyO3 binding.
+        """
+        return self._distributed
 
     def _parse_status_response(self, response) -> DeploymentStatus:
         """Parse API response into DeploymentStatus and update cached state."""
@@ -580,14 +668,7 @@ class Deployment:
         response = await loop.run_in_executor(
             None, self._client.get_deployment, self._name
         )
-
-        self._url = response.url
-        self._state = response.state
-        self._replicas_ready = response.replicas.ready
-        self._replicas_desired = response.replicas.desired
-        if response.updated_at:
-            self._updated_at = response.updated_at
-
+        self._copy_from_response(response)
         return self
 
     async def delete_async(self) -> None:
@@ -660,15 +741,32 @@ class Deployment:
             >>> print(f"Current state: {deployment.state}")
         """
         response = self._client.get_deployment(self._name)
+        self._copy_from_response(response)
+        return self
 
+    def _copy_from_response(self, response) -> None:
+        """Copy mutable fields from a fresh PyO3 response onto this wrapper.
+
+        Shared between `refresh` and `refresh_async` so the two stay in lock
+        step. Keeps `image`, `phase`, `distributed`, etc. fresh -- those
+        fields drove issues #453 / #454 when the wrapper held stale (or
+        missing) copies.
+        """
         self._url = response.url
         self._state = response.state
         self._replicas_ready = response.replicas.ready
         self._replicas_desired = response.replicas.desired
         if response.updated_at:
             self._updated_at = response.updated_at
-
-        return self
+        self._image = getattr(response, "image", self._image) or self._image
+        self._phase = getattr(response, "phase", self._phase)
+        self._message = getattr(response, "message", self._message)
+        self._share_token = getattr(response, "share_token", self._share_token)
+        self._share_url = getattr(response, "share_url", self._share_url)
+        self._public_metadata = bool(
+            getattr(response, "public_metadata", self._public_metadata)
+        )
+        self._distributed = getattr(response, "distributed", self._distributed)
 
     def __repr__(self) -> str:
         return (
@@ -684,6 +782,17 @@ class Deployment:
         Create a Deployment from an API response.
 
         Internal method used by BasilicaClient.
+
+        Issues #453 / #454: this factory previously extracted only a
+        narrow subset of the PyO3 `DeploymentResponse` fields, so
+        downstream code paths -- notably `_coerce_to_dict` driving
+        `DistributedTraining.world` / `.ranks` / `.bench` -- saw the
+        wrapper as missing `image`, `phase`, and `distributed`
+        regardless of what the binding had populated. Every PyO3
+        attribute the user could plausibly want at runtime is now
+        copied onto the wrapper. `getattr` with a default keeps the
+        method robust to older binding builds that have not yet
+        rolled to the post-#451 attribute set.
         """
         return cls(
             client=client,
@@ -696,4 +805,11 @@ class Deployment:
             replicas_ready=response.replicas.ready,
             replicas_desired=response.replicas.desired,
             updated_at=response.updated_at,
+            image=getattr(response, "image", "") or "",
+            phase=getattr(response, "phase", None),
+            message=getattr(response, "message", None),
+            share_token=getattr(response, "share_token", None),
+            share_url=getattr(response, "share_url", None),
+            public_metadata=bool(getattr(response, "public_metadata", False)),
+            distributed=getattr(response, "distributed", None),
         )

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -792,3 +792,214 @@ class TestIssue449DeploymentResponseDistributed:
         assert len(dist["ranks"]) == 2
         assert dist["bench"]["mode"] == "on-start"
         assert dist["bench"]["result"]["busbwGbpsP50"] == 0.00897
+
+
+# =============================================================================
+# Issue #454 / #453 regression tests: the `Deployment` wrapper preserves
+# `distributed` (and other PyO3 fields) end-to-end through `client.get(name)`.
+#
+# PR #451 fixed the PyO3 binding (`DeploymentResponse.distributed` getter)
+# but the lock-down test only covered `_coerce_to_dict(pyo3_response)`,
+# NOT `_coerce_to_dict(client.get(name))`. The high-level Python wrapper
+# `Deployment._from_response(...)` continued to drop `distributed`,
+# `image`, `phase`, `message`, `share_token`, `share_url`,
+# `public_metadata`, so the wrapper-path was still broken on `main` after
+# #451 merged. Issues #453 (elasticity-demo agent) and #454 (this fix)
+# both reported the same wrapper-strip symptom.
+# =============================================================================
+
+
+class TestIssue454DeploymentWrapperCarriesDistributed:
+    """End-to-end: `BasilicaClient(...).get(name)` -> `Deployment` wrapper
+    -> `_coerce_to_dict` -> facade reads. The mock injects at the lowest
+    layer (`_BasilicaClient.get_deployment`) so the assertion exercises
+    the real `Deployment._from_response` factory.
+    """
+
+    def _fake_pyo3_response(self) -> Any:
+        """Mirror of the issue #449 fixture but used through the wrapper path.
+
+        Must use a class with declared attributes (not MagicMock) for the
+        same reason as `TestIssue449...`: `_coerce_to_dict` does an
+        `isinstance(d, dict)` check on `obj.distributed`, which a
+        MagicMock auto-attr would falsely truthy past.
+        """
+
+        class FakeReplicas:
+            ready = 2
+            desired = 2
+
+        class FakeDeployment:
+            instance_name = "dlc-454-mock"
+            user_id = "u-test"
+            namespace = "u-test"
+            image = "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime"
+            state = "running"
+            url = "https://dlc-454-mock.deployments.basilica.ai"
+            created_at = "2026-05-02T10:00:00Z"
+            updated_at = "2026-05-02T10:05:00Z"
+            phase = "Running"
+            message = None
+            share_token = None
+            share_url = None
+            public_metadata = False
+            replicas = FakeReplicas()
+            distributed = {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 3,
+                    "belowMinimum": False,
+                },
+                "ranks": [
+                    {
+                        "rank": 0,
+                        "podName": "dlc-454-mock-0",
+                        "nodeName": "basilica-verda-fin-03",
+                        "provider": "verda",
+                        "region": "FIN-03",
+                        "phase": "Running",
+                        "restarts": 0,
+                    },
+                    {
+                        "rank": 1,
+                        "podName": "dlc-454-mock-1",
+                        "nodeName": "basilica-verda-fin-04",
+                        "provider": "verda",
+                        "region": "FIN-04",
+                        "phase": "Running",
+                        "restarts": 0,
+                    },
+                ],
+                "transport": "hub-relay",
+                "bench": {
+                    "mode": "on-start",
+                    "result": {
+                        "measuredAt": "2026-05-02T10:00:30Z",
+                        "busbwGbpsP50": 0.00897,
+                        "sizeBytesSwept": [1048576, 16777216],
+                        "probeNodeA": "basilica-verda-fin-03",
+                        "probeNodeB": "basilica-verda-fin-04",
+                    },
+                    "lastAttemptOutcome": "success",
+                },
+            }
+
+        return FakeDeployment()
+
+    def _build_client(self) -> BasilicaClient:
+        """Construct a real `BasilicaClient` with a mocked `_BasilicaClient`
+        underneath so the wrapper path (`get` -> `get_deployment` ->
+        `Deployment._from_response`) executes for real.
+        """
+        client = BasilicaClient(
+            base_url="https://api.test.invalid",
+            api_key="fake-test-token",
+        )
+        # Replace the PyO3 inner client with a mock that returns our fixture.
+        # `BasilicaClient.get_deployment` delegates to `self._client.get_deployment`.
+        client._client = MagicMock()
+        client._client.get_deployment.return_value = self._fake_pyo3_response()
+        return client
+
+    def test_wrapper_carries_distributed(self) -> None:
+        """The load-bearing assertion: `client.get(name).distributed` must
+        be the operator's camelCase dict, not None and not stripped.
+        """
+        client = self._build_client()
+        deployment = client.get("dlc-454-mock")
+        assert deployment.distributed is not None, (
+            "Deployment wrapper dropped `distributed` (issue #454). "
+            "PR #451 fixed PyO3; the wrapper was still broken on main."
+        )
+        assert deployment.distributed["worldSize"]["ready"] == 2
+        assert deployment.distributed["worldSize"]["target"] == 2
+        assert deployment.distributed["worldSize"]["min"] == 2
+        assert deployment.distributed["worldSize"]["belowMinimum"] is False
+        assert len(deployment.distributed["ranks"]) == 2
+
+    def test_wrapper_carries_other_previously_dropped_fields(self) -> None:
+        """`image`, `phase`, `message`, `share_token`, `share_url`,
+        `public_metadata` were all dropped by `Deployment._from_response`
+        before this fix. They are part of the PyO3 binding's surface
+        (see `crates/basilica-sdk-python/src/types.rs::DeploymentResponse`)
+        and must reach the user.
+        """
+        client = self._build_client()
+        deployment = client.get("dlc-454-mock")
+        assert deployment.image == "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime"
+        assert deployment.phase == "Running"
+        assert deployment.message is None
+        assert deployment.share_token is None
+        assert deployment.share_url is None
+        assert deployment.public_metadata is False
+        # Pre-existing fields should still survive.
+        assert deployment.name == "dlc-454-mock"
+        assert deployment.namespace == "u-test"
+        assert deployment.user_id == "u-test"
+        assert deployment.state == "running"
+        assert deployment.created_at == "2026-05-02T10:00:00Z"
+        assert deployment.updated_at == "2026-05-02T10:05:00Z"
+
+    def test_NEGATIVE_coerce_to_dict_after_wrapper_carries_distributed(self) -> None:
+        """The test PR #451 should have had.
+
+        PR #451's `test_NEGATIVE_coerce_to_dict_carries_distributed_and_image`
+        passed a raw PyO3 fixture into `_coerce_to_dict` and asserted the
+        keys round-trip. That test did NOT exercise
+        `Deployment._from_response`, so the wrapper-strip bug went
+        undetected and shipped to users.
+
+        This test goes one layer deeper: the input to `_coerce_to_dict`
+        is the `Deployment` wrapper produced by `client.get(name)`. If
+        the wrapper drops a field, this assertion fails.
+        """
+        from basilica.distributed import _coerce_to_dict
+
+        client = self._build_client()
+        deployment = client.get("dlc-454-mock")
+        d = _coerce_to_dict(deployment)
+        for required_key in (
+            "instanceName",
+            "userId",
+            "namespace",
+            "image",
+            "state",
+            "url",
+            "createdAt",
+            "updatedAt",
+            "phase",
+            "distributed",
+        ):
+            assert required_key in d, (
+                f"_coerce_to_dict(client.get(name)) must carry "
+                f"'{required_key}' (issue #454); got keys: {sorted(d.keys())}"
+            )
+        # The distributed block survives the wrapper round-trip.
+        dist = d["distributed"]
+        assert dist["worldSize"]["ready"] == 2
+        assert dist["worldSize"]["belowMinimum"] is False
+        assert len(dist["ranks"]) == 2
+        assert dist["bench"]["mode"] == "on-start"
+
+    def test_distributed_training_facade_reads_via_wrapper(self) -> None:
+        """The user-visible symptom: `DistributedTraining.world` must
+        return real values when driven through `client.get(name)`. This
+        is the path the elasticity-demo agent (#453) exercised before
+        having to subclass `refresh()` to bypass the wrapper.
+        """
+        client = self._build_client()
+        training = DistributedTraining(client, "dlc-454-mock")
+        ws = training.world
+        assert ws.ready == 2, (
+            f"DistributedTraining.world.ready must be 2 (got {ws.ready}); "
+            f"this is the symptom #453 / #454 reported on a healthy UD."
+        )
+        assert ws.target == 2
+        assert ws.min == 2
+        assert ws.max == 3
+        assert ws.below_minimum is False
+        # `wait_until_min_world` must NOT raise BelowMinimumWorld here:
+        # ready=2 >= min=2.
+        training.wait_until_min_world(timeout=1)


### PR DESCRIPTION
## Summary

Closes #454 and #453 (same root cause, different reporters).

PR #451 fixed the PyO3 binding so `DeploymentResponse.distributed` is exposed end-to-end -- but the lock-down test only covered `_coerce_to_dict(pyo3_response)`, not `_coerce_to_dict(client.get(name))`. The high-level Python wrapper `Deployment._from_response(...)` (in `_deployment.py`) continued to extract just **9 of the binding's 16 attributes**, silently dropping `distributed`, `image`, `phase`, `message`, `share_token`, `share_url`, `public_metadata`. Result on `main` (post-#451):

- `client.get(name).distributed` -> `AttributeError`
- `DistributedTraining.refresh()` walked an absent key, observed `ready=0/target=0/min=0/max=0` on a healthy cluster
- `wait_until_min_world(timeout=N)` raised `BelowMinimumWorld(ready=0, required_min=0)` even though the UD was fully Ready
- `client.deploy_distributed(...)` was non-functional on `main` because its internal `wait_until_ready` path always timed out
- The elasticity-demo agent (#453) had to subclass `DistributedTraining.refresh()` and call `client._client.get_deployment(...)` directly to bypass the wrapper -- exactly the workaround a public-SDK user should never have to find

## What changed

**`crates/basilica-sdk-python/python/basilica/_deployment.py`:**
- `Deployment.__init__` and `_from_response` now carry every PyO3 `DeploymentResponse` attribute reachable on the wrapper path: `image`, `phase`, `message`, `share_token`, `share_url`, `public_metadata`, `distributed`. `getattr` with defaults keeps the factory robust against older binding builds.
- New read-only properties: `deployment.distributed`, `.image`, `.phase`, `.message`, `.share_token`, `.share_url`, `.public_metadata`, `.updated_at`, `.instance_name` (the last is an alias of `name` so `_coerce_to_dict` -- which walks `obj.instance_name` for the camelCase `instanceName` key -- sees the wrapper as having the same attribute surface as the binding).
- `refresh` / `refresh_async` refactored onto a shared `_copy_from_response` helper so the new fields stay in sync on every API round-trip.

**`crates/basilica-sdk-python/tests/test_distributed.py`:**
- New `TestIssue454DeploymentWrapperCarriesDistributed` class (4 tests) -- the test PR #451 should have had:
  - `test_wrapper_carries_distributed`: builds a real `BasilicaClient`, mocks `_BasilicaClient.get_deployment` to return a fake PyO3 response, asserts `client.get(name).distributed["worldSize"]["ready"] == 2` and not `None`.
  - `test_wrapper_carries_other_previously_dropped_fields`: asserts `image`, `phase`, `message`, `share_token`, `share_url`, `public_metadata`, plus the pre-existing fields, all survive the wrapper round-trip.
  - `test_NEGATIVE_coerce_to_dict_after_wrapper_carries_distributed`: the negative regression-lock -- `_coerce_to_dict(client.get(name))` must contain `instanceName`, `userId`, `namespace`, `image`, `state`, `url`, `createdAt`, `updatedAt`, `phase`, `distributed`. PR #451's analogue tested `_coerce_to_dict(pyo3_object)`, missing the wrapper layer entirely.
  - `test_distributed_training_facade_reads_via_wrapper`: the user-visible symptom -- `DistributedTraining.world.ready == 2` and `wait_until_min_world(timeout=1)` returns cleanly when driven through `client.get(name)`.

## Regression-catch evidence (load-bearing)

All 4 new tests **fail on `main`** (before the fix), proving they would have caught the bug PR #451 missed:

```
FAILED test_wrapper_carries_distributed
    AttributeError: 'Deployment' object has no attribute 'distributed'

FAILED test_wrapper_carries_other_previously_dropped_fields
    AttributeError: 'Deployment' object has no attribute 'image'

FAILED test_NEGATIVE_coerce_to_dict_after_wrapper_carries_distributed
    AssertionError: _coerce_to_dict(client.get(name)) must carry 'instanceName' (issue #454);
    got keys: ['createdAt', 'namespace', 'state', 'url', 'userId']

FAILED test_distributed_training_facade_reads_via_wrapper
    AssertionError: DistributedTraining.world.ready must be 2 (got 0)
    assert 0 == 2
     +  where 0 = WorldStatus(ready=0, target=0, min=0, max=0, below_minimum=False).ready
```

All 4 tests **pass with the fix**. Full SDK test suite green: 73/73.

## Live verification (load-bearing)

Deployed a 2-rank verda A100 distributed UD via `client.deploy_distributed(...)` on the production cluster:

```
deploy_distributed returned: <basilica.distributed.DistributedTraining object at 0x...>
  type: DistributedTraining
  name: 9ceaa401-af9d-4c75-965e-831f31997ecc
  namespace: u-github-434149

Reading t.world via the wrapper (post-fix):
  ready=2, target=2, min=2, max=2
  below_minimum=False
PASS: world.target/min/max are populated (NOT zeros)

Calling t.wait_until_min_world(timeout=300)...
PASS: wait_until_min_world returned cleanly (ready >= min)
  Final world: ready=2, target=2, min=2

Cleaning up 9ceaa401-af9d-4c75-965e-831f31997ecc...
Deleted
```

`t.world.ready == 2` (not zero), `wait_until_min_world(...)` does NOT raise `BelowMinimumWorld` -- exactly inverting the symptom #453 / #454 reported.

## What is NOT in this PR

- **No PyO3 changes.** The binding (`crates/basilica-sdk-python/src/lib.rs`, `src/types.rs`) is correct after PR #451; this PR only touches the Python wrapper `_deployment.py` and tests.
- **No `command=` shlex fix.** That is issue #452, being fixed in parallel by a separate agent against `__init__.py`.
- **No API gateway fix.** That is issue #455, in basilica-private (the backend repo).
- **No release.** No version bump, no PyPI publish, no tag. This PR is the fix + lock-down test only.

## Test plan

- [x] `pytest crates/basilica-sdk-python/tests/test_distributed.py -v` -- 41/41 passing
- [x] `pytest crates/basilica-sdk-python/tests/ -v --ignore=tests/test_dns_propagation_e2e.py` -- 73/73 passing
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p basilica-sdk-python --tests -- -D warnings` clean
- [x] `python -c "from basilica import BasilicaClient; print('imports OK')"` clean
- [x] Live: 2-rank verda A100 distributed UD, `t.world.ready == 2`, `wait_until_min_world(timeout=300)` returned cleanly
- [x] All 4 new tests verified to FAIL on `main` (regression-catch confirmed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployment class now exposes additional fields: `image`, `phase`, `message`, `share_token`, `share_url`, `public_metadata`, and `distributed`.
  * Added `instance_name` property as an alias for deployment name.
  * Added `updated_at` property to track deployment status.

* **Bug Fixes**
  * Fixed preservation of distributed training payload and related fields in Deployment wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->