### PR TITLE
fix(sdk): deploy_distributed_managed context manager (closes basilica-backend#538)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -159,6 +159,8 @@ from .distributed import (
     BenchStatus,
     DistributedMetrics,
     DistributedTraining,
+    DistributedTrainingManaged,
+    DistributedTrainingManagedAsync,
     ProviderFilter,
     RankExit,
     RankStatus,
@@ -1277,6 +1279,94 @@ class BasilicaClient:
             )
         return training
 
+    def deploy_distributed_managed(
+        self,
+        name: str,
+        source: Optional[Union[str, Path, Callable]] = None,
+        image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+        port: int = 18789,
+        env: Optional[Dict[str, str]] = None,
+        cpu: str = "8",
+        memory: str = "32Gi",
+        gpu_count: int = 1,
+        gpu_models: Optional[List[str]] = None,
+        min_gpu_memory_gb: Optional[int] = None,
+        world_size: Optional[WorldSize] = None,
+        provider_filter: Optional[ProviderFilter] = None,
+        topology_spread: str = "provider-aware",
+        nccl_env: Optional[Dict[str, str]] = None,
+        bench: str = "off",
+        bench_placement: str = "preferred",
+        rendezvous_backend: str = "etcd-v2",
+        command: Optional[List[str]] = None,
+        args: Optional[List[str]] = None,
+        pip_packages: Optional[List[str]] = None,
+        ttl_seconds: Optional[int] = 86400,
+        timeout: int = 600,
+        enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
+    ) -> DistributedTrainingManaged:
+        """
+        Context-managed variant of :meth:`deploy_distributed`.
+
+        Defensive sibling of basilica-backend#486 (which fixed UD leak
+        inside ``deploy_distributed`` itself when the initial
+        ``wait_until_min_world`` raised). This variant fixes the
+        *caller-side* leak: when an intermediate wait such as
+        ``wait_until_target_world`` (after ``scale()``) raises, the
+        script aborts before reaching ``delete()``.
+
+        Returns a :class:`DistributedTrainingManaged` that, on scope
+        exit (normal OR exceptional), best-effort calls
+        ``training.delete()`` so the UD does not leak.
+
+        All keyword arguments match :meth:`deploy_distributed` exactly
+        and are forwarded verbatim. See that method for full semantics.
+
+        Recommended pattern for any ``deploy → use → delete`` flow::
+
+            with client.deploy_distributed_managed(
+                name="dlc-job",
+                image="...",
+                world_size=WorldSize(min=2, target=2, max=4),
+            ) as training:
+                training.scale(target=3)
+                training.wait_until_target_world(timeout=300)
+                ...
+            # `delete()` ran on scope exit, success or exception.
+
+        Refs: basilica-backend#538 (defensive sibling of #486).
+        """
+        training = self.deploy_distributed(
+            name=name,
+            source=source,
+            image=image,
+            port=port,
+            env=env,
+            cpu=cpu,
+            memory=memory,
+            gpu_count=gpu_count,
+            gpu_models=gpu_models,
+            min_gpu_memory_gb=min_gpu_memory_gb,
+            world_size=world_size,
+            provider_filter=provider_filter,
+            topology_spread=topology_spread,
+            nccl_env=nccl_env,
+            bench=bench,
+            bench_placement=bench_placement,
+            rendezvous_backend=rendezvous_backend,
+            command=command,
+            args=args,
+            pip_packages=pip_packages,
+            ttl_seconds=ttl_seconds,
+            timeout=timeout,
+            enable_billing=enable_billing,
+            wait_for_bench=wait_for_bench,
+            bench_timeout=bench_timeout,
+        )
+        return DistributedTrainingManaged(training)
+
     @staticmethod
     def _handle_post_deploy_bench_wait(
         training: DistributedTraining,
@@ -2307,6 +2397,94 @@ class BasilicaClient:
                 training, mode=wait_for_bench, timeout=bench_timeout
             )
         return training
