### PR TITLE
feat(sdk): expose explicit bench lifecycle; wait_until_min_world is bench-independent (refs #506)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -149,7 +149,14 @@ from .decorators import DeployedFunction, DistributedFunction, deployment, distr
 # Import new modules
 from ._deployment import Deployment, DeploymentStatus, ProgressInfo
 from .distributed import (
+    BENCH_PHASE_FAILED,
+    BENCH_PHASE_PENDING,
+    BENCH_PHASE_RUNNING,
+    BENCH_PHASE_SKIPPED,
+    BENCH_PHASE_SUCCEEDED,
+    BENCH_PHASE_TIMED_OUT,
     BenchResult,
+    BenchStatus,
     DistributedMetrics,
     DistributedTraining,
     ProviderFilter,

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -200,6 +200,71 @@ class BenchResult:
         )
 
 
+# Issue B/N (refs #506): bench probe lifecycle phase. Mirrors the
+# operator's `status.distributed.bench.phase`. INDEPENDENT of UD
+# readiness; `wait_until_min_world` polls `WorldStatus.ready >= min`
+# and is unaffected by this enum. Stable string wire tokens (PascalCase
+# matching the operator's `#[serde(rename_all = "PascalCase")]`).
+BENCH_PHASE_SKIPPED: str = "Skipped"
+BENCH_PHASE_PENDING: str = "Pending"
+BENCH_PHASE_RUNNING: str = "Running"
+BENCH_PHASE_SUCCEEDED: str = "Succeeded"
+BENCH_PHASE_FAILED: str = "Failed"
+BENCH_PHASE_TIMED_OUT: str = "TimedOut"
+
+_BENCH_TERMINAL_PHASES: frozenset = frozenset(
+    {BENCH_PHASE_SUCCEEDED, BENCH_PHASE_FAILED, BENCH_PHASE_TIMED_OUT}
+)
+
+
+@dataclass(frozen=True)
+class BenchStatus:
+    """
+    Issue B/N (refs #506): full bench probe surface.
+
+    Decoupling contract: this object is published asynchronously to
+    `status.distributed.bench` by the operator. `phase` reflects the
+    bench Job lifecycle (`Skipped` | `Pending` | `Running` |
+    `Succeeded` | `Failed` | `TimedOut`) and is INDEPENDENT of
+    `WorldStatus.ready` -- callers waiting on `wait_until_min_world`
+    will return when workers are Ready regardless of this state.
+
+    Use `wait_until_bench_complete` for the explicit opt-in to block
+    on the bench probe. Most callers should NOT need that; the bench
+    is a sanity probe per `basilica_bench.py:75-78`, not a gating
+    measurement.
+    """
+
+    mode: str
+    phase: str
+    result: Optional[BenchResult]
+    started_at: Optional[datetime]
+    completed_at: Optional[datetime]
+    message: Optional[str]
+    last_attempt_at: Optional[datetime]
+    last_attempt_outcome: Optional[str]
+
+    @property
+    def is_terminal(self) -> bool:
+        """True iff phase is `Succeeded`, `Failed`, or `TimedOut`."""
+        return self.phase in _BENCH_TERMINAL_PHASES
+
+    @classmethod
+    def from_status_dict(cls, raw: Dict[str, Any]) -> "BenchStatus":
+        """Construct from the operator's `status.distributed.bench` JSON."""
+        result_raw = raw.get("result")
+        return cls(
+            mode=raw.get("mode", "off"),
+            phase=raw.get("phase", BENCH_PHASE_PENDING),
+            result=BenchResult.from_status_dict(result_raw) if result_raw else None,
+            started_at=_parse_rfc3339(raw["startedAt"]) if raw.get("startedAt") else None,
+            completed_at=_parse_rfc3339(raw["completedAt"]) if raw.get("completedAt") else None,
+            message=raw.get("message"),
+            last_attempt_at=_parse_rfc3339(raw["lastAttemptAt"]) if raw.get("lastAttemptAt") else None,
+            last_attempt_outcome=raw.get("lastAttemptOutcome"),
+        )
+
+
 @dataclass(frozen=True)
 class DistributedMetrics:
     """
@@ -372,6 +437,11 @@ class DistributedTraining:
 
         SDK arch § 7: never a cross-tenant aggregate; always measured
         on this UD's own nodes, billed against this user's GPU minutes.
+
+        Issue B/N (refs #506): backward compatible. Use
+        :pyattr:`bench_status` for the full lifecycle (phase / timing /
+        message); this accessor remains for callers that only want the
+        measurement payload.
         """
         if self._cached_status is None:
             self.refresh()
@@ -384,6 +454,29 @@ class DistributedTraining:
         if not result:
             return None
         return BenchResult.from_status_dict(result)
+
+    @property
+    def bench_status(self) -> Optional[BenchStatus]:
+        """
+        Issue B/N (refs #506): full bench probe state, including
+        explicit lifecycle [`phase`], `started_at` / `completed_at`
+        timing, and a human-readable `message`.
+
+        Returns `None` when bench is off (`mode != on-start`) or the
+        operator has not yet observed the Job at all. Otherwise the
+        returned [`BenchStatus`] reflects the operator's
+        `status.distributed.bench` exactly.
+
+        DECOUPLING CONTRACT: this surface is INDEPENDENT of
+        `WorldStatus.ready`. `wait_until_min_world` polls workers only;
+        bench has its own opt-in waiter, `wait_until_bench_complete`.
+        """
+        if self._cached_status is None:
+            self.refresh()
+        bench_raw = (self._cached_status or {}).get("distributed", {}).get("bench")
+        if not bench_raw:
+            return None
+        return BenchStatus.from_status_dict(bench_raw)
 
     def metrics(self) -> DistributedMetrics:
         """Platform-side metric snapshot for this UD (SDK arch § 6)."""
@@ -561,6 +654,66 @@ class DistributedTraining:
                 required_min=ws.min,
                 timeout=timeout,
             )
