### PR TITLE
fix(sdk): pass bench lifecycle fields through DistributedBenchStatus (#521)

### DIFF
--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1449,6 +1449,16 @@ pub struct DistributedRankExit {
 #[serde(rename_all = "camelCase")]
 pub struct DistributedBenchStatus {
     pub mode: DistributedBenchMode,
+    /// PR #517 lifecycle phase: `Skipped | Pending | Running | Succeeded | Failed | TimedOut`.
+    /// Read by the SDK's `wait_until_bench_complete` opt-in waiter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<DistributedBenchResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2766,6 +2776,10 @@ mod tests {
                 preflight: None,
                 bench: Some(DistributedBenchStatus {
                     mode: DistributedBenchMode::OnStart,
+                    phase: None,
+                    started_at: None,
+                    completed_at: None,
+                    message: None,
                     result: Some(DistributedBenchResult {
                         measured_at: "2026-05-02T10:00:30Z".to_string(),
                         busbw_gbps_p50: Some(0.00897),


### PR DESCRIPTION
## Summary

Fixes #521: the four PR #517 bench lifecycle fields
(`phase`, `startedAt`, `completedAt`, `message`) were being silently
dropped by the SDK's PyO3 binding because they were not on the
strongly-typed `DistributedBenchStatus` in this crate. The binding
deserialises the API JSON into this struct, then re-serialises it
back to a Python dict via `pythonize`, so any field absent from the
struct round-trips to `None`. The Python facade
(`BenchStatus.from_status_dict` in `basilica/distributed.py`)
defaulted them to `BENCH_PHASE_PENDING` and never observed the
operator's terminal phase.

The parallel basilica-backend fix widened the basilica-api wire
mirror; both must merge for the SDK to expose the fields end-to-end.

This change adds the four fields with `#[serde(default,
skip_serializing_if = "Option::is_none")]`. No Python-side change
is required since the facade already reads them from the dict.

## Test plan

- [x] `cargo build -p basilica-sdk` (clean)
- [x] `cargo test -p basilica-sdk --lib` (79 tests pass; the existing
      end-to-end fixture at `types.rs:2777` was updated for the new
      fields)
- [x] `cargo fmt -p basilica-sdk -- --check` (clean)
- [x] `cargo clippy -p basilica-sdk --no-deps -- -D warnings` (clean)
- [x] `maturin develop --release` against the local venv, then ex22
      against production:
      - **r28** (warm UD): `wait_until_bench_complete()` returns
        instantly on the operator's terminal `phase=Succeeded`.
      - **r29** (cold UD, fresh probe): full
        `Pending → Running → Succeeded` observed in ~70s with a
        fresh `measured_at`, fresh probe values different from r28,
        and clean cleanup.

## Linked

- #521 (this fix)
- #517 (operator BenchPhase introduction; basilica-backend)
- #519 (etcd-barrier + BenchJob CRD scaffold; basilica-backend)
- #506 (parent: bench-decoupling architecture; basilica-backend)
- Parallel: basilica-backend#522 (basilica-api wire-type widening)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Distributed benchmark status now includes enhanced lifecycle tracking with phase information, start and completion timestamps, and status messages for improved visibility into benchmark operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/468)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->