### PR TITLE
fix(examples): use rdzv-backend=etcd in ex21 (closes #487, refs #368/#490)

### DIFF
--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -39,12 +39,23 @@ def main() -> None:
     # arch § 4 footnote on auto-torchrun wrapping. The basilica-
     # distributed-trainer image's `/workspace/all_reduce_smoke.py`
     # fixture is the smoke target.
+    # NOTE on `--rdzv-backend=etcd` (not `etcd-v2`): refs #368 / #490.
+    # The torchelastic `etcd-v2` backend (DynamicRendezvousHandler over
+    # etcd v3 gRPC) has an upstream regression in torch 2.5.0a0+nv24.10
+    # that returns RendezvousClosedError on the FIRST connect to a fresh
+    # etcd. The legacy `etcd` backend (EtcdRendezvousHandler over
+    # python-etcd / v2 KV API) works against the same etcd Pod with
+    # --enable-v2=true. The operator's "auto" command-build path
+    # (basilica-operator: distributed.rs::build_worker_command) maps the
+    # CRD value `etcd-v2` -> the working `etcd` torchrun arg until
+    # upstream resolves it; BYO commands (this example) need to do the
+    # same. When #368 closes, flip both back to `etcd-v2`.
     training = client.deploy_distributed(
         name="dlc-example-torchrun",
         image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
         command=[
             "torchrun",
-            "--rdzv-backend=etcd-v2",
+            "--rdzv-backend=etcd",
             "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
             "--rdzv-id=$BASILICA_RDZV_ID",
             "--nnodes=$BASILICA_WORLD_TARGET",


### PR DESCRIPTION
## Summary

Fixes the remaining cause of basilica-backend#487 — `examples/21_distributed_torchrun.py` was hardcoding `--rdzv-backend=etcd-v2`, which trips the upstream PyTorch regression tracked in basilica-backend#368 / #490 on every run, regardless of what the operator does to work around it.

The operator's auto-mode command builder
(`basilica-operator: distributed.rs::build_worker_command`) already maps
the CRD value `etcd-v2` -> the working torchrun arg `etcd` until the
upstream fix lands. This PR makes the BYO example do the same.

## Validation against prod

Prod state at validation:
- basilica-operator `sha256:4828716c...` with `BASILICA_BENCH_CONTROLLER_OWNS_APPLY=true` (the basilica-backend#506 Phase 3 cutover, merged ~30 min ago)
- SDK installed via `maturin develop --release` against
  `crates/basilica-sdk@0.29.1` (which carries the basilica-backend#521
  bench-lifecycle-fields fix)

Run evidence (log: `/tmp/ex21-rdzv-fix-20260510T001342Z.log`):

```
Deployed: f01dd43a-760b-428b-abdd-c43e20d6dce2
World: WorldStatus(ready=2, target=2, min=2, max=4, below_minimum=False)
Scaled to target=3; world now: WorldStatus(ready=2, target=3, min=2, max=4, below_minimum=False)
All 3 ranks ready: WorldStatus(ready=3, target=3, min=2, max=4, below_minimum=False)
...
Cleanup complete.
```

Counters:
- `RendezvousClosedError`: **0** (was 3+ pre-fix per basilica-backend#487/#490 evidence)
- `Rendezvous version 1 is complete`: **2** (initial 2-rank + post-scale 3-rank rendezvous)
- `Cleanup complete`: 1 (script exited 0)

## Cosmetic noise still present

Worker logs include sporadic `etcd.EtcdException: Raft Internal Error : ... : Not a file` tracebacks from the `lease_worker` daemon thread after rendezvous-version transitions (e.g., on scale). The keep-alive path becomes stale when torchelastic moves to a new rendezvous version; the daemon thread surfaces the etcd exception without crashing the rank. This is upstream `python-etcd` behaviour, independent of this fix, and cosmetic. Not blocking the example's correctness.

## Closes / refs

- **closes** basilica-backend#487 (ex21 broken — last remaining cause)
- **refs** basilica-backend#368 (workaround removal trigger)
- **refs** basilica-backend#490 (deeper torchrun cold-start race; the etcd-backend choice neutralises the most-common manifestation but the rendezvous-timeout race in slow-image-pull scenarios still applies — keeps #490 in scope)

## Test plan

- [x] Re-run ex21 against prod operator with the fix → PASS (evidence above)
- [x] No regression on ex22 (last validated this session post-cutover; bench probe + ex22 are independent of this example)
- [x] No regression on ex20 (validated post-cutover this session)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the distributed deployment example with clarified configuration settings and added detailed explanations of rendezvous backend behavior differences to guide users on proper configuration choices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->