### PR TITLE
fix(sdk): wait_until_target_world races stale status.worldSize.target (#495)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -253,6 +253,12 @@ class DistributedTraining:
         self._client = client
         self.name = name
         self._cached_status: Optional[Dict[str, Any]] = None
+        # Issue #495: target requested by the most recent `scale()` call,
+        # cleared once the operator's `status.worldSize.target` reflects it.
+        # `wait_until_target_world` consults this to avoid short-circuiting
+        # against a stale `status.worldSize.target` (the API patches `spec`
+        # only; the operator mirrors `spec → status` on its next reconcile).
+        self._pending_scale_target: Optional[int] = None
 
     # -------------------------------------------------------------------------
     # Status / observation
@@ -481,9 +487,25 @@ class DistributedTraining:
         # Issue the patch via the new POST /deployments/{name}/scale-distributed
         # endpoint shipped in the Phase 5b precursor (basilica-backend #421).
         self._client._client.scale_distributed_deployment(self.name, target)
-        # Refresh local cache so subsequent `world` reads reflect the new target.
+        # Issue #495: record the requested target before the refresh races
+        # the operator. `wait_until_target_world` keys off this to ignore a
+        # stale `status.worldSize.target` until the operator reconciles
+        # `spec → status` and reflects the new target.
+        self._pending_scale_target = target
         self.refresh()
-        return self.world
+        # Issue #495: return a snapshot reflecting the requested target so
+        # callers that print or inspect the return value see the truth.
+        # `status.worldSize.target` may still carry the pre-patch value
+        # because the API patches `spec` only; the operator mirrors to
+        # status on its next reconcile.
+        observed = self.world
+        return WorldStatus(
+            ready=observed.ready,
+            target=target,
+            min=observed.min,
+            max=observed.max,
+            below_minimum=observed.below_minimum,
+        )
 
     async def scale_async(self, target: int) -> WorldStatus:
         """Async variant of `scale`."""
@@ -550,22 +572,32 @@ class DistributedTraining:
         with `exit_code == 0`), so the contract `ready >= target` was
         met at some point. `failed` / `cancelled` raise `BelowMinimumWorld`
         because the contract was NOT met.
+
+        Issue #495: when called immediately after `scale(target=N)`, the
+        operator's `status.worldSize.target` may still carry the
+        pre-patch value (the API patches `spec` only; status mirroring
+        happens on the next reconcile). The success condition therefore
+        also requires `status.worldSize.target >= pending_scale_target`
+        when a scale is pending — otherwise the loop short-circuits
+        against the stale target.
         """
         deadline = time.monotonic() + max(timeout, 0)
         while time.monotonic() < deadline:
             self.refresh()
             ws = self.world
             if self.phase == "succeeded":
+                self._pending_scale_target = None
                 return
             if self.phase in ("failed", "cancelled"):
                 raise BelowMinimumWorld(
                     f"wait_until_target_world: UD '{self.name}' reached "
                     f"terminal phase '{self.phase}' before world reached target",
                     ready=ws.ready,
-                    required_min=ws.target,
+                    required_min=self._effective_required_target(ws),
                     timeout=timeout,
                 )
-            if ws.ready >= ws.target and ws.target > 0:
+            if self._target_world_reached(ws):
+                self._pending_scale_target = None
                 return
             if timeout == 0:
                 break
@@ -573,33 +605,58 @@ class DistributedTraining:
         self.refresh()
         ws = self.world
         if self.phase == "succeeded":
+            self._pending_scale_target = None
             return
-        if ws.ready < ws.target or ws.target == 0:
+        if not self._target_world_reached(ws):
+            required = self._effective_required_target(ws)
             raise BelowMinimumWorld(
                 f"wait_until_target_world timed out after {timeout}s "
-                f"(ready={ws.ready}, required_min={ws.target})",
+                f"(ready={ws.ready}, required_min={required})",
                 ready=ws.ready,
-                required_min=ws.target,
+                required_min=required,
                 timeout=timeout,
             )
+        self._pending_scale_target = None
+
+    def _target_world_reached(self, ws: WorldStatus) -> bool:
+        """
+        Issue #495: success predicate for `wait_until_target_world`. A
+        pending scale request gates the predicate so the caller does not
+        observe `ready >= stale_target` while the operator has not yet
+        mirrored the patched `spec.worldSize.target` into status.
+        """
+        pending = self._pending_scale_target
+        if pending is not None and pending > 0:
+            if ws.target < pending:
+                return False
+            return ws.ready >= pending
+        return ws.ready >= ws.target and ws.target > 0
+
+    def _effective_required_target(self, ws: WorldStatus) -> int:
+        """Required target reported by exception messages (max of pending vs. observed)."""
+        pending = self._pending_scale_target or 0
+        return max(pending, ws.target)
 
     async def wait_until_target_world_async(self, timeout: int = 600) -> None:
-        """Async variant of `wait_until_target_world`. Same Phase 5b semantics."""
+        """Async variant of `wait_until_target_world`. Same Phase 5b semantics
+        and the same #495 pending-scale gate."""
         deadline = asyncio.get_event_loop().time() + max(timeout, 0)
         while asyncio.get_event_loop().time() < deadline:
             await self.refresh_async()
             ws = self.world
             if self.phase == "succeeded":
