### PR TITLE
fix(examples): add --rdzv-conf=timeout=1500 to ex21 (refs #490)

### DIFF
--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -50,6 +50,12 @@ def main() -> None:
     # CRD value `etcd-v2` -> the working `etcd` torchrun arg until
     # upstream resolves it; BYO commands (this example) need to do the
     # same. When #368 closes, flip both back to `etcd-v2`.
+    # NOTE on `--rdzv-conf=timeout=1500`: refs #490. torchelastic's
+    # rendezvous handlers default to a ~600 s join timeout; on slow
+    # cold-starts (image pull blip, transient registry slowness, GPU
+    # node first boot) rank-0 can raise RendezvousClosedError before
+    # rank-N joins. The operator's "auto" command-build path injects
+    # this same value; BYO commands need to mirror it.
     training = client.deploy_distributed(
         name="dlc-example-torchrun",
         image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
@@ -58,6 +64,7 @@ def main() -> None:
             "--rdzv-backend=etcd",
             "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
             "--rdzv-id=$BASILICA_RDZV_ID",
+            "--rdzv-conf=timeout=1500",
             "--nnodes=$BASILICA_WORLD_TARGET",
             "--nproc-per-node=$BASILICA_GPUS_PER_POD",
             "--max-restarts=10",


### PR DESCRIPTION
## Summary

Mirrors basilica-backend#531 on the BYO torchrun path. Without this knob, ex21 inherits the torchelastic ~600 s default rendezvous join timeout and is exposed to the same cold-start race basilica-backend#490 describes.

## Cluster context

basilica-backend#485 (verda 50 Mbps egress throttle on basilica-c493e646) is now closed — verified live ~750 Mbps mean today (~15x the original cap). The chronic case of #490 is gone. This is defense-in-depth for the residual case (transient registry slowness, GPU node first boot variance).

## Validation

ex21 was already end-to-end validated against prod **without** this knob in basilica#470 (closed basilica-backend#487):
- 0 RendezvousClosedError
- 2 successful rendezvous (initial 2-rank + post-scale 3-rank)
- Clean SDK exit
- Log: \`/tmp/ex21-rdzv-fix-20260510T001342Z.log\`

The bump is risk-free for the working case (no extra wait when ranks join quickly) and aligns the BYO example with the auto-mode behaviour the operator now ships.

## Test plan

- [x] ex21 still passes against prod (validated yesterday with the etcd-backend fix; this is a pure-additive knob, no behaviour change for fast cold-starts)
- [ ] Post-merge: re-run ex21 once basilica-backend#531 + this PR are both deployed; confirm the auto-mode and BYO paths behave identically end-to-end

## Refs

- basilica-backend#490 (residual rendezvous-timeout race)
- basilica-backend#531 (operator-side companion: same knob in auto-mode)
- basilica-backend#485 / #496 (closed today: chronic cause gone)
- #470 (basilica#470 closed basilica-backend#487 yesterday)