### PR TITLE
fix(examples): use topology_spread=pack in 21_distributed_torchrun (refs #487)

### DIFF
--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -59,7 +59,7 @@ def main() -> None:
         cpu="8",
         memory="32Gi",
         provider_filter=ProviderFilter(include=["verda"]),
-        topology_spread="provider-aware",
+        topology_spread="pack",
         nccl_env={"NCCL_DEBUG": "WARN"},
         ttl_seconds=600,
         timeout=900,


### PR DESCRIPTION
## Summary

Resolves the `SchedulingDegraded=SingleProviderForProviderAware` contradiction in `examples/21_distributed_torchrun.py` that caused the example to regress to `BelowMinimumWorld` after the 15-min SDK timeout. The example combined `provider_filter=ProviderFilter(include=["verda"])` with `topology_spread="provider-aware"`, which are mutually exclusive: the filter restricts scheduling to a single provider, while provider-aware spread expects ranks distributed across multiple providers.

The example's stated purpose is BYO-launcher demonstration, not provider spread. With the verda-only filter intentional, `"pack"` is the matching strategy (all ranks together on the same provider).

Tracks: one-covenant/basilica-backend#487

## Diff

```diff
-        topology_spread="provider-aware",
+        topology_spread="pack",
```

## Validation

Live re-run against prod (r2 evidence: `data/distributed-sweep/2026-05-08/ex21-r2/`):
- LAUNCH: 2026-05-08T12:52:10Z, EXIT: 2026-05-08T12:53:00Z, EXIT_CODE=0
- rank-0 -> `basilica-aed217e4` (verda), rank-1 -> `basilica-fc604172` (verda), rendezvous -> `k3s-agent-4`
- Operator events:
  - `WorldReachedMin: ready=2 >= min=2 ; training can start`
  - `WorldReachedTarget: ready=2 >= target=2 ; world fully assembled`
- No `SchedulingDegraded`, no `BelowMinimumWorld`, no `RendezvousClosedError`

## Out of scope

**Phase 2 elasticity verification deferred to one-covenant/basilica-backend#495** -- the `scale(target=3)` call returns silently before `status.worldSize.target` reflects the request, so `wait_until_target_world` returns immediately based on stale `target=2`. This PR does **not** exercise the scale path; #495 tracks the SDK/operator status-freshness fix.

## Test plan

- [x] r2 run against prod completes cleanly (50s wall clock, exit 0)
- [x] Operator emits WorldReachedMin + WorldReachedTarget for the new UD
- [x] No `SchedulingDegraded` condition on the UD
- [ ] Re-run after #495 lands to validate the scale path end-to-end