### PR TITLE
fix(sdk): preserve $VAR expansion in deploy_distributed(command=...) (closes #452)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -187,6 +187,56 @@ DEFAULT_COMMAND = ["/bin/bash"]
 # Default Python image for source deployments
 DEFAULT_PYTHON_IMAGE = "python:3.11-slim"
 
+# Shell-safe alphabet for distributed-mode `command=` joining (issue #452).
+# Mirrors `shlex._find_unsafe`'s safe set `[\w@%+=:,./-]` PLUS `$`, so tokens
+# like `--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT` survive verbatim and get
+# the shell expansion the user intends when the operator wraps the whole
+# string in `["/bin/sh", "-c", ...]`. Tokens containing whitespace, quotes,
+# semicolons, backticks, parens, etc. still go through `shlex.quote`.
+_SHELL_DOLLAR_SAFE_RE = re.compile(r"^[\w@%+=:,./\-$]+$", re.ASCII)
+
+# Recognised shell-script wrapper shapes for `deploy_distributed(command=...)`.
+# When `command` matches `[<one-of-these>, "-c", <script>]`, the script is
+# emitted verbatim instead of being shlex-joined -- see issue #452.
+_SHELL_SCRIPT_LAUNCHERS = frozenset({"bash", "sh", "/bin/bash", "/bin/sh"})
+
+
+def _shell_join_preserving_vars(command: List[str]) -> str:
+    """
+    Join an argv list into a single shell command string for the operator's
+    `["/bin/sh", "-c", <cmd>]` wrapper, preserving `$VAR` expansion.
+
+    Issue #452: `shlex.join` single-quotes any token containing `$`,
+    so `["torchrun", "--nnodes=$BASILICA_WORLD_TARGET"]` became
+    `torchrun '--nnodes=$BASILICA_WORLD_TARGET'`, the operator handed
+    that to `sh -c`, and the user's training code received the literal
+    string `$BASILICA_WORLD_TARGET` (then crashed on `int(...)`).
+
+    Behaviour:
+    - `["bash"|"sh"|"/bin/bash"|"/bin/sh", "-c", <script>]` -> verbatim
+      `<script>`. This is the canonical "I am a shell script" shape.
+    - argv list -> per-token: verbatim if it matches the shell-safe
+      alphabet plus `$` (so `$VAR` survives); otherwise `shlex.quote`
+      (preserves argv structure for whitespace / metachars at the cost
+      of expansion -- a genuinely ambiguous case we err on the safe side).
+    """
+    import shlex as _shlex
+
+    if (
+        len(command) == 3
+        and command[0] in _SHELL_SCRIPT_LAUNCHERS
+        and command[1] == "-c"
+    ):
+        return command[2]
+
+    parts: List[str] = []
+    for token in command:
+        if token and _SHELL_DOLLAR_SAFE_RE.match(token):
+            parts.append(token)
+        else:
+            parts.append(_shlex.quote(token))
+    return " ".join(parts)
+
 
 def _build_inference_health_check(port: int) -> HealthCheckConfig:
     """Build default health check config for inference servers (vLLM, SGLang).
@@ -1192,8 +1242,23 @@ class BasilicaClient:
         #   5b ships source via this BYO heredoc-free path; Phase 6 may
         #   move source-shipping into the operator via init container.
         #
-        # - `command` set -> shlex-join (NOT plain " ".join, which would
-        #   break embedded whitespace / quotes). Operator passes verbatim.
+        # - `command` set -> shell-safe join that preserves `$VAR`
+        #   expansion. The operator passes `distributed.command` to
+        #   `["/bin/sh", "-c", <cmd>]` (operator distributed.rs
+        #   build_worker_command), so user-supplied `$BASILICA_*` tokens
+        #   in `command` are intended to expand at sh-eval time. Plain
+        #   `shlex.join` single-quotes any token containing `$`, which
+        #   defeats expansion -- see issue #452 (literal
+        #   `'$BASILICA_WORLD_TARGET'` reached `int(...)` and crashed).
+        #   Two shapes are recognised here:
+        #   1. `["bash"|"sh"|"/bin/bash"|"/bin/sh", "-c", <script>]`
+        #      -> emit <script> verbatim (canonical "I am a shell script")
+        #   2. argv list -> per-token: leave verbatim if shlex-safe over
+        #      the alphabet `[\w@%+=:,./-]` plus `$` (i.e. only `$VAR`
+        #      makes it "unsafe" in plain shlex); otherwise shlex.quote.
+        #      A token mixing `$` with whitespace/metachars is genuinely
+        #      ambiguous -- we choose safety (quote, lose expansion) so
+        #      argv structure is preserved.
         #
         # - neither -> ValidationError. The operator's distributed-mode
         #   renderer has no "use image ENTRYPOINT, just pass args" mode;
@@ -1233,8 +1298,7 @@ class BasilicaClient:
                 f"/tmp/__basilica_source.py"
             )
         elif command is not None:
-            import shlex as _shlex
-            distributed_command = _shlex.join(command)
+            distributed_command = _shell_join_preserving_vars(command)
         else:
             raise ValidationError(
                 "deploy_distributed requires either source= (Phase 5b "

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -518,6 +518,132 @@ class TestBuildDistributedRequest:
             )
         assert exc_info.value.field == "bench"
 
+    # -------------------------------------------------------------------------
+    # Issue #452: $VAR expansion in `command=` must survive the `sh -c` wrap.
+    #
+    # The operator wraps `distributed.command` in `["/bin/sh", "-c", <cmd>]`
+    # (operator distributed.rs build_worker_command). The pre-fix
+    # implementation used plain `shlex.join`, which single-quotes any token
+    # containing `$`, killing shell expansion. Live failure on UD f01dd43a
+    # (2026-05-02 smoke): `int('$BASILICA_WORLD_TARGET')` raised ValueError.
+    # -------------------------------------------------------------------------
+
+    def _build_with_command(
+        self, client: BasilicaClient, command: list
+    ) -> Dict[str, Any]:
+        return client._build_distributed_request(
+            name="dlc-452",
+            source=None,
+            image="my-image",
+            port=18789,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=1, target=1, max=1),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="off",
+            rendezvous_backend="etcd-v2",
+            command=command,
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+        )
+
+    def test_command_bash_dash_c_emits_script_verbatim(self) -> None:
+        # Canonical "I am a shell script" shape: the script string lands
+        # on `distributed.command` byte-for-byte, no surrounding quotes,
+        # no escape of `$`. Issue #452.
+        client = self._client()
+        script = "echo $BASILICA_WORLD_TARGET"
+        req = self._build_with_command(client, ["bash", "-c", script])
+        assert req["distributed"]["command"] == script
+        # Belt-and-braces: no single-quotes wrapping the env-var ref.
+        assert "'$BASILICA_WORLD_TARGET'" not in req["distributed"]["command"]
+
+    def test_command_sh_dash_c_also_recognised(self) -> None:
+        # All four launcher spellings are recognised; the wrapper layer
+        # is what matters, not which busybox/bash flavour the user typed.
+        client = self._client()
+        for launcher in ("sh", "bash", "/bin/sh", "/bin/bash"):
+            req = self._build_with_command(
+                client, [launcher, "-c", "true && echo $X"]
+            )
+            assert req["distributed"]["command"] == "true && echo $X", launcher
+
+    def test_command_torchrun_argv_preserves_dollar_vars(self) -> None:
+        # Real shape from examples/21_distributed_torchrun.py: a flat argv
+        # list containing `$BASILICA_*` tokens. Pre-fix `shlex.join` wrote
+        # `'--nnodes=$BASILICA_WORLD_TARGET'` (single-quoted), the operator
+        # passed THAT to `sh -c`, the literal string reached the user's
+        # `int(...)`, ValueError. Post-fix: tokens stay verbatim.
+        client = self._client()
+        req = self._build_with_command(
+            client,
+            [
+                "torchrun",
+                "--rdzv-backend=etcd-v2",
+                "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+                "--rdzv-id=$BASILICA_RDZV_ID",
+                "--nnodes=$BASILICA_WORLD_TARGET",
+                "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+                "--max-restarts=10",
+                "/workspace/all_reduce_smoke.py",
+            ],
+        )
+        cmd = req["distributed"]["command"]
+        # Positive: every $VAR ref appears unquoted.
+        for var in (
+            "$BASILICA_RDZV_ENDPOINT",
+            "$BASILICA_RDZV_ID",
+            "$BASILICA_WORLD_TARGET",
+            "$BASILICA_GPUS_PER_POD",
+        ):
+            assert var in cmd, f"missing {var} in {cmd!r}"
+        # Negative regression guard: the OLD `shlex.join` wrapped any
+        # token containing `$` in single quotes (e.g.
+        # `'--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT'`). Locks the #452
+        # fix in place -- if a future refactor restores `shlex.join`,
+        # these substrings would re-appear and the test would fail.
+        assert "'--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT'" not in cmd, (
+            f"regression: `shlex.join` quoting of $VAR token returned. "
+            f"command: {cmd!r}"
+        )
+        assert "'--nnodes=$BASILICA_WORLD_TARGET'" not in cmd, (
+            f"regression: `shlex.join` quoting of $VAR token returned. "
+            f"command: {cmd!r}"
+        )
+        # Structure preserved.
+        assert cmd.startswith("torchrun ")
+        assert cmd.endswith(" /workspace/all_reduce_smoke.py")
+
+    def test_command_with_whitespace_token_falls_back_to_quote(self) -> None:
+        # Safety: a token with embedded whitespace MUST be quoted, otherwise
+        # sh would split it into multiple argv elements. The fallback path
+        # uses `shlex.quote` to preserve argv shape.
+        client = self._client()
+        req = self._build_with_command(
+            client, ["my-binary", "--flag", "value with spaces"]
+        )
+        cmd = req["distributed"]["command"]
+        # Quoted somehow (single-quote is shlex.quote's choice).
+        assert "'value with spaces'" in cmd
+        # Bare tokens stay bare.
+        assert cmd.startswith("my-binary --flag ")
+
+    def test_command_simple_invocation_no_quoting_overhead(self) -> None:
+        # `command=["my-binary"]` produces just `my-binary` -- no quoting
+        # added, no list-bracket leakage. Smoke that the trivial case
+        # works after the helper refactor.
+        client = self._client()
+        req = self._build_with_command(client, ["my-binary"])
+        assert req["distributed"]["command"] == "my-binary"
+
 
 # =============================================================================
 # Decorator (SDK arch § 5).


### PR DESCRIPTION
## Summary

`deploy_distributed(command=[...])` ran the argv list through `shlex.join`, which single-quotes any token containing `$`. The operator wraps `distributed.command` in `["/bin/sh", "-c", <cmd>]` (operator `distributed.rs` `build_worker_command`, line 1692), so user-supplied `$BASILICA_*` tokens were intended to expand at sh-eval time. With `shlex.join`'s quoting, the literal string `$BASILICA_WORLD_TARGET` reached the user's training code and crashed:

```
ValueError: invalid literal for int() with base 10: '$BASILICA_WORLD_TARGET'
```

(Live evidence on UD `f01dd43a` from today's smoke; same shape on examples 21 and 22.)

## Bug location

- `crates/basilica-sdk-python/python/basilica/__init__.py` line 1237 (pre-fix): `distributed_command = _shlex.join(command)` -- this is the source of the breakage.
- `crates/basilica-operator/src/controllers/distributed.rs` `build_worker_command` (lines 1636-1695, basilica-private repo): the operator unconditionally wraps `dist.command` in `["/bin/sh", "-c", ...]`, confirming sh evaluation is the contract on the wire.

## Fix

`crates/basilica-sdk-python/python/basilica/__init__.py`: introduce `_shell_join_preserving_vars(command)` and call it in the `elif command is not None:` branch of `_build_distributed_request`. The helper recognises two shapes:

1. `["bash" | "sh" | "/bin/bash" | "/bin/sh", "-c", <script>]` -> emit `<script>` verbatim. Canonical "I am a shell script" shape.
2. argv list -> per-token: leave verbatim if shlex-safe over the alphabet `[\w@%+=:,./-]` plus `$` (so `$VAR` survives); otherwise `shlex.quote`. Tokens mixing `$` with whitespace/metachars stay quoted -- argv structure trumps expansion when ambiguous.

The fallback path preserves whitespace safety (`shlex.quote`) for tokens like `"value with spaces"`.

## Tests

`crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest`:

- `test_command_bash_dash_c_emits_script_verbatim` -- positive: `["bash", "-c", "echo $X"]` -> `"echo $X"` byte-for-byte.
- `test_command_sh_dash_c_also_recognised` -- all four launcher spellings (`sh`, `bash`, `/bin/sh`, `/bin/bash`).
- `test_command_torchrun_argv_preserves_dollar_vars` -- positive + regression. Real example-21 argv (8 tokens, 4 with `$BASILICA_*`); asserts every `$VAR` ref appears unquoted; explicitly asserts the OLD `shlex.join` substrings (e.g. `'--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT'`) do NOT appear -- this is the load-bearing regression guard.
- `test_command_with_whitespace_token_falls_back_to_quote` -- safety: `["my-binary", "--flag", "value with spaces"]` still goes through `shlex.quote`.
- `test_command_simple_invocation_no_quoting_overhead` -- trivial `["my-binary"]` invocation unchanged.

Pytest output:

```
crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest::test_command_bash_dash_c_emits_script_verbatim PASSED
crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest::test_command_sh_dash_c_also_recognised PASSED
crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest::test_command_torchrun_argv_preserves_dollar_vars PASSED
crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest::test_command_with_whitespace_token_falls_back_to_quote PASSED
crates/basilica-sdk-python/tests/test_distributed.py::TestBuildDistributedRequest::test_command_simple_invocation_no_quoting_overhead PASSED
============================== 42 passed in 0.36s ==============================
```

`cargo fmt --all -- --check` clean. `cargo clippy --workspace --tests -- -D warnings` clean.

## Live verification

Ran `examples/21_distributed_torchrun.py` UNMODIFIED with `BASILICA_API_TOKEN` set against prod. The example currently aborts mid-flow due to a separate `wait_until_min_world` facade race (issue #454, separate PR), but the CR is correctly created server-side. Captured the wire shape directly off the cluster:

```
$ kubectl get userdeployment -n u-github-434149 \
    ud-015de399-5be6-4429-a46d-6e7a0ccfec94-deployment \
    -o jsonpath='{.spec.distributed.command}'

torchrun --rdzv-backend=etcd-v2 --rdzv-endpoint=$BASILICA_RDZV_ENDPOINT \
  --rdzv-id=$BASILICA_RDZV_ID --nnodes=$BASILICA_WORLD_TARGET \
  --nproc-per-node=$BASILICA_GPUS_PER_POD --max-restarts=10 \
  /workspace/all_reduce_smoke.py
```

Every `$BASILICA_*` reference is **unquoted** on the CR. Pre-fix it would have been e.g. `'--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT'` (single-quoted), proven by the `shlex.join` regression test.

Worker pod logs from rank-0 (during the first successful run window before a separate etcd flake hit on restart):

```
[rank 0/2] init OK provider=? region=? gpu_model=?
NCCL version 2.22.3+cuda12.6
[rank 0] size=   1048576 time=0.4896s algbw=    2.14MB/s busbw=    2.14MB/s
[rank 0] size=   4194304 time=0.3335s algbw=   12.58MB/s busbw=   12.58MB/s
[rank 0] size=  16777216 time=1.5214s algbw=   11.03MB/s busbw=   11.03MB/s
[rank 0] size=  67108864 time=6.6431s algbw=   10.10MB/s busbw=   10.10MB/s
```

Pre-fix this would not happen -- the literal `$BASILICA_WORLD_TARGET` would have crashed `all_reduce_smoke.py` at `int(...)` long before NCCL init. Post-fix: rendezvous succeeded, NCCL world joined, real bytes moved across all_reduce.

Test deployments cleaned up via `client.delete_deployment`.

Full transcript: `/tmp/example21_post_452_transcript.txt` (locally captured).

## What is NOT in this PR

- No operator changes. The operator's `["/bin/sh", "-c", <cmd>]` wrapping is correct and intended.
- No API changes.
- No #454 facade fix (separate agent, `_deployment.py` + facade refresh race).
- No #455 gateway fix (separate agent, basilica-private/basilica-api).
- No version bump, no PyPI publish, no tag.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `pytest crates/basilica-sdk-python/tests/test_distributed.py -v` -- 42 passed
- [x] Live verification: CR persisted with unquoted `$VAR` against prod
- [x] Live verification: rank-0 pod reached `[rank 0/2] init OK` and NCCL all_reduce