### PR TITLE
feat(sdk)!: deploy_distributed bench wait is now opt-in (re-opened after auto-close on basilica#466)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -33,7 +33,7 @@ import re
 import time
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from basilica._basilica import (
     DEFAULT_API_URL,
@@ -1122,6 +1122,8 @@ class BasilicaClient:
         ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
     ) -> DistributedTraining:
         """
         Deploy a distributed-training UserDeployment (SDK arch § 4).
@@ -1178,6 +1180,25 @@ class BasilicaClient:
             ttl_seconds: Auto-delete after N seconds.
             timeout: Seconds to wait for `min` ranks to be ready. Default 600.
             enable_billing: Whether to bill for this deployment. Default True.
+            wait_for_bench: How to handle the bench probe before returning.
+                Default `"never"`: return as soon as `wait_until_min_world`
+                succeeds; the bench probe runs in the background and the
+                caller can opt in via
+                :py:meth:`DistributedTraining.wait_until_bench_complete`.
+                `"best_effort"`: also call `wait_until_bench_complete`
+                after workers Ready, but never raise — log/print the
+                outcome and return. `"required"`: call
+                `wait_until_bench_complete` and re-raise on a non-Succeeded
+                terminal phase (`Failed` / `TimedOut`) or on timeout.
+                The default `"never"` is a BREAKING change from the prior
+                implicit "deploy waits on bench" behavior — chained bench
+                regressions made `deploy_distributed` look broken even
+                when workers were Ready. Bench remains best-effort per
+                `basilica_bench.py:75-78`.
+            bench_timeout: Seconds budget for `wait_for_bench` modes
+                `best_effort` / `required`. Default 1500 (matches the
+                operator's `BENCH_ACTIVE_DEADLINE_SECONDS`). Ignored when
+                `wait_for_bench="never"`.
 
         Returns:
             DistributedTraining: Facade with scale/wait/logs/bench/delete and
@@ -1189,9 +1210,19 @@ class BasilicaClient:
             QuotaExceeded: namespace rank budget exceeded.
             BelowMinimumWorld: `wait_until_min_world` timed out before `min`
                 ranks were ready.
+            DistributedError: `wait_for_bench="required"` and bench reached
+                `Failed` / `TimedOut` / `Skipped`, or the bench wait timed
+                out without a terminal phase.
         """
         if world_size is None:
             raise ValidationError("deploy_distributed requires world_size", field="world_size")
+        if wait_for_bench not in ("never", "best_effort", "required"):
+            raise ValidationError(
+                f"wait_for_bench must be 'never' | 'best_effort' | 'required', "
+                f"got {wait_for_bench!r}",
+                field="wait_for_bench",
+                value=wait_for_bench,
+            )
 
         request_dict = self._build_distributed_request(
             name=name,
@@ -1234,7 +1265,67 @@ class BasilicaClient:
             except Exception:
                 pass
             raise
+        # Issue B/N (refs #506): bench wait is OPT-IN. Default `"never"`
+        # returns as soon as workers are Ready; the bench probe is
+        # decoupled from UD readiness on the operator side, so blocking
+        # here would only re-couple it in the SDK. Callers that want the
+        # measurement use `wait_for_bench=` or
+        # `training.wait_until_bench_complete(...)` directly.
+        if wait_for_bench != "never":
+            self._handle_post_deploy_bench_wait(
+                training, mode=wait_for_bench, timeout=bench_timeout
+            )
         return training
+
+    @staticmethod
+    def _handle_post_deploy_bench_wait(
+        training: DistributedTraining,
+        mode: Literal["best_effort", "required"],
+        timeout: int,
+    ) -> None:
+        """
+        Issue B/N (refs #506): post-deploy bench-wait helper for
+        `wait_for_bench={best_effort, required}` modes.
+
+        - `best_effort`: call `wait_until_bench_complete` and swallow any
+          non-Succeeded outcome (including `TimeoutError`). Logs to stderr
+          via `warnings.warn` so users see the failure but the deploy
+          still returns the live `DistributedTraining`.
+        - `required`: call `wait_until_bench_complete`; raise
+          `DistributedError` on a non-Succeeded terminal phase or on
+          timeout. The UD is NOT auto-deleted — the workers are healthy
+          and the caller may still want to use them. Use `.delete()`
+          explicitly if the bench failure is grounds for tearing down.
+        """
+        try:
+            bs = training.wait_until_bench_complete(timeout=timeout)
+        except TimeoutError as e:
+            if mode == "required":
+                raise DistributedError(
+                    f"wait_for_bench='required' but bench did not "
+                    f"reach a terminal phase within {timeout}s: {e}"
+                ) from e
+            warnings.warn(
+                f"wait_for_bench='best_effort': bench did not "
+                f"reach a terminal phase within {timeout}s: {e}",
+                stacklevel=3,
+            )
+            return
+        # `bs is None` means bench.mode == off, i.e. caller passed
+        # `bench="off"` (or omitted it). Nothing to wait on.
+        if bs is None:
+            return
+        if bs.phase == BENCH_PHASE_SUCCEEDED:
+            return
+        msg = (
+            f"bench probe phase={bs.phase}"
+            f"{f' message={bs.message!r}' if bs.message else ''}"
+        )
+        if mode == "required":
+            raise DistributedError(
+                f"wait_for_bench='required' but {msg}"
+            )
+        warnings.warn(f"wait_for_bench='best_effort': {msg}", stacklevel=3)
 
     def _build_distributed_request(
         self,
@@ -2149,14 +2240,26 @@ class BasilicaClient:
         ttl_seconds: Optional[int] = 86400,
         timeout: int = 600,
         enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
     ) -> DistributedTraining:
         """
         Async variant of `deploy_distributed`. Same arguments and semantics
         per SDK arch § 9; uses `run_in_executor` over the underlying Rust
         client and `asyncio.sleep` for the wait loop.
+
+        See `deploy_distributed` for the `wait_for_bench` /
+        `bench_timeout` contract.
         """
         if world_size is None:
             raise ValidationError("deploy_distributed_async requires world_size", field="world_size")
+        if wait_for_bench not in ("never", "best_effort", "required"):
+            raise ValidationError(
+                f"wait_for_bench must be 'never' | 'best_effort' | 'required', "
+                f"got {wait_for_bench!r}",
+                field="wait_for_bench",
+                value=wait_for_bench,
+            )
 
         request_dict = self._build_distributed_request(
             name=name,
@@ -2199,7 +2302,46 @@ class BasilicaClient:
             except Exception:
                 pass
             raise
+        if wait_for_bench != "never":
+            await self._handle_post_deploy_bench_wait_async(
+                training, mode=wait_for_bench, timeout=bench_timeout
+            )
         return training
+
+    @staticmethod
+    async def _handle_post_deploy_bench_wait_async(
+        training: DistributedTraining,
+        mode: Literal["best_effort", "required"],
+        timeout: int,
+    ) -> None:
+        """Async variant of `_handle_post_deploy_bench_wait`."""
+        try:
+            bs = await training.wait_until_bench_complete_async(timeout=timeout)
+        except TimeoutError as e:
+            if mode == "required":
+                raise DistributedError(
+                    f"wait_for_bench='required' but bench did not "
+                    f"reach a terminal phase within {timeout}s: {e}"
+                ) from e
+            warnings.warn(
+                f"wait_for_bench='best_effort': bench did not "
+                f"reach a terminal phase within {timeout}s: {e}",
+                stacklevel=3,
+            )
+            return
+        if bs is None:
+            return
+        if bs.phase == BENCH_PHASE_SUCCEEDED:
+            return
+        msg = (
+            f"bench probe phase={bs.phase}"
+            f"{f' message={bs.message!r}' if bs.message else ''}"
+        )
+        if mode == "required":
+            raise DistributedError(
+                f"wait_for_bench='required' but {msg}"
+            )
+        warnings.warn(f"wait_for_bench='best_effort': {msg}", stacklevel=3)
 
     async def get_async(self, name: str) -> Deployment:
         """

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -357,6 +357,8 @@ def distributed(
     ttl_seconds: Optional[int] = 86400,
     timeout: int = 600,
     enable_billing: bool = True,
+    wait_for_bench: str = "never",
+    bench_timeout: int = 1500,
 ) -> Callable[[Callable], DistributedFunction]:
     """
     Decorator marking a function as the per-rank entrypoint for a
@@ -384,6 +386,11 @@ def distributed(
         ttl_seconds: Auto-delete after N seconds.
         timeout: Seconds to wait for `min` ranks to be ready. Default 600.
         enable_billing: Whether to bill for this deployment.
+        wait_for_bench: `"never"` (default) returns when workers Ready;
+            `"best_effort"` also waits for bench, swallowing failures;
+            `"required"` raises if bench is non-Succeeded. See
+            `BasilicaClient.deploy_distributed`.
+        bench_timeout: Seconds budget for the opt-in bench wait.
 
     Returns:
         DistributedFunction wrapper. Calling it deploys; `.local()` runs
@@ -440,6 +447,8 @@ def distributed(
         "ttl_seconds": ttl_seconds,
         "timeout": timeout,
         "enable_billing": enable_billing,
+        "wait_for_bench": wait_for_bench,
+        "bench_timeout": bench_timeout,
     }
 
     def decorator(func: Callable) -> DistributedFunction:

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -26,6 +26,7 @@ from basilica import (
     BasilicaClient,
     BelowMinimumWorld,
     BenchResult,
+    DistributedError,
     DistributedFunction,
     DistributedTraining,
     ProviderFilter,
@@ -33,6 +34,7 @@ from basilica import (
     RankExit,
     RankStatus,
     UDTerminalState,
+    ValidationError,
     WorldSize,
     WorldSizeOutOfBounds,
     WorldStatus,
@@ -2297,3 +2299,260 @@ class TestBenchPhaseDecoupling:
         assert r is not None
         assert r.busbw_gbps_p50 == 12.5
         assert r.probe_node_a == "n-a"
+
+
+# =============================================================================
+# Issue B/N (refs #506) follow-up: deploy_distributed default does NOT
+# wait for the bench probe; bench is opt-in via `wait_for_bench=` modes.
+#
+# Pre-this-change behaviour: deploy_distributed implicitly blocked on
+# bench (20-min budget). The chained #510-#515 bench init-container
+# regressions made `deploy_distributed` look failed even when workers
+# were Ready. New contract: deploy returns when workers Ready; bench
+# is observed via `training.wait_until_bench_complete()` or the
+# `wait_for_bench=` parameter.
+# =============================================================================
+
+
+def _ready_pyo3_response_with_bench(
+    bench_phase: str,
+    bench_result: bool = False,
+    bench_message: str = "",
+    instance_name: str = "dlc-bench-opt-in",
+    namespace: str = "u-test",
+) -> MagicMock:
+    """Workers Ready (2/2). Bench published with the supplied phase.
+
+    Built on the same PyO3-shape used by the issue #486 tests so the
+    BasilicaClient.deploy_distributed -> training.refresh path works
+    identically.
+    """
+    bench: Dict[str, Any] = {"mode": "on-start", "phase": bench_phase}
+    if bench_phase != "Pending":
+        bench["startedAt"] = "2026-05-08T12:00:00Z"
+    if bench_phase in {"Succeeded", "Failed", "TimedOut"}:
+        bench["completedAt"] = "2026-05-08T12:10:00Z"
+    if bench_message:
+        bench["message"] = bench_message
+    if bench_result and bench_phase == "Succeeded":
+        bench["result"] = {
+            "measuredAt": "2026-05-08T12:10:00Z",
+            "busbwGbpsP50": 42.0,
+            "sizeBytesSwept": [1048576],
+            "probeNodeA": "n-a",
+            "probeNodeB": "n-b",
+        }
+    return _pyo3_response(
+        instance_name,
+        namespace,
+        {
+            "worldSize": {
+                "ready": 2,
+                "target": 2,
+                "min": 2,
+                "max": 2,
+                "belowMinimum": False,
+            },
+            "ranks": [],
+            "bench": bench,
+        },
+    )
+
+
+class TestDeployDistributedDefaultDoesNotWaitForBench:
+    """Refs #506: `deploy_distributed` default `wait_for_bench='never'`
+    must return as soon as `wait_until_min_world` succeeds; it must NOT
+    block on bench probe completion."""
+
+    def test_default_returns_with_bench_pending(self) -> None:
+        """LOAD-BEARING: workers Ready + bench Pending -> default deploy
+        returns; `training.bench_status.phase == 'Pending'`."""
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Pending")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-default-bench-pending",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+        )
+
+        # Deploy succeeded; bench is observably still Pending. The SDK
+        # did NOT block on bench (otherwise the default 20-min budget
+        # would have either succeeded or thrown TimeoutError -- with
+        # the mock, "Pending" never advances).
+        assert training.name == response.instance_name
+        bs = training.bench_status
+        assert bs is not None
+        assert bs.phase == "Pending"
+        assert not bs.is_terminal
+        client._client.delete_deployment.assert_not_called()
+
+    def test_default_returns_with_bench_failed(self) -> None:
+        """The whole point of the change: bench Failed must not make
+        the deploy look failed when workers are Ready."""
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Failed")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-default-bench-failed",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench_status is not None
+        assert training.bench_status.phase == "Failed"
+        # The UD was NOT auto-deleted just because the bench failed.
+        client._client.delete_deployment.assert_not_called()
+
+    def test_default_invalid_wait_for_bench_value_rejected(self) -> None:
+        """Typo defense: only the three documented modes are accepted."""
+        client = _build_minimal_client()
+        with pytest.raises(ValidationError):
+            client.deploy_distributed(
+                name="dlc",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                wait_for_bench="best-effort",  # hyphen, not underscore
+                timeout=0,
+            )
+
+
+class TestDeployDistributedWaitForBenchBestEffort:
+    """`wait_for_bench='best_effort'`: also wait for bench, but never
+    raise on a non-Succeeded outcome."""
+
+    def test_best_effort_returns_on_bench_failed_without_raising(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench(
+            "Failed", bench_message="bench worker pod OOMKilled"
+        )
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.warns(UserWarning, match="best_effort"):
+            training = client.deploy_distributed(
+                name="dlc-best-effort-failed",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="best_effort",
+                bench_timeout=10,
+            )
+
+        assert training.name == response.instance_name
+        client._client.delete_deployment.assert_not_called()
+
+    def test_best_effort_returns_on_bench_succeeded(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Succeeded", bench_result=True)
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-best-effort-success",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+            wait_for_bench="best_effort",
+            bench_timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench is not None
+        assert training.bench.busbw_gbps_p50 == 42.0
+
+
+class TestDeployDistributedWaitForBenchRequired:
+    """`wait_for_bench='required'`: raise on a non-Succeeded outcome."""
+
+    def test_required_raises_on_bench_failed(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench(
+            "Failed", bench_message="OOMKilled"
+        )
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="phase=Failed"):
+            client.deploy_distributed(
+                name="dlc-required-failed",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=10,
+            )
+        # The UD itself is still up: required mode does not auto-delete
+        # because the workers are healthy. The caller decides.
+        client._client.delete_deployment.assert_not_called()
+
+    def test_required_raises_on_bench_timed_out(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("TimedOut")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="phase=TimedOut"):
+            client.deploy_distributed(
+                name="dlc-required-timedout",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=10,
+            )
+
+    def test_required_raises_on_wait_timeout(self) -> None:
+        """When bench never reaches a terminal phase within
+        `bench_timeout`, required mode wraps the inner TimeoutError
+        in DistributedError."""
+        client = _build_minimal_client()
+        # Bench stays Pending -> wait_until_bench_complete will hit
+        # its own TimeoutError, which the helper re-raises as
+        # DistributedError.
+        response = _ready_pyo3_response_with_bench("Pending")
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        with pytest.raises(DistributedError, match="terminal phase"):
+            client.deploy_distributed(
+                name="dlc-required-timeout",
+                source="print('x')\n",
+                world_size=WorldSize(min=2, target=2, max=2),
+                bench="on-start",
+                timeout=10,
+                wait_for_bench="required",
+                bench_timeout=0,
+            )
+
+    def test_required_succeeds_on_bench_succeeded(self) -> None:
+        client = _build_minimal_client()
+        response = _ready_pyo3_response_with_bench("Succeeded", bench_result=True)
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+
+        training = client.deploy_distributed(
+            name="dlc-required-success",
+            source="print('x')\n",
+            world_size=WorldSize(min=2, target=2, max=2),
+            bench="on-start",
+            timeout=10,
+            wait_for_bench="required",
+            bench_timeout=10,
+        )
+
+        assert training.name == response.instance_name
+        assert training.bench is not None

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -119,6 +119,26 @@ if __name__ == "__main__":
     print(f"Rendezvous: {training.rendezvous_endpoint}")
     print(f"World: {training.world}")
 
+    # Refs #506: bench probe wait is OPT-IN. The deploy returned as soon
+    # as workers were Ready; here we explicitly block on the bench probe
+    # so the example still demonstrates measuring NCCL bandwidth.
+    # A bench failure no longer makes the whole run look failed.
+    print("Waiting for bench probe (opt-in)...")
+    bench_status = training.wait_until_bench_complete(timeout=1200)
+    if bench_status is None:
+        print("Bench was not enabled on this UD.")
+    elif bench_status.phase == "Succeeded" and training.bench is not None:
+        r = training.bench
+        print(
+            f"Bench result: busbw_gbps_p50={r.busbw_gbps_p50} "
+            f"latency_us_at_1mib={r.latency_us_at_1mib}"
+        )
+    else:
+        print(
+            f"Bench did NOT complete with a measurement: "
+            f"phase={bench_status.phase} message={bench_status.message}"
+        )
+
     # Wait for the run to finish (heuristic: poll until ranks all exit
     # 'Running' state, or 30 minutes elapsed -- whichever first).
     deadline = time.time() + 1800

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -17,6 +17,13 @@ There is intentionally NO `client.preflight(...)` and NO
 `client.nccl_baseline(...)` standalone helper. That surface implied a
 shared cache. Use this per-UD pattern instead.
 
+Bench wait is OPT-IN (refs #506): `deploy_distributed` returns as soon
+as workers are Ready, regardless of bench probe state. This script
+demonstrates the opt-in pattern via
+`training.wait_until_bench_complete(...)`. A bench failure no longer
+makes the deploy look failed -- the workers are healthy and you can
+choose what to do with the measurement (or its absence).
+
 Prereqs:
 - BASILICA_API_TOKEN set.
 - Account with verda A100 access (or adjust the provider filter).
@@ -24,7 +31,6 @@ Prereqs:
 """
 
 import json
-import time
 
 from basilica import BasilicaClient, ProviderFilter, WorldSize
 
@@ -105,23 +111,43 @@ if __name__ == "__main__":
     print(f"Deployed: {training.name}")
     print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
 
-    # Poll for the probe to complete. The probe runs ~5 minutes
-    # (all_reduce_perf sweep) plus scheduling overhead. The bench Job
-    # has `activeDeadlineSeconds=900` (architecture doc § 11.1).
-    deadline = time.time() + 1200
-    while time.time() < deadline:
-        training.refresh()
-        if training.bench is not None:
-            break
-        time.sleep(20)
+    # Refs #506: deploy_distributed now returns when workers are Ready;
+    # the bench probe is decoupled. Use the opt-in waiter to block on it.
+    # `bench_timeout=1200` (20 min) matches the prior implicit budget.
+    print("Waiting for bench probe (opt-in via wait_until_bench_complete)...")
+    bench_status = training.wait_until_bench_complete(timeout=1200)
 
-    if training.bench is None:
-        print("Bench probe did not complete within 20 minutes.")
-        print("Check `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+    if bench_status is None:
+        # mode=off — caller did not request a bench probe. Not reachable
+        # in this example (we set bench="on-start" above), but kept for
+        # symmetry with the API contract.
+        print("Bench was not enabled on this UD.")
         training.delete()
         raise SystemExit(1)
 
+    if bench_status.phase != "Succeeded":
+        # Workers were Ready -- the deploy is fine -- but the bench
+        # didn't measure. Print the lifecycle detail; do NOT exit non-zero
+        # for a bench-only failure (the workload itself is healthy).
+        print("Bench probe did NOT complete with a measurement.")
+        print(f"  phase:              {bench_status.phase}")
+        print(f"  message:            {bench_status.message}")
+        print(f"  last_attempt_at:    {bench_status.last_attempt_at}")
+        print(f"  last_attempt:       {bench_status.last_attempt_outcome}")
+        print("Workers are still Ready; the UD itself is healthy.")
+        print("Inspect via `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+        training.delete()
+        return
+
+    # bench_status.phase == "Succeeded"; the result payload is on
+    # `training.bench` (or `bench_status.result`).
     result = training.bench
+    if result is None:
+        # Defensive: phase=Succeeded but no result payload -- this would
+        # be an operator-side invariant break. Surface it explicitly.
+        print("Bench phase=Succeeded but no result payload available.")
+        training.delete()
+        raise SystemExit(1)
     print("--- Bench result ---")
     print(f"  measured_at:        {result.measured_at}")
     print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")


### PR DESCRIPTION
Re-opened version of basilica#466 (auto-closed when its base branch `feat/sdk-bench-non-blocking-decouple-506-prep` was deleted on basilica#465 merge).

Same content as basilica#466 — adds `wait_for_bench: never|best_effort|required` parameter to `deploy_distributed()`, modernizes ex22 + ex20 examples to use `training.wait_until_bench_complete()` opt-in pattern.

basilica#465 (predecessor) merged at 18:07Z. This PR's branch was authored against that base; needs rebase on main if conflicts.

Holding for human review — do NOT merge.