### PR TITLE
feat(sdk): expose UD phase + wait_until_complete + UDTerminalState (refs #445)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -153,6 +153,7 @@ from .distributed import (
     DistributedMetrics,
     DistributedTraining,
     ProviderFilter,
+    RankExit,
     RankStatus,
     WorldSize,
     WorldStatus,
@@ -174,6 +175,7 @@ from .exceptions import (
     ResourceError,
     SourceError,
     StorageError,
+    UDTerminalState,
     ValidationError,
     WorldSizeOutOfBounds,
 )

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -29,8 +29,15 @@ from typing import (
 
 from .exceptions import (
     BelowMinimumWorld,
+    UDTerminalState,
     WorldSizeOutOfBounds,
 )
+
+# Phase 5b (#445): operator phases that pin the UD as terminal. See the
+# operator's `DeploymentPhase::is_terminal` for the source of truth. The
+# Python side reads `status.phase` as a snake_case string straight from
+# the JSON the API returns, so the comparison is string-based.
+TERMINAL_PHASES: frozenset = frozenset({"succeeded", "failed", "cancelled"})
 
 if TYPE_CHECKING:
     from . import BasilicaClient
@@ -128,6 +135,28 @@ class RankStatus:
     region: Optional[str]
     phase: str
     restarts: int
+
+
+@dataclass(frozen=True)
+class RankExit:
+    """
+    Phase 5b (#445) per-rank exit diagnostics.
+
+    Populated by the operator on `status.distributed.rankExits` when the
+    UD reaches a terminal state (or on the deferred reconcile that fires
+    when workers complete before bench is terminal). Empty while the UD
+    is non-terminal -- the SDK distinguishes "in flight" from "finished"
+    by absence-vs-presence of `rank_exits`.
+
+    Mirrors the K8s container `terminated` block so consumers can read
+    per-rank exit codes after the operator has scaled the worker
+    StatefulSet to `replicas: 0` and the pods are no longer queryable.
+    """
+
+    rank: int
+    exit_code: int
+    termination_reason: Optional[str]
+    restart_count: int
 
 
 @dataclass(frozen=True)
@@ -274,6 +303,62 @@ class DistributedTraining:
         ]
 
     @property
+    def phase(self) -> str:
+        """
+        Phase 5b (#445): operator-driven lifecycle phase.
+
+        One of `pending` | `scheduling` | `pulling` | `initializing` |
+        `storage_sync` | `starting` | `health_check` | `ready` |
+        `degraded` | `failed` | `suspended` | `terminating` |
+        `succeeded` | `cancelled`. The terminal triple
+        (`succeeded`, `failed`, `cancelled`) is sticky — once set the
+        operator does not regress to a non-terminal phase.
+
+        Empty string when the operator has not yet written a status
+        block (just-created UD before the first reconcile).
+        """
+        if self._cached_status is None:
+            self.refresh()
+        # `phase` is a top-level field on DeploymentResponse (snake_case
+        # on the PyO3 binding -> camelCase'd by `_coerce_to_dict`).
+        phase = (self._cached_status or {}).get("phase")
+        if phase is None:
+            return ""
+        return str(phase)
+
+    @property
+    def is_terminal(self) -> bool:
+        """
+        Phase 5b (#445): convenience for callers that just want to know
+        "is this UD done?" — `phase in {succeeded, failed, cancelled}`.
+        """
+        return self.phase in TERMINAL_PHASES
+
+    @property
+    def rank_exits(self) -> List[RankExit]:
+        """
+        Phase 5b (#445): per-rank exit diagnostics, populated when the
+        UD reaches a terminal state (or on the deferred reconcile when
+        workers complete before bench finishes). Empty while the UD is
+        running; absence vs. presence is the SDK's signal for
+        "training in flight" vs. "training finished".
+        """
+        if self._cached_status is None:
+            self.refresh()
+        exits_raw = (
+            (self._cached_status or {}).get("distributed", {}).get("rankExits") or []
+        )
+        return [
+            RankExit(
+                rank=int(e.get("rank", 0)),
+                exit_code=int(e.get("exitCode", 0)),
+                termination_reason=e.get("terminationReason"),
+                restart_count=int(e.get("restartCount", 0)),
+            )
+            for e in exits_raw
+        ]
+
+    @property
     def bench(self) -> Optional[BenchResult]:
         """
         Per-UD bench probe result, or `None` if `bench.mode != on-start`
@@ -367,6 +452,20 @@ class DistributedTraining:
         # min/max only at create-time, but a stale cache from before
         # creation would show min=max=0).
         self.refresh()
+        # Phase 5b (#445): refuse to scale a UD that has already reached
+        # a terminal state. The operator's defense in depth (renderer
+        # uses `effective_worker_replicas` and the reconciler emits a
+        # `UDTerminalState` Warning Event on attempted mutations) catches
+        # `kubectl edit` mutations that bypass the SDK; this guard is the
+        # primary user-facing rejection.
+        current_phase = self.phase
+        if current_phase in TERMINAL_PHASES:
+            raise UDTerminalState(
+                f"scale: UD '{self.name}' is in terminal phase "
+                f"'{current_phase}'; recreate the UD to scale",
+                phase=current_phase,
+                requested_target=target,
+            )
         ws = self.world
         # ws.min == 0 means we have not yet observed the operator's first
         # status write; in that case skip the bounds check and let the
@@ -442,11 +541,30 @@ class DistributedTraining:
             )
 
     def wait_until_target_world(self, timeout: int = 600) -> None:
-        """Block until `ready >= target`, or raise `BelowMinimumWorld` on timeout."""
+        """
+        Block until `ready >= target`, or raise `BelowMinimumWorld` on timeout.
+
+        Phase 5b (#445): returns cleanly when the UD has already reached
+        `succeeded` -- by definition the world was assembled (the
+        operator only transitions to `succeeded` after every rank exited
+        with `exit_code == 0`), so the contract `ready >= target` was
+        met at some point. `failed` / `cancelled` raise `BelowMinimumWorld`
+        because the contract was NOT met.
+        """
         deadline = time.monotonic() + max(timeout, 0)
         while time.monotonic() < deadline:
             self.refresh()
             ws = self.world
+            if self.phase == "succeeded":
+                return
+            if self.phase in ("failed", "cancelled"):
+                raise BelowMinimumWorld(
+                    f"wait_until_target_world: UD '{self.name}' reached "
+                    f"terminal phase '{self.phase}' before world reached target",
+                    ready=ws.ready,
+                    required_min=ws.target,
+                    timeout=timeout,
+                )
             if ws.ready >= ws.target and ws.target > 0:
                 return
             if timeout == 0:
@@ -454,6 +572,8 @@ class DistributedTraining:
             time.sleep(min(5, max(timeout // 10, 1)))
         self.refresh()
         ws = self.world
+        if self.phase == "succeeded":
+            return
         if ws.ready < ws.target or ws.target == 0:
             raise BelowMinimumWorld(
                 f"wait_until_target_world timed out after {timeout}s "
@@ -464,11 +584,21 @@ class DistributedTraining:
             )
 
     async def wait_until_target_world_async(self, timeout: int = 600) -> None:
-        """Async variant of `wait_until_target_world`."""
+        """Async variant of `wait_until_target_world`. Same Phase 5b semantics."""
         deadline = asyncio.get_event_loop().time() + max(timeout, 0)
         while asyncio.get_event_loop().time() < deadline:
             await self.refresh_async()
             ws = self.world
+            if self.phase == "succeeded":
+                return
+            if self.phase in ("failed", "cancelled"):
+                raise BelowMinimumWorld(
+                    f"wait_until_target_world_async: UD '{self.name}' reached "
+                    f"terminal phase '{self.phase}' before world reached target",
+                    ready=ws.ready,
+                    required_min=ws.target,
+                    timeout=timeout,
+                )
             if ws.ready >= ws.target and ws.target > 0:
                 return
             if timeout == 0:
@@ -476,6 +606,8 @@ class DistributedTraining:
             await asyncio.sleep(min(5, max(timeout // 10, 1)))
         await self.refresh_async()
         ws = self.world
+        if self.phase == "succeeded":
+            return
         if ws.ready < ws.target or ws.target == 0:
             raise BelowMinimumWorld(
                 f"wait_until_target_world_async timed out after {timeout}s "
@@ -484,6 +616,128 @@ class DistributedTraining:
                 required_min=ws.target,
                 timeout=timeout,
             )
+
+    def wait_until_complete(self, timeout: int = 1800) -> WorldStatus:
+        """
+        Phase 5b (#445): block until the UD reaches any terminal state.
+
+        Returns the final `WorldStatus` on `succeeded`. Raises
+        `BelowMinimumWorld` on `failed` (with the per-rank exit
+        diagnostics from `rank_exits` summarised in the message). Raises
+        `UDTerminalState` if the UD is ALREADY terminal at the time of
+        the call -- so the caller distinguishes "I waited and it
+        completed" from "I called this on an already-completed UD".
+
+        Polls every 10s. The default 30-minute timeout assumes a typical
+        bench Job (~5 min) plus reasonable training time; long-running
+        runs should pass an explicit timeout.
+
+        Raises:
+            UDTerminalState: UD was already terminal at entry.
+            BelowMinimumWorld: UD reached `failed` / `cancelled` mid-wait
+                or the timeout elapsed without a terminal transition.
+        """
+        # Refuse to block on something that already reached a terminal
+        # state. Caller can read `t.world` / `t.bench` / `t.rank_exits`
+        # directly instead.
+        self.refresh()
+        if self.is_terminal:
+            raise UDTerminalState(
+                f"wait_until_complete: UD '{self.name}' is already in "
+                f"terminal phase '{self.phase}'",
+                phase=self.phase,
+                requested_target=None,
+            )
+
+        deadline = time.monotonic() + max(timeout, 0)
+        while time.monotonic() < deadline:
+            self.refresh()
+            current_phase = self.phase
+            if current_phase == "succeeded":
+                return self.world
+            if current_phase in ("failed", "cancelled"):
+                ws = self.world
+                exits = self.rank_exits
+                # Summarise non-zero exits for the error message so the
+                # caller has actionable context without an extra fetch.
+                bad = [
+                    f"rank {e.rank}: exit_code={e.exit_code}"
+                    + (f" reason={e.termination_reason}" if e.termination_reason else "")
+                    for e in exits
+                    if e.exit_code != 0
+                ]
+                detail = "; ".join(bad) if bad else "no per-rank exits recorded"
+                raise BelowMinimumWorld(
+                    f"wait_until_complete: UD '{self.name}' reached "
+                    f"terminal phase '{current_phase}' ({detail})",
+                    ready=ws.ready,
+                    required_min=ws.min,
+                    timeout=timeout,
+                )
+            if timeout == 0:
+                break
+            time.sleep(min(10, max(timeout // 30, 1)))
+        # Timeout: surface as `BelowMinimumWorld` with the live shape.
+        self.refresh()
+        ws = self.world
+        if self.phase == "succeeded":
+            return ws
+        raise BelowMinimumWorld(
+            f"wait_until_complete: timed out after {timeout}s "
+            f"(phase={self.phase}, ready={ws.ready}, target={ws.target})",
+            ready=ws.ready,
+            required_min=ws.min,
+            timeout=timeout,
+        )
+
+    async def wait_until_complete_async(self, timeout: int = 1800) -> WorldStatus:
+        """Async variant of `wait_until_complete`. Same Phase 5b semantics."""
+        await self.refresh_async()
+        if self.is_terminal:
+            raise UDTerminalState(
+                f"wait_until_complete_async: UD '{self.name}' is already in "
+                f"terminal phase '{self.phase}'",
+                phase=self.phase,
+                requested_target=None,
+            )
+
+        deadline = asyncio.get_event_loop().time() + max(timeout, 0)
+        while asyncio.get_event_loop().time() < deadline:
+            await self.refresh_async()
+            current_phase = self.phase
+            if current_phase == "succeeded":
+                return self.world
+            if current_phase in ("failed", "cancelled"):
+                ws = self.world
+                exits = self.rank_exits
+                bad = [
+                    f"rank {e.rank}: exit_code={e.exit_code}"
+                    + (f" reason={e.termination_reason}" if e.termination_reason else "")
+                    for e in exits
+                    if e.exit_code != 0
+                ]
+                detail = "; ".join(bad) if bad else "no per-rank exits recorded"
+                raise BelowMinimumWorld(
+                    f"wait_until_complete_async: UD '{self.name}' reached "
+                    f"terminal phase '{current_phase}' ({detail})",
+                    ready=ws.ready,
+                    required_min=ws.min,
+                    timeout=timeout,
+                )
+            if timeout == 0:
+                break
+            await asyncio.sleep(min(10, max(timeout // 30, 1)))
+        await self.refresh_async()
+        ws = self.world
+        if self.phase == "succeeded":
+            return ws
+        raise BelowMinimumWorld(
+            f"wait_until_complete_async: timed out after {timeout}s "
+            f"(phase={self.phase}, ready={ws.ready}, target={ws.target})",
+            ready=ws.ready,
+            required_min=ws.min,
+            timeout=timeout,
+        )
 
     def delete(self) -> None:
         """

--- a/crates/basilica-sdk-python/python/basilica/exceptions.py
+++ b/crates/basilica-sdk-python/python/basilica/exceptions.py
@@ -554,3 +554,55 @@ class WorldSizeOutOfBounds(DistributedError):
             code="DISTRIBUTED_WORLD_SIZE_OUT_OF_BOUNDS",
             retryable=False,
         )
+
+
+class UDTerminalState(DistributedError):
+    """
+    Phase 5b (#445): raised when the user attempts to mutate a
+    `DistributedTraining` UD that has already reached a terminal state
+    (`succeeded`, `failed`, or `cancelled`).
+
+    Two paths raise this:
+
+    1. `t.scale(target=N)` against a terminal UD. The operator's
+       defense in depth catches `kubectl edit` mutations that bypass the
+       SDK with a `UDTerminalState` Warning Event, but `t.scale` is the
+       primary user-facing rejection.
+    2. `t.wait_until_complete()` against a UD that is ALREADY terminal at
+       the time of the call. Distinguishes "I waited and it completed"
+       from "I called this on an already-completed UD" -- the caller
+       should read `t.world` / `t.bench` / `t.rank_exits` directly and
+       call `t.delete()` when done.
+
+    Attributes:
+        phase: The terminal phase observed (`succeeded` | `failed` |
+            `cancelled`).
+        requested_target: The `target` the caller passed to `scale()`,
+            or `None` for the `wait_until_complete()` path.
+
+    Example:
+        >>> training.refresh()
+        >>> training.phase
+        'succeeded'
+        >>> training.scale(target=4)
+        UDTerminalState: phase='succeeded', requested_target=4
+
+        >>> training.wait_until_complete()
+        UDTerminalState: phase='succeeded', requested_target=None
+
+    The user's only entry point for cleanup is `t.delete()`.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        phase: str,
+        requested_target: Optional[int] = None,
+    ):
+        self.phase = phase
+        self.requested_target = requested_target
+        super().__init__(
+            message=message,
+            code="DISTRIBUTED_UD_TERMINAL_STATE",
+            retryable=False,
+        )

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -30,7 +30,9 @@ from basilica import (
     DistributedTraining,
     ProviderFilter,
     QuotaExceeded,
+    RankExit,
     RankStatus,
+    UDTerminalState,
     WorldSize,
     WorldSizeOutOfBounds,
     WorldStatus,
@@ -1238,3 +1240,368 @@ class TestIssue454DeploymentWrapperCarriesDistributed:
         # `wait_until_min_world` must NOT raise BelowMinimumWorld here:
         # ready=2 >= min=2.
         training.wait_until_min_world(timeout=1)
+
+
+# =============================================================================
+# Phase 5b (#445) -- distributed UD completion semantics.
+# =============================================================================
+
+
+def _make_terminal_training(
+    name: str = "dlc-done",
+    namespace: str = "u-test",
+    phase: str = "succeeded",
+    rank_exits: list = None,
+) -> DistributedTraining:
+    """Build a `DistributedTraining` with a pre-populated terminal status.
+
+    The phase is at the top level of `_cached_status` (mirroring
+    `DeploymentResponse.phase`). `rank_exits` lives under
+    `distributed.rankExits` (camelCase JSON keys).
+    """
+    client = MagicMock()
+    client._client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.namespace = namespace
+    fake_response.phase = phase
+    fake_response._distributed_status = {
+        "worldSize": {
+            "ready": 0,
+            "target": 2,
+            "min": 2,
+            "max": 2,
+            "belowMinimum": True,
+        },
+        "rankExits": rank_exits or [
+            {
+                "rank": 0,
+                "exitCode": 0,
+                "terminationReason": "Completed",
+                "restartCount": 1,
+            },
+            {
+                "rank": 1,
+                "exitCode": 0,
+                "terminationReason": "Completed",
+                "restartCount": 1,
+            },
+        ],
+    }
+    client.get.return_value = fake_response
+    training = DistributedTraining(client, name)
+    training._cached_status = {
+        "namespace": namespace,
+        "phase": phase,
+        "distributed": fake_response._distributed_status,
+    }
+    training.namespace = namespace
+    training.rendezvous_endpoint = (
+        f"{name}-rendezvous.{namespace}.svc.cluster.local:2379"
+    )
+    return training
+
+
+class TestPhase5bCompletionSemantics:
+    """Phase 5b (#445) SDK-side terminal-state contracts."""
+
+    def test_phase_property_reads_succeeded_from_cached_status(self) -> None:
+        training = _make_terminal_training(phase="succeeded")
+        assert training.phase == "succeeded"
+        assert training.is_terminal is True
+
+    def test_phase_property_reads_running_phase(self) -> None:
+        # Non-terminal phase: `is_terminal` False, scale path open.
+        client = MagicMock()
+        client._client = MagicMock()
+        client.get.return_value = MagicMock(
+            namespace="u-test",
+            phase="ready",
+            _distributed_status={
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                }
+            },
+        )
+        training = DistributedTraining(client, "dlc-running")
+        training._cached_status = {
+            "namespace": "u-test",
+            "phase": "ready",
+            "distributed": {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                }
+            },
+        }
+        training.namespace = "u-test"
+        assert training.phase == "ready"
+        assert training.is_terminal is False
+
+    def test_rank_exits_property_reads_camelcase_json(self) -> None:
+        training = _make_terminal_training(phase="succeeded")
+        exits = training.rank_exits
+        assert len(exits) == 2
+        assert all(isinstance(e, RankExit) for e in exits)
+        assert exits[0].rank == 0
+        assert exits[0].exit_code == 0
+        assert exits[0].termination_reason == "Completed"
+        assert exits[0].restart_count == 1
+        assert exits[1].rank == 1
+        assert exits[1].exit_code == 0
+
+    def test_rank_exits_empty_when_running(self) -> None:
+        # No `rankExits` key in distributed status -> empty list.
+        client = MagicMock()
+        client._client = MagicMock()
+        training = DistributedTraining(client, "dlc-running")
+        training._cached_status = {
+            "namespace": "u-test",
+            "phase": "ready",
+            "distributed": {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                }
+            },
+        }
+        training.namespace = "u-test"
+        assert training.rank_exits == []
+
+    def test_scale_on_succeeded_raises_ud_terminal_state(self) -> None:
+        """SDK-side rejection BEFORE the API call. The operator's
+        `UDTerminalState` Warning Event is the defense in depth for
+        kubectl-edit mutations that bypass the SDK."""
+        training = _make_terminal_training(phase="succeeded")
+        # Stub the refresh fetch so the scale path has the latest phase.
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                phase="succeeded",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 0,
+                        "target": 2,
+                        "min": 2,
+                        "max": 2,
+                        "belowMinimum": True,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(UDTerminalState) as exc_info:
+            training.scale(target=4)
+        assert exc_info.value.phase == "succeeded"
+        assert exc_info.value.requested_target == 4
+        # The PyO3 patch MUST NOT have been issued -- the SDK rejection
+        # is local.
+        training._client._client.scale_distributed_deployment.assert_not_called()
+
+    def test_scale_on_failed_raises_ud_terminal_state(self) -> None:
+        """`failed` is also terminal; mirrors the operator's
+        `is_terminal` set."""
+        training = _make_terminal_training(phase="failed")
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                phase="failed",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 1,
+                        "target": 2,
+                        "min": 2,
+                        "max": 2,
+                        "belowMinimum": True,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(UDTerminalState) as exc_info:
+            training.scale(target=4)
+        assert exc_info.value.phase == "failed"
+        training._client._client.scale_distributed_deployment.assert_not_called()
+
+    def test_wait_until_complete_returns_world_when_already_succeeded_at_entry_raises(
+        self,
+    ) -> None:
+        """`wait_until_complete` distinguishes 'I waited and it
+        completed' from 'I called this on an already-complete UD' --
+        the latter raises `UDTerminalState` so the caller switches to
+        reading `t.world` / `t.bench` / `t.rank_exits` directly."""
+        training = _make_terminal_training(phase="succeeded")
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                phase="succeeded",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 0,
+                        "target": 2,
+                        "min": 2,
+                        "max": 2,
+                        "belowMinimum": True,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(UDTerminalState) as exc_info:
+            training.wait_until_complete(timeout=1)
+        assert exc_info.value.phase == "succeeded"
+        assert exc_info.value.requested_target is None
+
+    def test_wait_until_complete_returns_world_when_phase_flips_to_succeeded(
+        self,
+    ) -> None:
+        """Real waiting path: phase starts non-terminal, flips to
+        `succeeded` mid-wait, returns `WorldStatus`. We simulate two
+        polls: first sees `pending`, second sees `succeeded`."""
+        # Counter to mutate the response across refresh() calls.
+        call_count = {"n": 0}
+
+        def fake_get(name: str) -> MagicMock:
+            call_count["n"] += 1
+            phase = "pending" if call_count["n"] <= 1 else "succeeded"
+            return MagicMock(
+                namespace="u-test",
+                phase=phase,
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 0,
+                        "target": 2,
+                        "min": 2,
+                        "max": 2,
+                        "belowMinimum": True,
+                    },
+                    "rankExits": [],
+                },
+            )
+
+        client = MagicMock()
+        client._client = MagicMock()
+        client.get.side_effect = fake_get
+        training = DistributedTraining(client, "dlc-flip")
+        # Start the wait. timeout=1 so the test is fast; we expect the
+        # second poll to flip the phase, returning WorldStatus.
+        ws = training.wait_until_complete(timeout=1)
+        assert isinstance(ws, WorldStatus)
+
+    def test_wait_until_complete_raises_below_minimum_on_failed(self) -> None:
+        """`failed` mid-wait raises `BelowMinimumWorld` with per-rank
+        exit detail. The first refresh sees `pending` (so the entry
+        guard does not fire); the second sees `failed`."""
+        call_count = {"n": 0}
+
+        def fake_get(name: str) -> MagicMock:
+            call_count["n"] += 1
+            phase = "pending" if call_count["n"] <= 1 else "failed"
+            return MagicMock(
+                namespace="u-test",
+                phase=phase,
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 1,
+                        "target": 2,
+                        "min": 2,
+                        "max": 2,
+                        "belowMinimum": True,
+                    },
+                    "rankExits": [
+                        {
+                            "rank": 0,
+                            "exitCode": 0,
+                            "terminationReason": "Completed",
+                            "restartCount": 0,
+                        },
+                        {
+                            "rank": 1,
+                            "exitCode": 137,
+                            "terminationReason": "OOMKilled",
+                            "restartCount": 1,
+                        },
+                    ],
+                },
+            )
+
+        client = MagicMock()
+        client._client = MagicMock()
+        client.get.side_effect = fake_get
+        training = DistributedTraining(client, "dlc-fail")
+
+        with pytest.raises(BelowMinimumWorld) as exc_info:
+            training.wait_until_complete(timeout=1)
+        # The error message must mention the OOMKilled rank so the
+        # caller has actionable context (per CLAUDE.md
+        # `feedback_evidence_backed_issues`).
+        assert "rank 1" in str(exc_info.value)
+        assert "137" in str(exc_info.value)
+
+    def test_wait_until_target_world_returns_clean_on_succeeded(self) -> None:
+        """Phase 5b: `wait_until_target_world` returns cleanly when the
+        UD has reached `succeeded` (training is done by definition).
+        Was previously timing out on `ready=0` after the
+        StatefulSet scaled to 0."""
+        # First poll observes `succeeded`; with `ready=0` (workers
+        # scaled to 0), the legacy `ready >= target` check would have
+        # timed out.
+        client = MagicMock()
+        client._client = MagicMock()
+        client.get.return_value = MagicMock(
+            namespace="u-test",
+            phase="succeeded",
+            _distributed_status={
+                "worldSize": {
+                    "ready": 0,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": True,
+                },
+                "rankExits": [
+                    {
+                        "rank": 0,
+                        "exitCode": 0,
+                        "terminationReason": "Completed",
+                        "restartCount": 1,
+                    },
+                    {
+                        "rank": 1,
+                        "exitCode": 0,
+                        "terminationReason": "Completed",
+                        "restartCount": 1,
+                    },
+                ],
+            },
+        )
+        training = DistributedTraining(client, "dlc-finish")
+        # Pre-populate the cache so the wait sees `succeeded` on its
+        # first refresh.
+        training._cached_status = {
+            "namespace": "u-test",
+            "phase": "succeeded",
+            "distributed": client.get.return_value._distributed_status,
+        }
+        training.namespace = "u-test"
+
+        # Should return without raising; explicit None result.
+        result = training.wait_until_target_world(timeout=1)
+        assert result is None
+
+    def test_async_phase_5b_methods_exist(self) -> None:
+        """Phase 5b: `wait_until_complete_async` exists for parity with
+        the sync method (SDK arch § 9)."""
+        training = _make_terminal_training()
+        assert hasattr(training, "wait_until_complete")
+        assert hasattr(training, "wait_until_complete_async")
+        assert asyncio.iscoroutinefunction(training.wait_until_complete_async)

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1419,6 +1419,29 @@ pub struct DistributedBenchResult {
     pub probe_node_b: String,
 }
 
