### PR TITLE
feat(sdk): add bench placement knob (preferred default, strict opt-in)

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/train.rs
+++ b/crates/basilica-cli/src/cli/handlers/train.rs
@@ -160,7 +160,10 @@ async fn handle_up(
         },
         topology_spread: DistributedTopologySpread { strategy: topology },
         nccl: DistributedNcclSpec { env: nccl_env_map },
-        bench: Some(DistributedBenchSpec { mode: bench_mode }),
+        bench: Some(DistributedBenchSpec {
+            mode: bench_mode,
+            placement: None,
+        }),
         command: "auto".to_string(),
     };
 

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -1105,6 +1105,7 @@ class BasilicaClient:
         topology_spread: str = "provider-aware",
         nccl_env: Optional[Dict[str, str]] = None,
         bench: str = "off",
+        bench_placement: str = "preferred",
         rendezvous_backend: str = "etcd-v2",
         command: Optional[List[str]] = None,
         args: Optional[List[str]] = None,
@@ -1146,6 +1147,19 @@ class BasilicaClient:
                 user's namespace alongside workers (counts against the
                 namespace rank budget; result lands on `training.bench`).
                 `"off"` (default) skips the probe. SDK arch § 7.
+            bench_placement: Placement policy for the bench Pod pair on
+                multi-tenant clusters. `"preferred"` (default) lets the
+                bench fall back off the worker pair when those nodes have
+                no spare GPU — bench always schedules but may measure a
+                different pair than the workers. `"strict"` keeps the
+                bench pinned to the worker pair's nodes — bench measures
+                the worker pair's link or stays Pending; never silently
+                mismeasures. Architecture doc § 11.1: silently-wrong
+                outranks no-number, so `strict` is the architecturally
+                honest mode for research papers / SLA evidence on multi-
+                GPU/node hardware. Default is `"preferred"` for
+                runnability on the current single-GPU/node fleet.
+                Ignored when `bench == "off"`.
             rendezvous_backend: One of `etcd-v2 | c10d | static`. Default
                 `etcd-v2` (the only backend with full elasticity).
             command: BYO-launcher escape hatch. When set, the operator does
@@ -1186,6 +1200,7 @@ class BasilicaClient:
             topology_spread=topology_spread,
             nccl_env=nccl_env,
             bench=bench,
+            bench_placement=bench_placement,
             rendezvous_backend=rendezvous_backend,
             command=command,
             args=args,
@@ -1231,6 +1246,7 @@ class BasilicaClient:
         pip_packages: Optional[List[str]],
         ttl_seconds: Optional[int],
         enable_billing: bool,
