### PR TITLE
Bump Python SDK to v0.29.1

### DIFF
--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-05-09
+
+### Fixed
+- `DistributedTraining.bench` and `wait_until_bench_complete()` now
+  surface the four PR #517 lifecycle fields (`phase`, `startedAt`,
+  `completedAt`, `message`) end-to-end. The SDK's PyO3 binding
+  deserialises the API JSON into the strongly-typed
+  `DistributedBenchStatus` and re-serialises it back to a Python
+  dict via `pythonize`; the four new fields were absent from that
+  type and were silently dropped, so `wait_until_bench_complete()`
+  could never observe the operator's terminal `phase` and would
+  always fall through to `TimeoutError` even on a successful probe.
+  Closes #521. The companion basilica-backend fix
+  (one-covenant/basilica-backend#522) widens the wire mirror on the
+  basilica-api side; both releases are required for the fix to be
+  visible end-to-end.
+
 ## [0.29.0] - 2026-05-04
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.0"
+version = "0.29.1"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
## Summary

Patch release of the Python SDK containing the cross-repo #521 fix
that landed in #468.

- `crates/basilica-sdk-python/Cargo.toml`: 0.29.0 → 0.29.1
- `crates/basilica-sdk-python/pyproject.toml`: 0.29.0 → 0.29.1
- `CHANGELOG.md`: 0.29.1 entry documenting the bench-lifecycle-field
  fix and pointing at the companion basilica-backend PR (#522)

## Why a release is needed

#468 widened the `DistributedBenchStatus` Rust struct so the SDK's
PyO3 binding stops dropping the four lifecycle fields. Without a
new wheel on PyPI, downstream users still get the broken 0.29.0
binding and `wait_until_bench_complete()` continues to hit
`TimeoutError` even on a successful probe. Tagging
`basilica-sdk-python-v0.29.1` after merge triggers the publish
workflow.

## Validation

The fix itself was end-to-end validated against production with a
local `maturin develop --release` rebuild before #468 was opened
(see basilica-backend#522 for the ex22-r28 + r29 evidence). This
PR only bumps the version + updates CHANGELOG; no code changes.