+/// Phase 5b (#445) per-rank exit diagnostics, populated when a distributed
+/// UD reaches a terminal state (`Succeeded` / `Failed` / `Cancelled`).
+/// Mirrors the K8s container `terminated` block so the SDK can surface
+/// per-rank exit codes after the operator scales the worker StatefulSet
+/// to `replicas: 0` (and the worker pods are no longer queryable). Source:
+/// `crd::user_deployment::RankExit`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DistributedRankExit {
+    pub rank: u32,
+    pub exit_code: i32,
+    /// `Completed` | `Error` | `OOMKilled` | ... or `None` when kubelet did
+    /// not record a reason (rare; usually means the container terminated
+    /// before kubelet could attribute a cause).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub termination_reason: Option<String>,
+    /// Container `restartCount` at the moment the operator observed the
+    /// terminated state. `0` for a clean first-iteration exit; non-zero
+    /// when kubelet's `restartPolicy=Always` already restarted the
+    /// container at least once before the operator caught it.
+    pub restart_count: u32,
+}
+
 /// Bench probe state. `result` is populated only after a successful run.
 /// `last_attempt_outcome` is one of `success | error | timeout` (stable
 /// wire tokens defined in the operator).
@@ -1585,6 +1608,13 @@ pub struct DistributedStatus {
     /// Phase 5a deprecation flag for the legacy preflight surface.
     #[serde(default, skip_serializing_if = "is_false_status")]
     pub preflight_deprecation_warned: bool,
+    /// Phase 5b (#445): per-rank exit diagnostics. Empty while the UD is
+    /// non-terminal. On transition to `Succeeded` / `Failed` the operator
+    /// snapshots each worker pod's container `terminated` state and
+    /// persists it here so the SDK can surface them after the worker
+    /// StatefulSet has been scaled to `replicas: 0`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rank_exits: Vec<DistributedRankExit>,
 }
 
 #[inline]