+                self._pending_scale_target = None
                 return
             if self.phase in ("failed", "cancelled"):
                 raise BelowMinimumWorld(
                     f"wait_until_target_world_async: UD '{self.name}' reached "
                     f"terminal phase '{self.phase}' before world reached target",
                     ready=ws.ready,
-                    required_min=ws.target,
+                    required_min=self._effective_required_target(ws),
                     timeout=timeout,
                 )
-            if ws.ready >= ws.target and ws.target > 0:
+            if self._target_world_reached(ws):
+                self._pending_scale_target = None
                 return
             if timeout == 0:
                 break
@@ -607,15 +664,18 @@ class DistributedTraining:
         await self.refresh_async()
         ws = self.world
         if self.phase == "succeeded":
+            self._pending_scale_target = None
             return
-        if ws.ready < ws.target or ws.target == 0:
+        if not self._target_world_reached(ws):
+            required = self._effective_required_target(ws)
             raise BelowMinimumWorld(
                 f"wait_until_target_world_async timed out after {timeout}s "
-                f"(ready={ws.ready}, required_min={ws.target})",
+                f"(ready={ws.ready}, required_min={required})",
                 ready=ws.ready,
-                required_min=ws.target,
+                required_min=required,
                 timeout=timeout,
             )
+        self._pending_scale_target = None
 
     def wait_until_complete(self, timeout: int = 1800) -> WorldStatus:
         """

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -208,6 +208,240 @@ class TestDistributedTrainingScale:
         assert ws.target == 3
 
 
+class TestIssue495ScaleStaleTargetGate:
+    """
+    Issue #495: `scale(target=N)` patches `spec.distributed.worldSize.target`
+    only; the operator mirrors `spec → status` on its next reconcile. The
+    SDK's `wait_until_target_world` must NOT short-circuit while the
+    operator-observed `status.worldSize.target` still carries the
+    pre-patch value.
+    """
+
+    def test_issue_495_scale_returns_world_status_with_requested_target(
+        self,
+    ) -> None:
+        # Stub the API so refresh() after scale() still returns the OLD
+        # `status.worldSize.target` (operator hasn't reconciled yet). The
+        # SDK must NOT report the stale value back to the caller.
+        training = _make_mock_training(
+            world={
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": False,
+            },
+        )
+        training._client._client.scale_distributed_deployment = MagicMock()
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 2,  # stale: operator hasn't observed scale yet
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            )
+        )
+
+        ws = training.scale(target=3)
+
+        # Reported target must reflect the request, not the stale operator
+        # snapshot. Otherwise `Scaled to target=3; world now: ...target=2`
+        # is a lie that misleads operators reviewing example output.
+        assert ws.target == 3, (
+            "issue #495: scale() must report the REQUESTED target, not the "
+            "stale `status.worldSize.target` from before the operator's "
+            "next reconcile."
+        )
+
+    def test_issue_495_wait_until_target_world_does_not_shortcircuit_on_stale_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reproduces the ex21-r2 silent-failure: scale(target=3) succeeds,
+        # but `status.worldSize.target` stays at 2 because the operator
+        # hasn't reconciled yet. wait_until_target_world MUST keep waiting.
+        training = _make_mock_training(
+            world={
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": False,
+            },
+        )
+        training._client._client.scale_distributed_deployment = MagicMock()
+
+        # Three refresh ticks before status reflects the patch:
+        #   tick 0 (the refresh inside scale()): stale target=2 ready=2
+        #   tick 1 (first wait iteration): stale target=2 ready=2
+        #   tick 2 (second wait iteration): operator reconciled, target=3 ready=2
+        #   tick 3 (third wait iteration): rank joined, target=3 ready=3 -- DONE
+        responses = [
+            MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 2,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            ),
+            MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 2,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            ),
+            MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 3,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            ),
+            MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 3,
+                        "target": 3,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            ),
+        ]
+        training._client.get = MagicMock(side_effect=responses)
+        # Avoid real sleeps -- the loop's inter-poll delay is irrelevant.
+        sleeps: list = []
+        import sys
+
+        _dist_mod = sys.modules["basilica.distributed"]
+        monkeypatch.setattr(_dist_mod.time, "sleep", lambda s: sleeps.append(s))
+
+        training.scale(target=3)
+        # The pre-fix bug: this returned ~immediately because ws.target==2
+        # and ws.ready==2 (stale) satisfied `ready >= target`. Post-fix,
+        # the pending-scale gate forces the loop to wait until status
+        # reflects target=3 AND ready>=3.
+        training.wait_until_target_world(timeout=120)
+
+        ws_final = training.world
+        assert ws_final.ready == 3
+        assert ws_final.target == 3
+        # Loop must have iterated at least twice (i.e. slept at least once).
+        assert sleeps, (
+            "issue #495: wait_until_target_world short-circuited on the "
+            "stale `status.worldSize.target` instead of waiting for the "
+            "operator to reflect the requested target."
+        )
+        # Pending-scale flag must be cleared on success.
+        assert training._pending_scale_target is None
+
+    def test_issue_495_wait_until_target_world_calls_refresh_before_first_check(
+        self,
+    ) -> None:
+        # Lock the SDK invariant: even with no pending scale, the first
+        # comparison in `wait_until_target_world` sees a fresh refresh.
+        training = _make_mock_training(
+            world={
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": False,
+            },
+        )
+        # Stub the API so the first refresh() call returns ready==target.
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 2,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            )
+        )
+        # Should return without raising.
+        training.wait_until_target_world(timeout=10)
+        # `client.get` is the underlying refresh path; it MUST have been
+        # called at least once before the success-predicate check.
+        assert training._client.get.call_count >= 1, (
+            "issue #495: wait_until_target_world must refresh from the API "
+            "before its first ready/target comparison."
+        )
+
+    def test_issue_495_wait_until_target_world_times_out_with_pending_required_min(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If the operator never reflects the patch, the timeout error
+        # message must report the REQUESTED target as required_min, not
+        # the stale operator-observed target.
+        training = _make_mock_training(
+            world={
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": False,
+            },
+        )
+        training._client._client.scale_distributed_deployment = MagicMock()
+        # Status never advances past the stale snapshot.
+        training._client.get = MagicMock(
+            return_value=MagicMock(
+                namespace="u-test",
+                _distributed_status={
+                    "worldSize": {
+                        "ready": 2,
+                        "target": 2,
+                        "min": 2,
+                        "max": 4,
+                        "belowMinimum": False,
+                    }
+                },
+            )
+        )
+        import sys
+
+        _dist_mod = sys.modules["basilica.distributed"]
+        monkeypatch.setattr(_dist_mod.time, "sleep", lambda s: None)
+
+        training.scale(target=4)
+        with pytest.raises(BelowMinimumWorld) as exc_info:
+            training.wait_until_target_world(timeout=0)
+        assert exc_info.value.ready == 2
+        assert exc_info.value.required_min == 4, (
+            "issue #495: timeout exception must surface the REQUESTED "
+            "target as required_min (not stale `status.worldSize.target`)."
+        )
+
+
 class TestWaitUntilMinWorld:
     def test_timeout_zero_raises_below_minimum_immediately(self) -> None:
         # World is below min (ready=0, min=2). With timeout=0, the call


### PR DESCRIPTION
## Summary

`DistributedTraining.scale(target=N)` patches `spec.distributed.worldSize.target` only; the operator mirrors `spec → status` on its next reconcile pass. The SDK's `wait_until_target_world` checked `ws.ready >= ws.target` against the stale `status.worldSize.target`, so on the first loop iteration after `scale()` it saw `ready == stale_target` and returned — claiming `N` ranks ready while only the original count had ever been scheduled.

Track the requested target on the `DistributedTraining` instance and gate the success predicate so a pending scale forces the loop to wait until both `status.worldSize.target` reflects the patch AND `ready >= requested`. Also return a `WorldStatus` from `scale()` that reports the requested target, so example output matches reality.

Closes #495.

## Layer responsibility

Per investigation in `docs/incidents/2026-05-08-scale-silent-failure-rca.md` (basilica-private):

- **SDK is the load-bearing fix.** `wait_until_target_world` had no way to distinguish "operator hasn't yet observed my scale request" from "world is settled at the current target."
- **API/operator is a contributor** but per the documented contract (`crates/basilica-api/.../handlers.rs:1480-1489`) `POST /scale-distributed` is intentionally async and the SDK wait-helpers are the documented synchronization point. No separate operator-side issue filed.

## Test plan

- [x] \`pytest tests/test_distributed.py\` — 70 tests pass (66 existing + 4 new).
- [x] \`pytest tests/\` (full SDK suite minus e2e) — 102 pass.
- [x] Anti-regression check: with the prod fix reverted, 3 of the 4 new \`issue_495\` tests fail (the load-bearing \`does_not_shortcircuit_on_stale_target\` test fails with the exact bug pattern).
- [ ] Live re-run of \`examples/21_distributed_torchrun.py\` (paid; deferred to reviewer).

## What's NOT in this PR

- No changes to the API or operator. \`POST /scale-distributed\` remains async; the resize-observed acknowledgement is not part of this change.
- No changes to \`examples/21_distributed_torchrun.py\`. The example was the canary; with the SDK fix, its existing \`wait_until_target_world(timeout=300)\` will block correctly until the new rank joins.

## Live evidence (the bug)

ex21-r2, 2026-05-08T12:52Z, exit 0 in 50s wall-clock:

\`\`\`
World: WorldStatus(ready=2, target=2, min=2, max=4, below_minimum=False)
Scaled to target=3; world now: WorldStatus(ready=2, target=2, min=2, max=4, below_minimum=False)
All 3 ranks ready: WorldStatus(ready=2, target=2, min=2, max=4, below_minimum=False)
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed distributed training scaling operations to correctly report requested scale targets and prevent premature timeouts. The system now properly tracks scaling requests through operator reconciliation.

* **Tests**
  * Added comprehensive regression tests covering distributed training scaling and wait-until-target operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->