### PR TITLE
feat(sdk)!: deploy_distributed bench wait is now opt-in (refs path-B chain)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -33,7 +33,7 @@ import re
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from basilica._basilica import (
     DEFAULT_API_URL,
@@ -1122,6 +1122,8 @@ class BasilicaClient:
         ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
     ) -> DistributedTraining:
         """
         Deploy a distributed-training UserDeployment (SDK arch § 4).
@@ -1178,6 +1180,25 @@ class BasilicaClient:
             ttl_seconds: Auto-delete after N seconds.
             timeout: Seconds to wait for `min` ranks to be ready. Default 600.
             enable_billing: Whether to bill for this deployment. Default True.
+            wait_for_bench: How to handle the bench probe before returning.
+                Default `"never"`: return as soon as `wait_until_min_world`
+                succeeds; the bench probe runs in the background and the
+                caller can opt in via
+                :py:meth:`DistributedTraining.wait_until_bench_complete`.
+                `"best_effort"`: also call `wait_until_bench_complete`
+                after workers Ready, but never raise — log/print the
+                outcome and return. `"required"`: call
+                `wait_until_bench_complete` and re-raise on a non-Succeeded
+                terminal phase (`Failed` / `TimedOut`) or on timeout.
+                The default `"never"` is a BREAKING change from the prior
+                implicit "deploy waits on bench" behavior — chained bench
+                regressions made `deploy_distributed` look broken even
+                when workers were Ready. Bench remains best-effort per
+                `basilica_bench.py:75-78`.
+            bench_timeout: Seconds budget for `wait_for_bench` modes
+                `best_effort` / `required`. Default 1500 (matches the
+                operator's `BENCH_ACTIVE_DEADLINE_SECONDS`). Ignored when
+                `wait_for_bench="never"`.
 
         Returns:
             DistributedTraining: Facade with scale/wait/logs/bench/delete and
@@ -1189,9 +1210,19 @@ class BasilicaClient:
             QuotaExceeded: namespace rank budget exceeded.
             BelowMinimumWorld: `wait_until_min_world` timed out before `min`
                 ranks were ready.
+            DistributedError: `wait_for_bench="required"` and bench reached
+                `Failed` / `TimedOut` / `Skipped`, or the bench wait timed
+                out without a terminal phase.
         """
         if world_size is None:
             raise ValidationError("deploy_distributed requires world_size", field="world_size")