### PR DESCRIPTION
## Summary

Refs #445 (closed by the matching basilica-backend PR). Exposes the operator's `Succeeded` terminal state to Python users via:

- `DistributedTraining.phase` — operator-driven phase string (`pending` ... `succeeded` | `failed` | `cancelled`).
- `DistributedTraining.is_terminal` — convenience for the terminal triple.
- `DistributedTraining.rank_exits: List[RankExit]` — per-rank exit diagnostics, populated when the UD reaches a terminal state.
- `wait_until_complete(timeout)` — sync + async; blocks until any terminal state, returns `WorldStatus` on `succeeded`, raises `BelowMinimumWorld` (with per-rank exit detail) on `failed`, raises `UDTerminalState` if the UD is already terminal at entry.
- `wait_until_target_world(timeout)` — returns cleanly on `succeeded` (training is done by definition); raises `BelowMinimumWorld` on `failed` / `cancelled`.
- `t.scale(target=N)` — raises `UDTerminalState` BEFORE the API call when the UD is already terminal. The operator-side defense in depth (`UDTerminalState` Warning Event) covers `kubectl edit` mutations that bypass the SDK.
- New `UDTerminalState(DistributedError)` exception with `phase` and `requested_target` attributes.

## Per-deliverable status

### Rust wire types
- [x] `DistributedRankExit` struct mirrors the operator's `RankExit`.
- [x] `DistributedStatus.rank_exits: Vec<DistributedRankExit>` field.
- [x] `cargo check -p basilica-sdk` clean.