+
+    def wait_until_bench_complete(self, timeout: int = 1500) -> Optional[BenchStatus]:
+        """
+        Issue B/N (refs #506): OPT-IN waiter for the bench probe.
+
+        Most callers do NOT need this; bench is best-effort per
+        `basilica_bench.py:75-78` and the world is considered ready
+        when workers reach Ready (see :py:meth:`wait_until_min_world`).
+        This method exists for the small set of callers that DO want
+        the bench measurement before continuing (e.g. a research run
+        that records busbw metadata into checkpoint headers).
+
+        Returns the terminal :py:class:`BenchStatus` (`phase` is one
+        of `Succeeded` | `Failed` | `TimedOut`). If `bench.mode != on-start`
+        returns `None` immediately. Polls every 5s.
+
+        Default timeout matches the operator's `BENCH_ACTIVE_DEADLINE_SECONDS`
+        (1500s = 25 min). Raises `TimeoutError` past the deadline.
+        """
+        deadline = time.monotonic() + max(timeout, 0)
+        while time.monotonic() < deadline:
+            self.refresh()
+            bs = self.bench_status
+            if bs is None:
+                # bench is Off — nothing to wait for.
+                return None
+            if bs.is_terminal:
+                return bs
+            time.sleep(min(5, max(timeout // 10, 1)))
+        # One last refresh.
+        self.refresh()
+        bs = self.bench_status
+        if bs is not None and bs.is_terminal:
+            return bs
+        raise TimeoutError(
+            f"wait_until_bench_complete timed out after {timeout}s "
+            f"(phase={bs.phase if bs else 'absent'})"
+        )
+
+    async def wait_until_bench_complete_async(
+        self, timeout: int = 1500
+    ) -> Optional[BenchStatus]:
+        """Async variant of :py:meth:`wait_until_bench_complete`."""
+        deadline = asyncio.get_event_loop().time() + max(timeout, 0)
+        while asyncio.get_event_loop().time() < deadline:
+            await self.refresh_async()
+            bs = self.bench_status
+            if bs is None:
+                return None
+            if bs.is_terminal:
+                return bs
+            await asyncio.sleep(min(5, max(timeout // 10, 1)))
+        await self.refresh_async()
+        bs = self.bench_status
+        if bs is not None and bs.is_terminal:
+            return bs
+        raise TimeoutError(
+            f"wait_until_bench_complete_async timed out after {timeout}s "
+            f"(phase={bs.phase if bs else 'absent'})"
+        )
 
     def wait_until_target_world(self, timeout: int = 600) -> None:
         """

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -2077,3 +2077,223 @@ class TestDeployDistributedAsyncCleanupOnFailure:
         client._client.delete_deployment.assert_called_once_with(
             response.instance_name
         )
+
+
+# =============================================================================
+# Issue B/N (refs #506): bench-decoupling SDK tests.
+#
+# These codify that `wait_until_min_world` polls workers ONLY and is
+# unaffected by `status.distributed.bench.phase`. They also exercise
+# the new `bench_status` accessor and `wait_until_bench_complete`
+# opt-in waiter.
+# =============================================================================
+
+
+class TestBenchPhaseDecoupling:
+    """Bench probe lifecycle is published asynchronously; never gates `world.ready`."""
+
+    def _make_status_dict(
+        self, ready: int, min_: int, bench_phase: str, bench_result: bool = False
+    ) -> Any:
+        bench: Dict[str, Any] = {
+            "mode": "on-start",
+            "phase": bench_phase,
+        }
+        if bench_phase != "Pending":
+            bench["startedAt"] = "2026-05-08T12:00:00Z"
+        if bench_phase in {"Succeeded", "Failed", "TimedOut"}:
+            bench["completedAt"] = "2026-05-08T12:10:00Z"
+        if bench_phase == "Succeeded":
+            bench["lastAttemptOutcome"] = "success"
+        if bench_phase == "Failed":
+            bench["lastAttemptOutcome"] = "error"
+        if bench_phase == "TimedOut":
+            bench["lastAttemptOutcome"] = "timeout"
+        if bench_result:
+            bench["result"] = {
+                "measuredAt": "2026-05-08T12:00:00Z",
+                "busbwGbpsP50": 12.5,
+                "sizeBytesSwept": [1048576],
+                "probeNodeA": "n-a",
+                "probeNodeB": "n-b",
+            }
+
+        class FakeDeployment:
+            instance_name = "ud-bench-decouple"
+            user_id = "u-test"
+            namespace = "u-test"
+            image = "pytorch/pytorch"
+            state = "running"
+            url = "https://x"
+            created_at = "2026-05-08T12:00:00Z"
+            updated_at = "2026-05-08T12:00:00Z"
+            phase = "Running"
+            message = None
+            share_token = None
+            share_url = None
+            public_metadata = False
+            distributed = {
+                "worldSize": {
+                    "ready": ready,
+                    "target": min_,
+                    "min": min_,
+                    "max": min_,
+                    "belowMinimum": ready < min_,
+                },
+                "ranks": [],
+                "transport": "hub-relay",
+                "bench": bench,
+            }
+
+        return FakeDeployment()
+
+    def test_wait_until_min_world_returns_when_workers_ready_bench_pending(self) -> None:
+        """LOAD-BEARING: workers Ready -> world.ready >= min, even if bench is Pending."""
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(2, 2, "Pending")
+        training = DistributedTraining(client, "ud-bench-decouple")
+        # Should NOT raise even though bench is Pending.
+        training.wait_until_min_world(timeout=10)
+
+    def test_wait_until_min_world_returns_when_workers_ready_bench_failed(self) -> None:
+        """LOAD-BEARING: bench Failed does NOT propagate to world.ready."""
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(2, 2, "Failed")
+        training = DistributedTraining(client, "ud-bench-decouple")
+        training.wait_until_min_world(timeout=10)
+        # bench.phase is observable independently.
+        bs = training.bench_status
+        assert bs is not None
+        assert bs.phase == "Failed"
+        assert bs.is_terminal
+
+    def test_wait_until_min_world_returns_when_workers_ready_bench_timed_out(
+        self,
+    ) -> None:
+        """LOAD-BEARING: bench TimedOut does NOT propagate to world.ready."""
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(2, 2, "TimedOut")
+        training = DistributedTraining(client, "ud-bench-decouple")
+        training.wait_until_min_world(timeout=10)
+        bs = training.bench_status
+        assert bs is not None
+        assert bs.phase == "TimedOut"
+
+    def test_bench_status_reflects_each_lifecycle_state(self) -> None:
+        """Bench lifecycle is observable through `bench_status` independent of UD phase."""
+        for phase in ["Pending", "Running", "Succeeded", "Failed", "TimedOut"]:
+            client = MagicMock()
+            client.get.return_value = self._make_status_dict(
+                2, 2, phase, bench_result=(phase == "Succeeded")
+            )
+            training = DistributedTraining(client, "ud-bench-decouple")
+            bs = training.bench_status
+            assert bs is not None, f"bench_status absent for phase={phase}"
+            assert bs.phase == phase
+            assert bs.mode == "on-start"
+            if phase in {"Succeeded", "Failed", "TimedOut"}:
+                assert bs.is_terminal
+                assert bs.completed_at is not None
+            else:
+                assert not bs.is_terminal
+                assert bs.completed_at is None
+
+    def test_bench_status_returns_none_when_bench_off(self) -> None:
+        class FakeDeployment:
+            instance_name = "ud"
+            user_id = "u"
+            namespace = "u"
+            image = "x"
+            state = "running"
+            url = "https://x"
+            created_at = "t"
+            updated_at = "t"
+            phase = "Running"
+            message = None
+            share_token = None
+            share_url = None
+            public_metadata = False
+            distributed = {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                },
+                "ranks": [],
+                "transport": "hub-relay",
+            }
+
+        client = MagicMock()
+        client.get.return_value = FakeDeployment()
+        training = DistributedTraining(client, "ud")
+        assert training.bench_status is None
+        # Backward-compat `bench` accessor also returns None.
+        assert training.bench is None
+
+    def test_wait_until_bench_complete_returns_terminal_status(self) -> None:
+        """Opt-in waiter returns terminal `BenchStatus` with phase + timing."""
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(
+            2, 2, "Succeeded", bench_result=True
+        )
+        training = DistributedTraining(client, "ud-bench-decouple")
+        bs = training.wait_until_bench_complete(timeout=10)
+        assert bs is not None
+        assert bs.phase == "Succeeded"
+        assert bs.result is not None
+        assert bs.result.busbw_gbps_p50 == 12.5
+        assert bs.completed_at is not None
+
+    def test_wait_until_bench_complete_returns_none_when_bench_off(self) -> None:
+        class FakeDeployment:
+            instance_name = "ud"
+            user_id = "u"
+            namespace = "u"
+            image = "x"
+            state = "running"
+            url = "https://x"
+            created_at = "t"
+            updated_at = "t"
+            phase = "Running"
+            message = None
+            share_token = None
+            share_url = None
+            public_metadata = False
+            distributed = {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                },
+                "ranks": [],
+                "transport": "hub-relay",
+            }
+
+        client = MagicMock()
+        client.get.return_value = FakeDeployment()
+        training = DistributedTraining(client, "ud")
+        # bench.mode == off -> waiter returns None immediately.
+        assert training.wait_until_bench_complete(timeout=1) is None
+
+    def test_wait_until_bench_complete_raises_timeout_on_non_terminal(self) -> None:
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(2, 2, "Running")
+        training = DistributedTraining(client, "ud-bench-decouple")
+        with pytest.raises(TimeoutError):
+            training.wait_until_bench_complete(timeout=0)
+
+    def test_backward_compat_bench_accessor_still_returns_result_payload(self) -> None:
+        """Existing `training.bench -> Optional[BenchResult]` keeps working."""
+        client = MagicMock()
+        client.get.return_value = self._make_status_dict(
+            2, 2, "Succeeded", bench_result=True
+        )
+        training = DistributedTraining(client, "ud-bench-decouple")
+        r = training.bench
+        assert r is not None
+        assert r.busbw_gbps_p50 == 12.5
+        assert r.probe_node_a == "n-a"


### PR DESCRIPTION
## Why

Companion PR to [`one-covenant/basilica-backend#517`](https://github.com/one-covenant/basilica-backend/pull/517).

The operator landed an explicit `BenchPhase` lifecycle on
`status.distributed.bench` and codified that `worldSize.ready` depends
ONLY on worker readiness. This PR plumbs that contract through the SDK
so callers can observe bench independently and opt in to blocking on
it when they actually want the measurement.

The driving incident: the #510 -> #513 -> #514 cascade in the operator
cost three iterations because every bench init-container bug also
surfaced as a UD-readiness regression. The bench probe is documented as
best-effort sanity per `basilica_bench.py:75-78`; this PR matches the
SDK contract to that documented intent.

## Behavioral change

- New `BenchStatus` dataclass mirrors the operator's status surface:
  `mode`, `phase`, `result`, `started_at`, `completed_at`, `message`,
  `last_attempt_at`, `last_attempt_outcome`, plus `is_terminal`.
- New `BENCH_PHASE_*` string constants (`Skipped`, `Pending`, `Running`,
  `Succeeded`, `Failed`, `TimedOut`).
- New `training.bench_status -> Optional[BenchStatus]` accessor.
- New `training.wait_until_bench_complete(timeout=1500)` opt-in waiter
  (sync + async; default matches operator `BENCH_ACTIVE_DEADLINE_SECONDS`).
- `wait_until_min_world` is unchanged behaviorally; new tests codify
  it is worker-only across `bench.phase=Pending|Failed|TimedOut`.

## Backward compat

- Existing `training.bench -> Optional[BenchResult]` keeps working
  unchanged. Docs updated to point at `bench_status` for the full
  lifecycle.
- `BenchResult` shape unchanged.

## Test plan

- [x] `uv run pytest tests/test_distributed.py` passes (79 tests, +9 new)
- [x] Full SDK test suite: 97 passes / 14 pre-existing async failures
      unrelated to this PR (missing pytest-asyncio plugin)
- [ ] After operator PR #517 merges, smoke-test against the live cluster:
  - `training.bench_status.phase` reflects each lifecycle state
  - `training.wait_until_min_world(...)` returns when workers Ready
    even with bench Failed
  - `training.wait_until_bench_complete(...)` returns terminal status
    on a real bench probe completion

## New tests (`TestBenchPhaseDecoupling`)

- `test_wait_until_min_world_returns_when_workers_ready_bench_pending`
- `test_wait_until_min_world_returns_when_workers_ready_bench_failed`
- `test_wait_until_min_world_returns_when_workers_ready_bench_timed_out`
- `test_bench_status_reflects_each_lifecycle_state`
- `test_bench_status_returns_none_when_bench_off`
- `test_wait_until_bench_complete_returns_terminal_status`
- `test_wait_until_bench_complete_returns_none_when_bench_off`
- `test_wait_until_bench_complete_raises_timeout_on_non_terminal`
- `test_backward_compat_bench_accessor_still_returns_result_payload`

## Cross-link

Refs #506 (operator splits bench into its own sub-CRD).
Pairs with one-covenant/basilica-backend#517.

---

**HOLDING FOR HUMAN REVIEW - DO NOT MERGE.**

This PR depends on the operator publishing `bench.phase` /
`startedAt` / `completedAt` / `message` fields. Both PRs should be
reviewed together; merge order is operator first, then SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark phase constants for tracking distributed training probe lifecycle states
  * Introduced benchmark status tracking with lifecycle state visibility and terminal state detection
  * Added property to retrieve current benchmark status
  * Added polling methods to wait for benchmark completion with configurable timeout support

* **Documentation**
  * Updated benchmark accessor documentation to guide users to new lifecycle details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->