+        if wait_for_bench not in ("never", "best_effort", "required"):
+            raise ValidationError(
+                f"wait_for_bench must be 'never' | 'best_effort' | 'required', "
+                f"got {wait_for_bench!r}",
+                field="wait_for_bench",
+                value=wait_for_bench,
+            )
 
         request_dict = self._build_distributed_request(
             name=name,
@@ -1234,7 +1265,67 @@ class BasilicaClient:
             except Exception:
                 pass
             raise
+        # Issue B/N (refs #506): bench wait is OPT-IN. Default `"never"`
+        # returns as soon as workers are Ready; the bench probe is
+        # decoupled from UD readiness on the operator side, so blocking
+        # here would only re-couple it in the SDK. Callers that want the
+        # measurement use `wait_for_bench=` or
+        # `training.wait_until_bench_complete(...)` directly.
+        if wait_for_bench != "never":
+            self._handle_post_deploy_bench_wait(
+                training, mode=wait_for_bench, timeout=bench_timeout
+            )
         return training
+
+    @staticmethod
+    def _handle_post_deploy_bench_wait(
+        training: DistributedTraining,
+        mode: Literal["best_effort", "required"],
+        timeout: int,
+    ) -> None:
+        """
+        Issue B/N (refs #506): post-deploy bench-wait helper for
+        `wait_for_bench={best_effort, required}` modes.
+
+        - `best_effort`: call `wait_until_bench_complete` and swallow any
+          non-Succeeded outcome (including `TimeoutError`). Logs to stderr
+          via `warnings.warn` so users see the failure but the deploy
+          still returns the live `DistributedTraining`.
+        - `required`: call `wait_until_bench_complete`; raise
+          `DistributedError` on a non-Succeeded terminal phase or on
+          timeout. The UD is NOT auto-deleted — the workers are healthy
+          and the caller may still want to use them. Use `.delete()`
+          explicitly if the bench failure is grounds for tearing down.
+        """
+        try:
+            bs = training.wait_until_bench_complete(timeout=timeout)
+        except TimeoutError as e:
+            if mode == "required":
+                raise DistributedError(
+                    f"wait_for_bench='required' but bench did not "
+                    f"reach a terminal phase within {timeout}s: {e}"
+                ) from e
+            warnings.warn(
+                f"wait_for_bench='best_effort': bench did not "
+                f"reach a terminal phase within {timeout}s: {e}",
+                stacklevel=3,
+            )
+            return
+        # `bs is None` means bench.mode == off, i.e. caller passed
+        # `bench="off"` (or omitted it). Nothing to wait on.
+        if bs is None:
+            return
+        if bs.phase == BENCH_PHASE_SUCCEEDED:
+            return
+        msg = (
+            f"bench probe phase={bs.phase}"
+            f"{f' message={bs.message!r}' if bs.message else ''}"
+        )
+        if mode == "required":
+            raise DistributedError(
+                f"wait_for_bench='required' but {msg}"
+            )
+        warnings.warn(f"wait_for_bench='best_effort': {msg}", stacklevel=3)
 
     def _build_distributed_request(
         self,
@@ -2149,14 +2240,26 @@ class BasilicaClient:
         ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
     ) -> DistributedTraining:
         """
         Async variant of `deploy_distributed`. Same arguments and semantics
         per SDK arch § 9; uses `run_in_executor` over the underlying Rust
         client and `asyncio.sleep` for the wait loop.
+
+        See `deploy_distributed` for the `wait_for_bench` /
+        `bench_timeout` contract.
         """
         if world_size is None:
             raise ValidationError("deploy_distributed_async requires world_size", field="world_size")
+        if wait_for_bench not in ("never", "best_effort", "required"):
+            raise ValidationError(
+                f"wait_for_bench must be 'never' | 'best_effort' | 'required', "
+                f"got {wait_for_bench!r}",
+                field="wait_for_bench",
+                value=wait_for_bench,
+            )
 
         request_dict = self._build_distributed_request(
             name=name,
@@ -2199,7 +2302,46 @@ class BasilicaClient:
             except Exception:
                 pass
             raise
+        if wait_for_bench != "never":
+            await self._handle_post_deploy_bench_wait_async(
+                training, mode=wait_for_bench, timeout=bench_timeout
+            )
         return training
+
+    @staticmethod
+    async def _handle_post_deploy_bench_wait_async(
+        training: DistributedTraining,
+        mode: Literal["best_effort", "required"],
+        timeout: int,
+    ) -> None:
+        """Async variant of `_handle_post_deploy_bench_wait`."""
+        try:
+            bs = await training.wait_until_bench_complete_async(timeout=timeout)
+        except TimeoutError as e:
+            if mode == "required":
+                raise DistributedError(
+                    f"wait_for_bench='required' but bench did not "
+                    f"reach a terminal phase within {timeout}s: {e}"
+                ) from e
+            warnings.warn(
+                f"wait_for_bench='best_effort': bench did not "
+                f"reach a terminal phase within {timeout}s: {e}",
+                stacklevel=3,
+            )
+            return
+        if bs is None:
+            return
+        if bs.phase == BENCH_PHASE_SUCCEEDED:
+            return
+        msg = (
+            f"bench probe phase={bs.phase}"
+            f"{f' message={bs.message!r}' if bs.message else ''}"
+        )
+        if mode == "required":
+            raise DistributedError(
+                f"wait_for_bench='required' but {msg}"
+            )
+        warnings.warn(f"wait_for_bench='best_effort': {msg}", stacklevel=3)
 
     async def get_async(self, name: str) -> Deployment:
         """

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -357,6 +357,8 @@ def distributed(
     ttl_seconds: Optional[int] = 86400,
     timeout: int = 600,
     enable_billing: bool = True,
+    wait_for_bench: str = "never",
+    bench_timeout: int = 1500,
 ) -> Callable[[Callable], DistributedFunction]:
     """
     Decorator marking a function as the per-rank entrypoint for a
@@ -384,6 +386,11 @@ def distributed(
         ttl_seconds: Auto-delete after N seconds.
         timeout: Seconds to wait for `min` ranks to be ready. Default 600.
         enable_billing: Whether to bill for this deployment.
+        wait_for_bench: `"never"` (default) returns when workers Ready;
+            `"best_effort"` also waits for bench, swallowing failures;
+            `"required"` raises if bench is non-Succeeded. See
+            `BasilicaClient.deploy_distributed`.
+        bench_timeout: Seconds budget for the opt-in bench wait.
 
     Returns:
         DistributedFunction wrapper. Calling it deploys; `.local()` runs
@@ -440,6 +447,8 @@ def distributed(
         "ttl_seconds": ttl_seconds,
         "timeout": timeout,
         "enable_billing": enable_billing,
+        "wait_for_bench": wait_for_bench,
+        "bench_timeout": bench_timeout,
     }
 
     def decorator(func: Callable) -> DistributedFunction:

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -26,6 +26,7 @@ from basilica import (
     BasilicaClient,
     BelowMinimumWorld,
     BenchResult,
+    DistributedError,
     DistributedFunction,
     DistributedTraining,
     ProviderFilter,
@@ -33,6 +34,7 @@ from basilica import (
     RankExit,
     RankStatus,
     UDTerminalState,
+    ValidationError,
     WorldSize,
     WorldSizeOutOfBounds,
     WorldStatus,
@@ -2297,3 +2299,260 @@ class TestBenchPhaseDecoupling:
         assert r is not None
         assert r.busbw_gbps_p50 == 12.5
         assert r.probe_node_a == "n-a"
+
+
+# =============================================================================
+# Issue B/N (refs #506) follow-up: deploy_distributed default does NOT
+# wait for the bench probe; bench is opt-in via `wait_for_bench=` modes.
+#
+# Pre-this-change behaviour: deploy_distributed implicitly blocked on
+# bench (20-min budget). The chained #510-#515 bench init-container
+# regressions made `deploy_distributed` look failed even when workers
+# were Ready. New contract: deploy returns when workers Ready; bench
+# is observed via `training.wait_until_bench_complete()` or the
+# `wait_for_bench=` parameter.
+# =============================================================================
+
+
+def _ready_pyo3_response_with_bench(
+    bench_phase: str,
+    bench_result: bool = False,
+    bench_message: str = "",
+    instance_name: str = "dlc-bench-opt-in",
+    namespace: str = "u-test",
+) -> MagicMock:
+    """Workers Ready (2/2). Bench published with the supplied phase.
+
+    Built on the same PyO3-shape used by the issue #486 tests so the
+    BasilicaClient.deploy_distributed -> training.refresh path works
+    identically.
+    """
+    bench: Dict[str, Any] = {"mode": "on-start", "phase": bench_phase}
+    if bench_phase != "Pending":
+        bench["startedAt"] = "2026-05-08T12:00:00Z"
+    if bench_phase in {"Succeeded", "Failed", "TimedOut"}:
+        bench["completedAt"] = "2026-05-08T12:10:00Z"
+    if bench_message:
+        bench["message"] = bench_message
+    if bench_result and bench_phase == "Succeeded":
+        bench["result"] = {
+            "measuredAt": "2026-05-08T12:10:00Z",
+            "busbwGbpsP50": 42.0,
+            "sizeBytesSwept": [1048576],
+            "probeNodeA": "n-a",
+            "probeNodeB": "n-b",
+        }
+    return _pyo3_response(
+        instance_name,
+        namespace,
+        {
+            "worldSize": {
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 2,
+                "belowMinimum": False,
+            },
+            "ranks": [],
+            "bench": bench,
+        },
+    )
+
+
+class TestDeployDistributedDefaultDoesNotWaitForBench:
+    """Refs #506: `deploy_distributed` default `wait_for_bench='never'`
+    must return as soon as `wait_until_min_world` succeeds; it must NOT
+    block on bench probe completion."""
+
+    def test_default_returns_with_bench_pending(self) -> None:
+        """LOAD-BEARING: workers Ready + bench Pending -> default deploy
+        returns; `training.bench_status.phase == 'Pending'`."""
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Pending")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-default-bench-pending",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+        )
+
+        # Deploy succeeded; bench is observably still Pending. The SDK
+        # did NOT block on bench (otherwise the default 20-min budget
+        # would have either succeeded or thrown TimeoutError -- with
+        # the mock, "Pending" never advances).
+        assert training.name == response.instance_name
+        bs = training.bench_status
+        assert bs is not None
+        assert bs.phase == "Pending"
+        assert not bs.is_terminal
+        client._client.delete_deployment.assert_not_called()
+
+    def test_default_returns_with_bench_failed(self) -> None:
+        """The whole point of the change: bench Failed must not make
+        the deploy look failed when workers are Ready."""
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Failed")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-default-bench-failed",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench_status is not None
+        assert training.bench_status.phase == "Failed"
+        # The UD was NOT auto-deleted just because the bench failed.
+        client._client.delete_deployment.assert_not_called()
+
+    def test_default_invalid_wait_for_bench_value_rejected(self) -> None:
+        """Typo defense: only the three documented modes are accepted."""
+        client = _build_minimal_client()
+        with pytest.raises(ValidationError):
+            client.deploy_distributed(
+                name="dlc",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                wait_for_bench="best-effort",  # hyphen, not underscore
+                timeout=0,
+            )
+
+
+class TestDeployDistributedWaitForBenchBestEffort:
+    """`wait_for_bench='best_effort'`: also wait for bench, but never
+    raise on a non-Succeeded outcome."""
+
+    def test_best_effort_returns_on_bench_failed_without_raising(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench(
+            "Failed", bench_message="bench worker pod OOMKilled"
+        )
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.warns(UserWarning, match="best_effort"):
+            training = client.deploy_distributed(
+                name="dlc-best-effort-failed",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="best_effort",
+                bench_timeout=10,
+            )
+
+        assert training.name == response.instance_name
+        client._client.delete_deployment.assert_not_called()
+
+    def test_best_effort_returns_on_bench_succeeded(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Succeeded", bench_result=True)
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-best-effort-success",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+            wait_for_bench="best_effort",
+            bench_timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench is not None
+        assert training.bench.busbw_gbps_p50 == 42.0
+
+
+class TestDeployDistributedWaitForBenchRequired:
+    """`wait_for_bench='required'`: raise on a non-Succeeded outcome."""
+
+    def test_required_raises_on_bench_failed(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench(
+            "Failed", bench_message="OOMKilled"
+        )
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="phase=Failed"):
+            client.deploy_distributed(
+                name="dlc-required-failed",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=10,
+            )
+        # The UD itself is still up: required mode does not auto-delete
+        # because the workers are healthy. The caller decides.
+        client._client.delete_deployment.assert_not_called()
+
+    def test_required_raises_on_bench_timed_out(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("TimedOut")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="phase=TimedOut"):
+            client.deploy_distributed(
+                name="dlc-required-timedout",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=10,
+            )
+
+    def test_required_raises_on_wait_timeout(self) -> None:
+        """When bench never reaches a terminal phase within
+        `bench_timeout`, required mode wraps the inner TimeoutError
+        in DistributedError."""
+        client = _build_minimal_client()
+        # Bench stays Pending -> wait_until_bench_complete will hit
+        # its own TimeoutError, which the helper re-raises as
+        # DistributedError.
+        response = _ready_pyo3_response_with_bench("Pending")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="terminal phase"):
+            client.deploy_distributed(
+                name="dlc-required-timeout",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=0,
+            )
+
+    def test_required_succeeds_on_bench_succeeded(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Succeeded", bench_result=True)
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-required-success",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+            wait_for_bench="required",
+            bench_timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench is not None

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -119,6 +119,26 @@ if __name__ == "__main__":
     print(f"Rendezvous: {training.rendezvous_endpoint}")
     print(f"World: {training.world}")
 
+    # Refs #506: bench probe wait is OPT-IN. The deploy returned as soon
+    # as workers were Ready; here we explicitly block on the bench probe
+    # so the example still demonstrates measuring NCCL bandwidth.
+    # A bench failure no longer makes the whole run look failed.
+    print("Waiting for bench probe (opt-in)...")
+    bench_status = training.wait_until_bench_complete(timeout=1200)
+    if bench_status is None:
+        print("Bench was not enabled on this UD.")
+    elif bench_status.phase == "Succeeded" and training.bench is not None:
+        r = training.bench
+        print(
+            f"Bench result: busbw_gbps_p50={r.busbw_gbps_p50} "
+            f"latency_us_at_1mib={r.latency_us_at_1mib}"
+        )
+    else:
+        print(
+            f"Bench did NOT complete with a measurement: "
+            f"phase={bench_status.phase} message={bench_status.message}"
+        )
+
     # Wait for the run to finish (heuristic: poll until ranks all exit
     # 'Running' state, or 30 minutes elapsed -- whichever first).
     deadline = time.time() + 1800

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -17,6 +17,13 @@ There is intentionally NO `client.preflight(...)` and NO
 `client.nccl_baseline(...)` standalone helper. That surface implied a
 shared cache. Use this per-UD pattern instead.
 
+Bench wait is OPT-IN (refs #506): `deploy_distributed` returns as soon
+as workers are Ready, regardless of bench probe state. This script
+demonstrates the opt-in pattern via
+`training.wait_until_bench_complete(...)`. A bench failure no longer
+makes the deploy look failed -- the workers are healthy and you can
+choose what to do with the measurement (or its absence).
+
 Prereqs:
 - BASILICA_API_TOKEN set.
 - Account with verda A100 access (or adjust the provider filter).
@@ -24,7 +31,6 @@ Prereqs:
 """
 
 import json
-import time
 
 from basilica import BasilicaClient, ProviderFilter, WorldSize
 
@@ -105,23 +111,43 @@ if __name__ == "__main__":
     print(f"Deployed: {training.name}")
     print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
 
-    # Poll for the probe to complete. The probe runs ~5 minutes
-    # (all_reduce_perf sweep) plus scheduling overhead. The bench Job
-    # has `activeDeadlineSeconds=900` (architecture doc § 11.1).
-    deadline = time.time() + 1200
-    while time.time() < deadline:
-        training.refresh()
-        if training.bench is not None:
-            break
-        time.sleep(20)
+    # Refs #506: deploy_distributed now returns when workers are Ready;
+    # the bench probe is decoupled. Use the opt-in waiter to block on it.
+    # `bench_timeout=1200` (20 min) matches the prior implicit budget.
+    print("Waiting for bench probe (opt-in via wait_until_bench_complete)...")
+    bench_status = training.wait_until_bench_complete(timeout=1200)
 
-    if training.bench is None:
-        print("Bench probe did not complete within 20 minutes.")
-        print("Check `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+    if bench_status is None:
+        # mode=off — caller did not request a bench probe. Not reachable
+        # in this example (we set bench="on-start" above), but kept for
+        # symmetry with the API contract.
+        print("Bench was not enabled on this UD.")
         training.delete()
         raise SystemExit(1)
 
+    if bench_status.phase != "Succeeded":
+        # Workers were Ready -- the deploy is fine -- but the bench
+        # didn't measure. Print the lifecycle detail; do NOT exit non-zero
+        # for a bench-only failure (the workload itself is healthy).
+        print("Bench probe did NOT complete with a measurement.")
+        print(f"  phase:              {bench_status.phase}")
+        print(f"  message:            {bench_status.message}")
+        print(f"  last_attempt_at:    {bench_status.last_attempt_at}")
+        print(f"  last_attempt:       {bench_status.last_attempt_outcome}")
+        print("Workers are still Ready; the UD itself is healthy.")
+        print("Inspect via `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+        training.delete()
+        return
+
+    # bench_status.phase == "Succeeded"; the result payload is on
+    # `training.bench` (or `bench_status.result`).
     result = training.bench
+    if result is None:
+        # Defensive: phase=Succeeded but no result payload -- this would
+        # be an operator-side invariant break. Surface it explicitly.
+        print("Bench phase=Succeeded but no result payload available.")
+        training.delete()
+        raise SystemExit(1)
     print("--- Bench result ---")
     print(f"  measured_at:        {result.measured_at}")
     print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")


### PR DESCRIPTION
## Why

Today's bench-init-container chain (#510 -> #513 -> #514 -> #515) made
`deploy_distributed` look broken even when workers were Ready. The
SDK's implicit "wait for bench" coupling re-introduces, in Python, the
exact coupling the operator's worker-only `world.ready` contract was
designed to break.

This PR flips `deploy_distributed`'s default: it now returns as soon as
`wait_until_min_world` succeeds. The bench probe still runs (scheduled
by `bench="on-start"`); callers who want the measurement opt in via
`training.wait_until_bench_complete(...)` or the new `wait_for_bench=`
parameter.

This makes the opt-in waiter shipped in #465 actually useful -- before
this change, bench was already implicitly waited on, so the new opt-in
API was redundant.

## New contract

`deploy_distributed` returns when workers Ready. Bench is observed via:

1. `training.wait_until_bench_complete(timeout=...)` (sync) /
   `training.wait_until_bench_complete_async(timeout=...)` (async),
   added by #465.
2. `wait_for_bench=` parameter on `deploy_distributed`.

## Backward-compat strategy: parameter with three modes

`wait_for_bench: Literal["never", "best_effort", "required"] = "never"`

| Mode | Behaviour |
|---|---|
| `never` (default) | Return after `wait_until_min_world`. Bench is opt-in. |
| `best_effort` | Also call `wait_until_bench_complete` after workers Ready; warn on non-Succeeded but never raise. |
| `required` | Call `wait_until_bench_complete`; raise `DistributedError` on Failed/TimedOut/wait-timeout. |

`bench_timeout: int = 1500` controls the budget for the two non-default
modes; matches the operator's `BENCH_ACTIVE_DEADLINE_SECONDS`.

The decorator (`@basilica.distributed`) gains the same two parameters
so decorator-style callers can opt in too.

This is a **breaking change** for callers that depend on the implicit
bench wait. The `wait_for_bench` parameter is the explicit migration
path; setting `wait_for_bench=\"required\"` reproduces (close to) the
prior default semantics.

## Example updates

- `examples/22_distributed_with_bench.py`: replaces the in-script
  polling loop with `training.wait_until_bench_complete(timeout=1200)`
  and prints the result. A bench failure no longer makes the example
  exit non-zero -- workers are healthy, deploy succeeded.
- `examples/20_distributed_diloco.py` (decorator path with
  `bench=\"on-start\"`): same pattern.
- `examples/21_distributed_torchrun.py`: untouched -- it doesn't
  schedule a bench probe.

## Test plan

- [x] `uv run pytest tests/test_distributed.py` -> 88/88 (was 79; +9 new)
- [x] Pre-existing 14 async failures in `test_async_methods.py` are
  unaffected (missing pytest-asyncio plugin; same as the parent PR).
- [ ] Smoke-test against the live cluster post-merge:
  - Default deploy returns when workers Ready, bench Pending in
    background, `training.bench_status.phase == \"Pending\"`.
  - `wait_for_bench=\"best_effort\"` warns on bench Failed but returns.
  - `wait_for_bench=\"required\"` raises `DistributedError` on bench Failed.

## New tests (test_distributed.py)

`TestDeployDistributedDefaultDoesNotWaitForBench`:
- `test_default_returns_with_bench_pending` -- regression guard:
  default deploy returns with `bench.phase=Pending`, no auto-delete.
- `test_default_returns_with_bench_failed` -- the load-bearing
  assertion: bench Failed must not make the deploy look failed.
- `test_default_invalid_wait_for_bench_value_rejected`.

`TestDeployDistributedWaitForBenchBestEffort`:
- `test_best_effort_returns_on_bench_failed_without_raising` (warns).
- `test_best_effort_returns_on_bench_succeeded`.

`TestDeployDistributedWaitForBenchRequired`:
- `test_required_raises_on_bench_failed`.
- `test_required_raises_on_bench_timed_out`.
- `test_required_raises_on_wait_timeout`.
- `test_required_succeeds_on_bench_succeeded`.

## Cross-links

- Predecessor: #465 (path-B SDK -- adds `BenchStatus` + opt-in waiter).
  This PR is **stacked on** #465 (base branch =
  `feat/sdk-bench-non-blocking-decouple-506-prep`); merge order is
  #465 first, then this.
- Refs #506 (operator splits bench into its own sub-CRD).
- Pairs with one-covenant/basilica-backend#517 (operator-side
  worker-only `world.ready`).

## Out of scope

- Operator-side changes (worker-only `world.ready` already shipped in #517).
- `basilica_bench.py` is unchanged.
- Bench-as-sub-CRD (#506) -- this PR keeps bench under `status.distributed.bench`.

---

**HOLDING FOR HUMAN REVIEW - DO NOT MERGE.**

Depends on #465 -- the base branch is the path-B SDK branch, not main.
After #465 merges, rebase this onto main.