### Python facade
- [x] `RankExit` dataclass.
- [x] `phase` / `is_terminal` / `rank_exits` properties on `DistributedTraining`.
- [x] `wait_until_complete` (sync + async) with `BelowMinimumWorld` (carrying per-rank exit context) on `failed`, `UDTerminalState` on already-terminal-at-entry, `BelowMinimumWorld` on timeout.
- [x] `wait_until_target_world` (sync + async) returns clean on `succeeded`.
- [x] `scale` raises `UDTerminalState` on terminal phase BEFORE the API call.
- [x] `UDTerminalState` exception added to `basilica.exceptions`.
- [x] All re-exported in `basilica/__init__.py`.

### Tests
- [x] 11 new tests in `tests/test_distributed.py::TestPhase5bCompletionSemantics`:
  1. `phase` property reads `succeeded` from cached status.
  2. `phase` property reads non-terminal `ready`; `is_terminal` False.
  3. `rank_exits` parses camelCase JSON correctly.
  4. `rank_exits` empty when no `rankExits` key in distributed status.
  5. `scale(target=N)` on `succeeded` raises `UDTerminalState`; PyO3 patch NOT issued.
  6. `scale(target=N)` on `failed` raises `UDTerminalState`.
  7. `wait_until_complete` on UD already terminal at entry raises `UDTerminalState`.
  8. `wait_until_complete` returns `WorldStatus` when phase flips to `succeeded` mid-wait.
  9. `wait_until_complete` raises `BelowMinimumWorld` with `rank 1: exit_code=137 reason=OOMKilled` detail on mid-wait `failed`.
  10. `wait_until_target_world` returns clean on `succeeded` even with `ready=0` (StatefulSet scaled to 0 by operator).
  11. `wait_until_complete_async` exists and is a coroutine function (SDK arch § 9 parity).
- [x] Full distributed test suite passes (60 tests; 49 prior + 11 Phase 5b).

### Architecture doc
- [x] SDK doc `§ 6` / `§ 8` / `§ 11` updates land in the matching backend PR (the doc lives in `basilica-private/docs/architecture/`, not in this repo).

## Test plan

- [ ] CI green on `pytest tests/test_distributed.py`.
- [ ] After backend PR's operator rollout, `examples/22_distributed_with_bench.py` exits 0 unmodified -- the load-bearing user-facing test referenced by issue #445. Live-verify transcript on the backend PR.

## What is NOT in this PR

- Backend-side operator/reaper/billing-daemon changes (in the matching `basilica-backend` PR).
- A typed `Phase` enum on the Python side. We use the snake_case string straight from the operator's `status.phase` because the SDK's existing `phase: Optional[String]` field on `DeploymentResponse` is already string-typed; introducing a new enum would have churned existing callers without buying type safety the existing surface lacks.
- Auto-cleanup of `Succeeded` UDs in the SDK. The user's only entry point for cleanup is `t.delete()`, matching the operator-side contract.