+        bench_placement: str = "preferred",
     ) -> Dict[str, Any]:
         """
         Build the camelCase JSON dict that PyO3's
@@ -1355,7 +1371,21 @@ class BasilicaClient:
             "nccl": {"env": dict(nccl_env) if nccl_env else {}},
         }
         if bench in ("on-start", "off"):
-            distributed["bench"] = {"mode": bench}
+            bench_dict: Dict[str, Any] = {"mode": bench}
+            # Architecture doc § 11.1 placement knob. Only emit the
+            # field when the user opts into a non-default; `None` on the
+            # wire is interpreted as Preferred operator-side, so
+            # omitting `placement` keeps backwards-compat with operators
+            # that don't yet know about the field.
+            if bench_placement not in ("preferred", "strict"):
+                raise ValidationError(
+                    f"bench_placement must be 'preferred' or 'strict', got {bench_placement!r}",
+                    field="bench_placement",
+                    value=bench_placement,
+                )
+            if bench == "on-start" and bench_placement == "strict":
+                bench_dict["placement"] = "strict"
+            distributed["bench"] = bench_dict
         else:
             raise ValidationError(
                 f"bench must be 'on-start' or 'off', got {bench!r}",
@@ -2098,6 +2128,7 @@ class BasilicaClient:
         topology_spread: str = "provider-aware",
         nccl_env: Optional[Dict[str, str]] = None,
         bench: str = "off",
+        bench_placement: str = "preferred",
         rendezvous_backend: str = "etcd-v2",
         command: Optional[List[str]] = None,
         args: Optional[List[str]] = None,
@@ -2130,6 +2161,7 @@ class BasilicaClient:
             topology_spread=topology_spread,
             nccl_env=nccl_env,
             bench=bench,
+            bench_placement=bench_placement,
             rendezvous_backend=rendezvous_backend,
             command=command,
             args=args,

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -488,6 +488,115 @@ class TestBuildDistributedRequest:
             f"See issue #448. command: {d_cmd!r}"
         )
 
+    def test_bench_placement_default_omits_field(self) -> None:
+        # Architecture doc § 11.1 placement knob: default `preferred`
+        # MUST NOT appear on the wire. The operator's serde default is
+        # also `Preferred`, so omitting the field keeps wire-compat with
+        # operators that don't yet know about the field. Locks the
+        # `bench_placement="preferred"` -> no `placement` key contract.
+        client = self._client()
+        req = client._build_distributed_request(
+            name="dlc-pref",
+            source=None,
+            image="x",
+            port=80,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=2, target=2, max=2),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="on-start",
+            rendezvous_backend="etcd-v2",
+            command=["python", "x.py"],
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+            # explicit default — same as omitting the kwarg.
+            bench_placement="preferred",
+        )
+        bench_dict = req["distributed"]["bench"]
+        assert bench_dict["mode"] == "on-start"
+        assert "placement" not in bench_dict, (
+            "default bench_placement='preferred' must NOT emit the field "
+            f"on the wire (keeps wire-compat with operators that don't "
+            f"know the placement enum yet); got: {bench_dict!r}"
+        )
+
+    def test_bench_placement_strict_emits_lowercase_token(self) -> None:
+        # Architecture doc § 11.1 placement knob: opt-in `strict` lands
+        # on the wire as `placement: "strict"` (lowercase, matches the
+        # operator's serde rename).
+        client = self._client()
+        req = client._build_distributed_request(
+            name="dlc-strict",
+            source=None,
+            image="x",
+            port=80,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=2, target=2, max=2),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="on-start",
+            rendezvous_backend="etcd-v2",
+            command=["python", "x.py"],
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+            bench_placement="strict",
+        )
+        bench_dict = req["distributed"]["bench"]
+        assert bench_dict["mode"] == "on-start"
+        assert bench_dict["placement"] == "strict", (
+            f"bench_placement='strict' must emit lowercase 'strict' on "
+            f"the wire; got: {bench_dict!r}"
+        )
+
+    def test_invalid_bench_placement_rejected(self) -> None:
+        # Negative: only "preferred" / "strict" are accepted. Anything
+        # else raises ValidationError before the request leaves the SDK.
+        from basilica.exceptions import ValidationError
+
+        client = self._client()
+        with pytest.raises(ValidationError) as exc_info:
+            client._build_distributed_request(
+                name="dlc-bad",
+                source=None,
+                image="x",
+                port=80,
+                env=None,
+                cpu="1",
+                memory="1Gi",
+                gpu_count=1,
+                gpu_models=None,
+                min_gpu_memory_gb=None,
+                world_size=WorldSize(min=1, target=1, max=1),
+                provider_filter=None,
+                topology_spread="provider-aware",
+                nccl_env=None,
+                bench="on-start",
+                rendezvous_backend="etcd-v2",
+                command=["python", "x.py"],
+                args=None,
+                pip_packages=None,
+                ttl_seconds=None,
+                enable_billing=True,
+                bench_placement="invalid-placement",
+            )
+        assert exc_info.value.field == "bench_placement"
+
     def test_invalid_bench_mode_rejected(self) -> None:
         from basilica.exceptions import ValidationError
 

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1258,11 +1258,36 @@ pub enum DistributedBenchMode {
     OnStart,
 }
 
+/// Architecture doc § 11.1 placement knob: bench Pod node-placement mode.
+///
+/// - `Preferred` (default): the bench Pod prefers the worker pair's
+///   nodes but falls back to any worker-eligible GPU node when the pair
+///   has no spare GPU. Bench always schedules; the resulting BenchResult
+///   may not measure the worker pair's link if it falls back.
+/// - `Strict`: bench measures the worker pair's link or stays Pending —
+///   never silently mismeasures. Architecturally correct for honest
+///   measurement on multi-GPU/node hardware.
+///
+/// Default is `Preferred` (operator-side default; `None` on the wire is
+/// treated identically). Wire token is lowercase: `"preferred"` |
+/// `"strict"`, matching the operator's serde rename.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DistributedBenchPlacement {
+    #[default]
+    Preferred,
+    Strict,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DistributedBenchSpec {
     #[serde(default)]
     pub mode: DistributedBenchMode,
+    /// Optional placement override. `None` is treated as `Preferred`
+    /// operator-side. Field omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<DistributedBenchPlacement>,
 }
 
 /// World-size triple: `min ≤ target ≤ max`. The operator clamps the worker
@@ -2390,6 +2415,7 @@ mod tests {
             },
             bench: Some(DistributedBenchSpec {
                 mode: DistributedBenchMode::OnStart,
+                placement: None,
             }),
             command: "auto".to_string(),
         }
@@ -2459,6 +2485,60 @@ mod tests {
             serde_json::to_string(&DistributedBenchMode::OnStart).unwrap(),
             "\"on-start\""
         );
+    }
+
+    #[test]
+    fn test_distributed_bench_placement_lowercase_tokens() {
+        // Architecture doc § 11.1: wire tokens are lowercase, matching
+        // the operator's `BenchPlacement` serde rename. Round-trip via
+        // BenchSpec to lock the field name (`"placement"`) too.
+        assert_eq!(
+            serde_json::to_string(&DistributedBenchPlacement::Preferred).unwrap(),
+            "\"preferred\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DistributedBenchPlacement::Strict).unwrap(),
+            "\"strict\""
+        );
+
+        let spec = DistributedBenchSpec {
+            mode: DistributedBenchMode::OnStart,
+            placement: Some(DistributedBenchPlacement::Strict),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(
+            json.contains("\"placement\":\"strict\""),
+            "BenchSpec JSON must contain placement=strict, got: {json}"
+        );
+        assert!(
+            json.contains("\"mode\":\"on-start\""),
+            "BenchSpec JSON must keep mode=on-start, got: {json}"
+        );
+        // Round-trip back.
+        let back: DistributedBenchSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, spec);
+    }
+
+    #[test]
+    fn test_distributed_bench_spec_placement_omitted_when_none() {
+        // Architecture doc § 11.1 wire-compat: pre-placement SDKs emit
+        // BenchSpec without the field. Locks `skip_serializing_if =
+        // Option::is_none` so a wire upgrade does not break older
+        // operators (`None` is interpreted as Preferred operator-side).
+        let spec = DistributedBenchSpec {
+            mode: DistributedBenchMode::OnStart,
+            placement: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&spec).unwrap();
+        assert_eq!(v["mode"], "on-start");
+        assert!(
+            v.get("placement").is_none(),
+            "placement omitted when None, got: {v}"
+        );
+        // And accepts an incoming JSON that lacks the field.
+        let parsed: DistributedBenchSpec = serde_json::from_str(r#"{"mode":"on-start"}"#).unwrap();
+        assert_eq!(parsed.mode, DistributedBenchMode::OnStart);
+        assert!(parsed.placement.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mirrors the operator-side `BenchPlacement` enum on the SDK wire types so users can opt into strict bench-Pod pinning when honest measurement matters more than runnability.

This is the SDK companion to **basilica-backend PR #444** (operator-side CRD field + render branching). The two PRs are interdependent and should ship together; the operator wins forward-compat (it always accepts the field; older SDKs that don't emit it default to `Preferred` operator-side).

## What changed

**Rust SDK (`basilica-sdk`):**
- New `DistributedBenchPlacement { Preferred, Strict }` enum (lowercase serde, matches operator's `BenchPlacement`).
- `DistributedBenchSpec.placement: Option<DistributedBenchPlacement>` with `skip_serializing_if = Option::is_none` so the field is omitted on the wire when unset (forward-compat with pre-placement operators).
- 2 round-trip serde tests lock the lowercase token + None-elision contract.

**Python SDK (`basilica-sdk-python`):**
- `deploy_distributed(...)` and `deploy_distributed_async(...)` gain `bench_placement: str = "preferred"`.
- Default emits no `placement` key on the wire; only `"strict"` opts into the new field.
- Docstring documents the silently-wrong > no-number trade-off.
- 3 pytest cases cover default-omits-field, strict-emits-token, invalid-placement-rejected.

**CLI (`basilica-cli`):**
- `distributed-train` handler updated to construct the new `BenchSpec` shape (`placement: None`, semantics unchanged).

## Architecture rationale

The architecturally honest measurement requires the bench Pod pair to land on the exact nodes the worker StatefulSet runs on (issue #441). On hardware with multiple GPUs per node, that pin is unambiguously correct. On the current production cluster (1 GPU per node fleet-wide), the strict pin produces `Pending` Pods because the workers occupy the only GPU per node.

`silently-wrong > no-number` is FALSE; therefore strict is the architecture-correct mode for honest measurement. `Preferred` is a deliberate usability concession to the current single-GPU-per-node fleet — it lets the bench fall back off the worker pair so the example stays runnable. Users who need a truthful number on multi-GPU/node hardware (research papers, SLA evidence, capacity planning) opt into `strict` explicitly.

## What is NOT in this PR

- No version bump (lands as part of the in-flight 0.29.x SDK release).
- No changes to the read-side bench surface (`DistributedTraining.bench`, `BenchResult`).
- No changes to admission/quota logic — placement is purely a render-time knob.

## Test plan

- [x] `cargo test -p basilica-sdk --lib` (79 passed, includes 2 new placement tests)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `pytest tests/test_distributed.py` (49 passed, includes 3 new placement tests)
- [ ] End-to-end live verification on the cluster — covered in the operator-side PR #444 transcripts.

## Linked PR

- basilica-backend #444 — operator CRD field + render branching (must merge together).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bench_placement` parameter to distributed deployment methods, enabling users to configure benchmark placement strategy
  * Supports two placement modes: "preferred" (default) and "strict" for control over benchmark resource allocation
  * Parameter is optional and maintains backward compatibility with existing deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->