+
+    def deploy_distributed_managed_async(
+        self,
+        name: str,
+        source: Optional[Union[str, Path, Callable]] = None,
+        image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime",
+        port: int = 18789,
+        env: Optional[Dict[str, str]] = None,
+        cpu: str = "8",
+        memory: str = "32Gi",
+        gpu_count: int = 1,
+        gpu_models: Optional[List[str]] = None,
+        min_gpu_memory_gb: Optional[int] = None,
+        world_size: Optional[WorldSize] = None,
+        provider_filter: Optional[ProviderFilter] = None,
+        topology_spread: str = "provider-aware",
+        nccl_env: Optional[Dict[str, str]] = None,
+        bench: str = "off",
+        bench_placement: str = "preferred",
+        rendezvous_backend: str = "etcd-v2",
+        command: Optional[List[str]] = None,
+        args: Optional[List[str]] = None,
+        pip_packages: Optional[List[str]] = None,
+        ttl_seconds: Optional[int] = 86400,
+        timeout: int = 600,
+        enable_billing: bool = True,
+        wait_for_bench: Literal["never", "best_effort", "required"] = "never",
+        bench_timeout: int = 1500,
+    ) -> DistributedTrainingManagedAsync:
+        """
+        Async context-managed variant of :meth:`deploy_distributed_async`.
+
+        Returns a :class:`DistributedTrainingManagedAsync` for use
+        directly with ``async with``. The actual deploy runs in
+        ``__aenter__`` (lazy), so this method itself does NOT need to
+        be awaited. On scope exit (normal OR exceptional), best-effort
+        calls ``training.delete_async()`` so the UD does not leak.
+
+        All keyword arguments match :meth:`deploy_distributed_async`
+        exactly and are forwarded verbatim.
+
+        Recommended pattern::
+
+            async with client.deploy_distributed_managed_async(
+                name="dlc-job",
+                image="...",
+                world_size=WorldSize(min=2, target=2, max=4),
+            ) as training:
+                await training.scale_async(target=3)
+                await training.wait_until_target_world_async(timeout=300)
+                ...
+
+        Refs: basilica-backend#538 (defensive sibling of #486).
+        """
+        # Capture the deploy invocation as a zero-arg coroutine factory
+        # so the manager can defer the deploy until `__aenter__`. Using
+        # a factory (not a one-shot coroutine) keeps the manager
+        # idempotent under accidental re-entry.
+        def _factory() -> Any:
+            return self.deploy_distributed_async(
+                name=name,
+                source=source,
+                image=image,
+                port=port,
+                env=env,
+                cpu=cpu,
+                memory=memory,
+                gpu_count=gpu_count,
+                gpu_models=gpu_models,
+                min_gpu_memory_gb=min_gpu_memory_gb,
+                world_size=world_size,
+                provider_filter=provider_filter,
+                topology_spread=topology_spread,
+                nccl_env=nccl_env,
+                bench=bench,
+                bench_placement=bench_placement,
+                rendezvous_backend=rendezvous_backend,
+                command=command,
+                args=args,
+                pip_packages=pip_packages,
+                ttl_seconds=ttl_seconds,
+                timeout=timeout,
+                enable_billing=enable_billing,
+                wait_for_bench=wait_for_bench,
+                bench_timeout=bench_timeout,
+            )
+
+        return DistributedTrainingManagedAsync(_factory)
 
     @staticmethod
     async def _handle_post_deploy_bench_wait_async(

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -16,6 +16,7 @@ import asyncio
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,6 +26,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
 )
 
 from .exceptions import (
@@ -1058,6 +1060,120 @@ class DistributedTraining:
         """`<ud>-rendezvous.<ns>.svc.cluster.local:2379` -- in-cluster only."""
         ns = self.namespace or "u-unknown"
         return f"{self.name}-rendezvous.{ns}.svc.cluster.local:2379"
+
+
+class DistributedTrainingManaged:
+    """
+    Sync context-managed wrapper around a :class:`DistributedTraining`.
+
+    Returned by :meth:`BasilicaClient.deploy_distributed_managed`.
+
+    Defensive sibling of basilica-backend#486 (which fixed UD leak
+    inside ``deploy_distributed``'s own ``wait_until_min_world``
+    failure path). This class handles the *caller-side* leak: when an
+    intermediate wait such as ``wait_until_target_world`` after
+    ``scale()`` raises, the script aborts before reaching ``delete()``
+    and the UD leaks.
+
+    Refs: basilica-backend#538.
+
+    Usage::
+
+        with client.deploy_distributed_managed(...) as training:
+            training.scale(target=3)
+            training.wait_until_target_world(timeout=300)
+            ...
+        # `delete()` ran on scope exit, success or exception.
+    """
+
+    def __init__(self, training: "DistributedTraining") -> None:
+        self._training = training
+
+    @property
+    def training(self) -> "DistributedTraining":
+        """The wrapped :class:`DistributedTraining` handle."""
+        return self._training
+
+    def __enter__(self) -> "DistributedTraining":
+        return self._training
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        # Best-effort cleanup. Swallow any delete-time exception so we
+        # never mask the (possibly more important) exception that is
+        # already propagating out of the `with` block.
+        try:
+            self._training.delete()
+        except Exception:
+            pass
+
+
+class DistributedTrainingManagedAsync:
+    """
+    Async context-managed wrapper that defers the actual deploy to
+    ``__aenter__``.
+
+    Returned by
+    :meth:`BasilicaClient.deploy_distributed_managed_async` so the
+    caller can write::
+
+        async with client.deploy_distributed_managed_async(...) as training:
+            await training.scale_async(target=3)
+            await training.wait_until_target_world_async(timeout=300)
+            ...
+
+    The deploy itself runs in ``__aenter__``; on scope exit (success
+    OR exception) ``__aexit__`` best-effort calls
+    ``training.delete_async()`` so the UD does not leak.
+
+    Refs: basilica-backend#538.
+    """
+
+    def __init__(
+        self,
+        deploy_coro_factory: Any,
+    ) -> None:
+        # `deploy_coro_factory` is a zero-arg callable returning a
+        # coroutine that resolves to a `DistributedTraining`. Stored
+        # as a factory (not a coroutine) because coroutines can only
+        # be awaited once; constructing the manager and entering it
+        # in the same expression must not eagerly bind the awaitable.
+        self._deploy_coro_factory = deploy_coro_factory
+        self._training: Optional["DistributedTraining"] = None
+
+    @property
+    def training(self) -> "DistributedTraining":
+        """The wrapped handle. Only valid after ``__aenter__`` ran."""
+        if self._training is None:
+            raise RuntimeError(
+                "DistributedTrainingManagedAsync.training accessed before "
+                "the async context was entered. Use `async with ... as t:`."
+            )
+        return self._training
+
+    async def __aenter__(self) -> "DistributedTraining":
+        self._training = await self._deploy_coro_factory()
+        return self._training
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        # If `__aenter__` raised before assigning, there is nothing to
+        # clean up (the deploy itself handles its own teardown via
+        # basilica-backend#486 inside `deploy_distributed_async`).
+        if self._training is None:
+            return
+        try:
+            await self._training.delete_async()
+        except Exception:
+            pass
 
 
 def _coerce_to_dict(obj: Any) -> Dict[str, Any]:

--- a/crates/basilica-sdk-python/tests/test_deploy_distributed_managed.py
+++ b/crates/basilica-sdk-python/tests/test_deploy_distributed_managed.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for `deploy_distributed_managed` / `deploy_distributed_managed_async`.
+
+Refs: basilica-backend#538 (defensive sibling of basilica-backend#486).
+
+The managed variant returns a context-manager that calls
+`training.delete()` on scope exit (success or exception). Issue #538
+covers the caller-side leak: when an intermediate wait such as
+`wait_until_target_world(timeout=...)` after `scale()` raises, the
+script aborts before reaching `delete()` and the UD leaks. These
+tests pin the auto-cleanup contract.
+
+Test stubbing strategy mirrors `tests/test_distributed.py`: stub the
+PyO3 binding at `BasilicaClient._client.create_distributed_deployment`
+and `BasilicaClient._client.delete_deployment`. We bypass
+`BasilicaClient.__init__` (the real constructor needs auth env / CLI
+tokens) by allocating an instance via `__new__`, which is the same
+pattern the existing distributed tests already rely on indirectly via
+`DistributedTraining(MagicMock(), name)`.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from basilica import (
+    BasilicaClient,
+    DistributedTraining,
+    DistributedTrainingManaged,
+    DistributedTrainingManagedAsync,
+    WorldSize,
+)
+
+
+# =============================================================================
+# Helpers.
+# =============================================================================
+
+
+def _make_client_with_stub(
+    name: str = "dlc-managed-test",
+    namespace: str = "u-test",
+) -> BasilicaClient:
+    """Build a BasilicaClient whose PyO3 binding is fully stubbed.
+
+    Bypasses BasilicaClient.__init__ to avoid the auth bootstrap
+    (env-var / CLI tokens), since these tests do not exercise auth.
+    """
+    client = BasilicaClient.__new__(BasilicaClient)
+    inner = MagicMock()
+
+    # `create_distributed_deployment` returns a `DeploymentResponse` whose
+    # only attribute the SDK reads here is `instance_name`.
+    create_response = MagicMock()
+    create_response.instance_name = name
+    inner.create_distributed_deployment = MagicMock(return_value=create_response)
+
+    # `get_deployment` is invoked indirectly by `training.refresh()` /
+    # `wait_until_min_world` via `BasilicaClient.get(name)`. The path is
+    # PyO3 response -> `Deployment._from_response` (real Python object)
+    # -> `_coerce_to_dict(deployment)` -> reads `deployment.distributed`
+    # ONLY if it is a real dict. Provide a response whose `distributed`
+    # attribute is a literal dict already showing min ranks ready so
+    # `wait_until_min_world` returns on the first poll.
+    get_response = MagicMock()
+    get_response.namespace = namespace
+    get_response.instance_name = name
+    get_response.distributed = {
+        "worldSize": {
+            "ready": 2,
+            "target": 2,
+            "min": 2,
+            "max": 4,
+            "belowMinimum": False,
+        },
+    }
+    # `Deployment.__init__` reads several scalar fields straight off the
+    # PyO3 response object; explicitly pin them so MagicMock does not
+    # produce a non-string auto-attr that downstream type checks reject.
+    get_response.image = "ghcr.io/example/trainer:latest"
+    get_response.phase = "ready"
+    get_response.message = None
+    get_response.share_token = None
+    get_response.share_url = None
+    get_response.public_metadata = None
+    inner.get_deployment = MagicMock(return_value=get_response)
+
+    # Track `delete_deployment` calls so tests can assert auto-cleanup.
+    inner.delete_deployment = MagicMock(return_value=None)
+
+    client._client = inner
+    return client
+
+
+def _deploy_kwargs() -> Dict[str, Any]:
+    """Minimum kwargs for `deploy_distributed_managed[_async]`."""
+    return {
+        "name": "dlc-managed-test",
+        "image": "ghcr.io/example/trainer:latest",
+        "world_size": WorldSize(min=2, target=2, max=4),
+        # `command=` (BYO launcher) keeps the request build path simple
+        # and avoids the source-packager codepath.
+        "command": ["python3", "/workspace/noop.py"],
+        # `timeout=0` is fine here: the stubbed status already reports
+        # min ranks ready, so `wait_until_min_world` returns immediately.
+        "timeout": 0,
+    }
+
+
+# =============================================================================
+# Sync managed deploy.
+# =============================================================================
+
+
+class TestDeployDistributedManagedSync:
+    def test_managed_calls_delete_on_normal_exit(self) -> None:
+        """No exception inside the `with` block: `delete_deployment` runs once."""
+        client = _make_client_with_stub()
+
+        with client.deploy_distributed_managed(**_deploy_kwargs()) as training:
+            assert isinstance(training, DistributedTraining)
+            assert training.name == "dlc-managed-test"
+
+        # delete fired exactly once on scope exit.
+        assert client._client.delete_deployment.call_count == 1
+        client._client.delete_deployment.assert_called_with("dlc-managed-test")
+
+    def test_managed_calls_delete_on_exception_propagation(self) -> None:
+        """Exception inside `with` body: delete still runs AND the original error propagates."""
+        client = _make_client_with_stub()
+
+        class _MyError(RuntimeError):
+            pass
+
+        with pytest.raises(_MyError, match="boom-from-caller"):
+            with client.deploy_distributed_managed(**_deploy_kwargs()) as training:
+                # Simulate the issue #538 scenario: an intermediate wait
+                # (e.g. wait_until_target_world after scale) raises and
+                # the caller would otherwise leak the UD.
+                raise _MyError("boom-from-caller")
+
+        assert client._client.delete_deployment.call_count == 1
+        client._client.delete_deployment.assert_called_with("dlc-managed-test")
+
+    def test_managed_swallows_delete_failure(self) -> None:
+        """delete() failing must not produce a NEW exception out of __exit__."""
+        client = _make_client_with_stub()
+        client._client.delete_deployment = MagicMock(
+            side_effect=RuntimeError("delete failed")
+        )
+
+        # Normal exit: no caller exception, delete raises. The contract
+        # says __exit__ swallows it (best-effort cleanup).
+        with client.deploy_distributed_managed(**_deploy_kwargs()) as training:
+            assert isinstance(training, DistributedTraining)
+
+        assert client._client.delete_deployment.call_count == 1
+
+    def test_managed_swallows_delete_failure_during_exception(self) -> None:
+        """delete() raising must NOT mask the propagating exception."""
+        client = _make_client_with_stub()
+        client._client.delete_deployment = MagicMock(
+            side_effect=RuntimeError("delete failed")
+        )
+
+        class _CallerError(RuntimeError):
+            pass
+
+        with pytest.raises(_CallerError, match="caller-error"):
+            with client.deploy_distributed_managed(**_deploy_kwargs()):
+                raise _CallerError("caller-error")
+
+        assert client._client.delete_deployment.call_count == 1
+
+    def test_managed_returns_distributed_training_managed_handle(self) -> None:
+        """Outside `with`, the managed object exposes `.training` (handle access)."""
+        client = _make_client_with_stub()
+
+        managed = client.deploy_distributed_managed(**_deploy_kwargs())
+        assert isinstance(managed, DistributedTrainingManaged)
+        assert isinstance(managed.training, DistributedTraining)
+        assert managed.training.name == "dlc-managed-test"
+
+        # Manual __enter__/__exit__ also works.
+        entered = managed.__enter__()
+        assert entered is managed.training
+        managed.__exit__(None, None, None)
+        assert client._client.delete_deployment.call_count == 1
+
+
+# =============================================================================
+# Async managed deploy.
+# =============================================================================
+
+
+class TestDeployDistributedManagedAsync:
+    @pytest.mark.asyncio
+    async def test_managed_async_calls_delete_async(self) -> None:
+        """`async with` triggers `delete()` on scope exit.
+
+        `delete_async` defers to `delete` via run_in_executor, which
+        ultimately invokes `_client.delete_deployment`. Asserting the
+        delete_deployment counter covers both sync and async paths
+        without coupling to the executor plumbing.
+        """
+        client = _make_client_with_stub()
+
+        async with client.deploy_distributed_managed_async(**_deploy_kwargs()) as training:
+            assert isinstance(training, DistributedTraining)
+            assert training.name == "dlc-managed-test"
+
+        assert client._client.delete_deployment.call_count == 1
+        client._client.delete_deployment.assert_called_with("dlc-managed-test")
+
+    @pytest.mark.asyncio
+    async def test_managed_async_calls_delete_on_exception(self) -> None:
+        """Exception inside async body: delete still runs, original propagates."""
+        client = _make_client_with_stub()
+
+        class _MyAsyncError(RuntimeError):
+            pass
+
+        with pytest.raises(_MyAsyncError, match="async-boom"):
+            async with client.deploy_distributed_managed_async(
+                **_deploy_kwargs()
+            ) as training:
+                _ = training  # keep handle in scope
+                raise _MyAsyncError("async-boom")
+
+        assert client._client.delete_deployment.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_managed_async_swallows_delete_failure(self) -> None:
+        """Async delete failure does not escape `__aexit__`."""
+        client = _make_client_with_stub()
+        client._client.delete_deployment = MagicMock(
+            side_effect=RuntimeError("async delete failed")
+        )
+
+        async with client.deploy_distributed_managed_async(**_deploy_kwargs()):
+            pass  # normal exit; cleanup will fail but be swallowed
+
+        assert client._client.delete_deployment.call_count == 1
+
+
+# =============================================================================
+# API surface assertions: pin the new public symbols.
+# =============================================================================
+
+
+class TestManagedSurfaceExposed:
+    def test_basilica_client_exposes_deploy_distributed_managed(self) -> None:
+        assert hasattr(BasilicaClient, "deploy_distributed_managed")
+        assert hasattr(BasilicaClient, "deploy_distributed_managed_async")
+
+    def test_distributed_training_managed_is_importable(self) -> None:
+        # Re-exported from `basilica` so callers can type-annotate the
+        # managed return value.
+        from basilica import DistributedTrainingManaged as Managed
+        assert Managed is DistributedTrainingManaged
+
+    def test_managed_class_implements_sync_protocol(self) -> None:
+        for method in ("__enter__", "__exit__"):
+            assert hasattr(DistributedTrainingManaged, method), (
+                f"DistributedTrainingManaged missing {method}"
+            )
+
+    def test_async_managed_class_implements_async_protocol(self) -> None:
+        for method in ("__aenter__", "__aexit__"):
+            assert hasattr(DistributedTrainingManagedAsync, method), (
+                f"DistributedTrainingManagedAsync missing {method}"
+            )

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -56,7 +56,13 @@ def main() -> None:
     # node first boot) rank-0 can raise RendezvousClosedError before
     # rank-N joins. The operator's "auto" command-build path injects
     # this same value; BYO commands need to mirror it.
-    training = client.deploy_distributed(
+    # `deploy_distributed_managed` is the defensive sibling of
+    # `deploy_distributed` (refs basilica-backend#538): on scope exit
+    # (success OR exception) it best-effort calls `training.delete()`
+    # so the UD does not leak when an intermediate wait such as
+    # `wait_until_target_world` after `scale()` raises before the
+    # explicit `delete()` line is reached.
+    with client.deploy_distributed_managed(
         name="dlc-example-torchrun",
         image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
         command=[
@@ -81,30 +87,30 @@ def main() -> None:
         nccl_env={"NCCL_DEBUG": "WARN"},
         ttl_seconds=600,
         timeout=900,
-    )
+    ) as training:
+        print(f"Deployed: {training.name}")
+        print(f"Namespace: {training.namespace}")
+        print(f"World: {training.world}")
 
-    print(f"Deployed: {training.name}")
-    print(f"Namespace: {training.namespace}")
-    print(f"World: {training.world}")
+        # Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
+        # torchelastic re-rendezvouses workers when the StatefulSet replica count
+        # changes, and the new rank joins.
+        time.sleep(30)
+        new_world = training.scale(target=3)
+        print(f"Scaled to target=3; world now: {new_world}")
 
-    # Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
-    # torchelastic re-rendezvouses workers when the StatefulSet replica count
-    # changes, and the new rank joins.
-    time.sleep(30)
-    new_world = training.scale(target=3)
-    print(f"Scaled to target=3; world now: {new_world}")
+        # Wait for the new rank to join. If this raises (e.g. operator
+        # leader transfer mid-rollout), the managed `with` block runs
+        # `delete()` on its way out so the UD does not leak.
+        training.wait_until_target_world(timeout=300)
+        print(f"All 3 ranks ready: {training.world}")
 
-    # Wait for the new rank to join.
-    training.wait_until_target_world(timeout=300)
-    print(f"All 3 ranks ready: {training.world}")
+        # Tail logs briefly so the example surfaces "is it actually running".
+        # Phase 5b: per-rank filtering not yet supported by the API; logs are
+        # returned merged across ranks.
+        print("--- merged logs ---")
+        print(training.logs(tail=30))
 
-    # Tail logs briefly so the example surfaces "is it actually running".
-    # Phase 5b: per-rank filtering not yet supported by the API; logs are
-    # returned merged across ranks.
-    print("--- merged logs ---")
-    print(training.logs(tail=30))
-
-    training.delete()
     print("Cleanup complete.")
 
 

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -52,7 +52,13 @@ def main() -> None:
     # torchrun entirely; ranks would crash with `RANK env var missing`.
     # For users who want full control over the launcher, see example 21
     # (BYO torchrun via `command=[...]`).
-    training = client.deploy_distributed(
+    # `deploy_distributed_managed` (refs basilica-backend#538) auto-
+    # deletes the UD on scope exit, even when the script aborts via
+    # `raise SystemExit(1)` on a bench-Succeeded-but-no-result path.
+    # The exit propagates through the `with` block; `__exit__` cleans
+    # up; the script exits 1 as before -- no behavioral change beyond
+    # closing the leak window.
+    with client.deploy_distributed_managed(
         name="dlc-example-bench",
         image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
         source="""\
@@ -106,81 +112,80 @@ if __name__ == "__main__":
         nccl_env={"NCCL_DEBUG": "WARN"},
         ttl_seconds=900,
         timeout=900,
-    )
+    ) as training:
+        print(f"Deployed: {training.name}")
+        print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
 
-    print(f"Deployed: {training.name}")
-    print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
+        # Refs #506: deploy_distributed now returns when workers are Ready;
+        # the bench probe is decoupled. Use the opt-in waiter to block on it.
+        # `bench_timeout=1200` (20 min) matches the prior implicit budget.
+        print("Waiting for bench probe (opt-in via wait_until_bench_complete)...")
+        bench_status = training.wait_until_bench_complete(timeout=1200)
 
-    # Refs #506: deploy_distributed now returns when workers are Ready;
-    # the bench probe is decoupled. Use the opt-in waiter to block on it.
-    # `bench_timeout=1200` (20 min) matches the prior implicit budget.
-    print("Waiting for bench probe (opt-in via wait_until_bench_complete)...")
-    bench_status = training.wait_until_bench_complete(timeout=1200)
+        if bench_status is None:
+            # mode=off — caller did not request a bench probe. Not reachable
+            # in this example (we set bench="on-start" above), but kept for
+            # symmetry with the API contract. Managed `__exit__` deletes
+            # the UD as the SystemExit propagates.
+            print("Bench was not enabled on this UD.")
+            raise SystemExit(1)
 
-    if bench_status is None:
-        # mode=off — caller did not request a bench probe. Not reachable
-        # in this example (we set bench="on-start" above), but kept for
-        # symmetry with the API contract.
-        print("Bench was not enabled on this UD.")
-        training.delete()
-        raise SystemExit(1)
+        if bench_status.phase != "Succeeded":
+            # Workers were Ready -- the deploy is fine -- but the bench
+            # didn't measure. Print the lifecycle detail; do NOT exit non-zero
+            # for a bench-only failure (the workload itself is healthy).
+            # `return` falls through the managed exit which deletes the UD.
+            print("Bench probe did NOT complete with a measurement.")
+            print(f"  phase:              {bench_status.phase}")
+            print(f"  message:            {bench_status.message}")
+            print(f"  last_attempt_at:    {bench_status.last_attempt_at}")
+            print(f"  last_attempt:       {bench_status.last_attempt_outcome}")
+            print("Workers are still Ready; the UD itself is healthy.")
+            print("Inspect via `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
+            return
 
-    if bench_status.phase != "Succeeded":
-        # Workers were Ready -- the deploy is fine -- but the bench
-        # didn't measure. Print the lifecycle detail; do NOT exit non-zero
-        # for a bench-only failure (the workload itself is healthy).
-        print("Bench probe did NOT complete with a measurement.")
-        print(f"  phase:              {bench_status.phase}")
-        print(f"  message:            {bench_status.message}")
-        print(f"  last_attempt_at:    {bench_status.last_attempt_at}")
-        print(f"  last_attempt:       {bench_status.last_attempt_outcome}")
-        print("Workers are still Ready; the UD itself is healthy.")
-        print("Inspect via `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
-        training.delete()
-        return
+        # bench_status.phase == "Succeeded"; the result payload is on
+        # `training.bench` (or `bench_status.result`).
+        result = training.bench
+        if result is None:
+            # Defensive: phase=Succeeded but no result payload -- this would
+            # be an operator-side invariant break. Surface it explicitly;
+            # SystemExit propagates through the managed `with`, which
+            # deletes the UD on its way out.
+            print("Bench phase=Succeeded but no result payload available.")
+            raise SystemExit(1)
+        print("--- Bench result ---")
+        print(f"  measured_at:        {result.measured_at}")
+        print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
+        print(f"  busbw_gbps_p50:     {result.busbw_gbps_p50}")
+        print(f"  busbw_gbps_p90:     {result.busbw_gbps_p90}")
+        print(f"  algbw_gbps_p50:     {result.algbw_gbps_p50}")
+        print(f"  latency_us_at_1mib: {result.latency_us_at_1mib}")
+        print(f"  size_bytes_swept:   {result.size_bytes_swept}")
+        print(f"  probe_node_a:       {result.probe_node_a}")
+        print(f"  probe_node_b:       {result.probe_node_b}")
 
-    # bench_status.phase == "Succeeded"; the result payload is on
-    # `training.bench` (or `bench_status.result`).
-    result = training.bench
-    if result is None:
-        # Defensive: phase=Succeeded but no result payload -- this would
-        # be an operator-side invariant break. Surface it explicitly.
-        print("Bench phase=Succeeded but no result payload available.")
-        training.delete()
-        raise SystemExit(1)
-    print("--- Bench result ---")
-    print(f"  measured_at:        {result.measured_at}")
-    print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
-    print(f"  busbw_gbps_p50:     {result.busbw_gbps_p50}")
-    print(f"  busbw_gbps_p90:     {result.busbw_gbps_p90}")
-    print(f"  algbw_gbps_p50:     {result.algbw_gbps_p50}")
-    print(f"  latency_us_at_1mib: {result.latency_us_at_1mib}")
-    print(f"  size_bytes_swept:   {result.size_bytes_swept}")
-    print(f"  probe_node_a:       {result.probe_node_a}")
-    print(f"  probe_node_b:       {result.probe_node_b}")
+        # Researchers writing papers can serialize this to JSON and aggregate
+        # across many UDs offline -- each measurement is on their own nodes,
+        # billed against their own usage, with no cross-tenant shared cache.
+        out = {
+            "name": training.name,
+            "world_size": {
+                "min": training.world.min,
+                "target": training.world.target,
+                "max": training.world.max,
+            },
+            "bench": {
+                "busbw_gbps_p50": result.busbw_gbps_p50,
+                "latency_us_at_1mib": result.latency_us_at_1mib,
+                "probe_node_a": result.probe_node_a,
+                "probe_node_b": result.probe_node_b,
+            },
+        }
+        with open(f"/tmp/{training.name}-bench.json", "w") as f:
+            json.dump(out, f, indent=2, default=str)
+        print(f"Saved bench result: /tmp/{training.name}-bench.json")
 
-    # Researchers writing papers can serialize this to JSON and aggregate
-    # across many UDs offline -- each measurement is on their own nodes,
-    # billed against their own usage, with no cross-tenant shared cache.
-    out = {
-        "name": training.name,
-        "world_size": {
-            "min": training.world.min,
-            "target": training.world.target,
-            "max": training.world.max,
-        },
-        "bench": {
-            "busbw_gbps_p50": result.busbw_gbps_p50,
-            "latency_us_at_1mib": result.latency_us_at_1mib,
-            "probe_node_a": result.probe_node_a,
-            "probe_node_b": result.probe_node_b,
-        },
-    }
-    with open(f"/tmp/{training.name}-bench.json", "w") as f:
-        json.dump(out, f, indent=2, default=str)
-    print(f"Saved bench result: /tmp/{training.name}-bench.json")
-
-    training.delete()
     print("Cleanup complete.")
 
 


### PR DESCRIPTION
## Summary

Adds `client.deploy_distributed_managed(...)` and
`client.deploy_distributed_managed_async(...)` -- the context-managed
siblings of `deploy_distributed` / `deploy_distributed_async`. On scope
exit (normal OR exceptional) the wrappers best-effort call
`training.delete()` so the UD does not leak when an intermediate wait
such as `wait_until_target_world(timeout=...)` after `scale()` raises
before the explicit `delete()` line is reached.

Defensive sibling of basilica-backend#486 (which fixed the leak inside
`deploy_distributed`'s own `wait_until_min_world` failure path). This
PR closes the **caller-side** leak window surfaced during the #350
closeout sweep when ex21 raced an operator-rollout leader transfer:
`wait_until_target_world(timeout=300)` raised `BelowMinimumWorld`, the
script aborted before `delete()` was reached, and the UD leaked.

Closes basilica-backend#538.

## What changed

**SDK surface** (`crates/basilica-sdk-python/python/basilica/`)
- `distributed.py`: new `DistributedTrainingManaged` (sync) and
  `DistributedTrainingManagedAsync` (lazy async) wrapper classes.
  Sync wraps an already-deployed `DistributedTraining` and runs
  `delete()` in `__exit__`. Async defers the deploy to `__aenter__`
  so the caller can write `async with client.deploy_distributed_managed_async(...) as training:`
  directly (no extra `await`), and runs `delete_async()` in `__aexit__`.
- `__init__.py`: new `BasilicaClient.deploy_distributed_managed` and
  `BasilicaClient.deploy_distributed_managed_async`. Both forward all
  keyword arguments to the underlying `deploy_distributed[_async]`
  verbatim. `__exit__` / `__aexit__` swallow any delete-time exception
  so the cleanup never masks a propagating caller exception.

**Examples**
- `examples/21_distributed_torchrun.py`: migrated to `with client.deploy_distributed_managed(...) as training:`.
- `examples/22_distributed_with_bench.py`: migrated. The
  `raise SystemExit(1)` paths on bench-Succeeded-but-no-result still
  exit 1; they now propagate through the `with` block which deletes
  the UD on its way out -- no behavioral change beyond closing the
  leak window.
- `examples/20_distributed_diloco.py`: uses the `@basilica.distributed`
  decorator (no explicit `deploy_distributed` call site), left intact
  per its own lifecycle management.

**Tests** (`crates/basilica-sdk-python/tests/test_deploy_distributed_managed.py`, new file)
- Sync: normal-exit cleanup, exception-propagation cleanup, delete-failure
  swallowed (with and without a propagating caller exception), handle
  access via `.training`.
- Async: normal-exit cleanup, exception-propagation cleanup, delete-failure
  swallowed.
- Surface: `deploy_distributed_managed[_async]` and
  `DistributedTrainingManaged[Async]` are exposed; sync class
  implements `__enter__`/`__exit__`, async class implements
  `__aenter__`/`__aexit__`.

## Compatibility

Pure Python wrapper -- no Rust changes, no PyO3 binding changes, no
SDK version bump. The existing `deploy_distributed` / `deploy_distributed_async`
call sites keep working unchanged. Users can drop into the new pattern
after the next routine SDK release.

## Test plan

- [x] `pytest tests/test_deploy_distributed_managed.py -v` -- 12 passed
- [x] `pytest -q --ignore=tests/test_dns_propagation_e2e.py` -- 132 passed (+12 over the 120 baseline; zero pre-existing tests regressed)
- [x] `mypy python/basilica` -- 249 errors, identical to the main-branch baseline (the 249 are all pre-existing PyO3 stub vs runtime-mixin attr-defined warnings; none are introduced by this PR and none mention the new symbols)
- [x] Examples compile clean (`python -m py_compile` on ex21, ex22)
- [x] `tests/test_dns_propagation_e2e.py` skipped: pre-existing missing `httpx` dependency, unrelated to this PR
- [ ] Live cluster smoke (deferred to manual run -- this PR is a pure Python wrapper around already-validated paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context managers for managed distributed training deployments that automatically handle resource cleanup and deletion on scope exit, preventing resource leaks during intermediate operations (both synchronous and asynchronous variants supported).

* **Tests**
  * Added comprehensive tests validating cleanup behavior for managed distributed deployments under normal and exceptional conditions.

* **Documentation**
  * Updated distributed training examples to use the new managed deployment approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->