### PR TITLE
fix(examples): broaden ex21 provider_filter (workaround for basilica-backend#544/#545)

### DIFF
--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -82,7 +82,17 @@ def main() -> None:
         min_gpu_memory_gb=40,
         cpu="8",
         memory="32Gi",
-        provider_filter=ProviderFilter(include=["verda"]),
+        # Broadened provider include-list (refs basilica-backend#544): pinning
+        # to a single provider exposed the example to provider-side
+        # rental-revoke transients (the autoscaler's `Rental disappeared from
+        # provider` failure mode). Including the four providers we onboard
+        # today lets the autoscaler fall back across them when one provider's
+        # rental API is misbehaving under burst load. The `topology_spread="pack"`
+        # below still keeps the workers on a single provider per UD; this list
+        # is a fallback set, not a spread directive.
+        provider_filter=ProviderFilter(
+            include=["verda", "hyperstack", "masscompute", "shadeform"]
+        ),
         topology_spread="pack",
         nccl_env={"NCCL_DEBUG": "WARN"},
         ttl_seconds=600,


### PR DESCRIPTION
## Summary

Broaden ex21's `provider_filter` include-list from `["verda"]` to `["verda", "hyperstack", "masscompute", "shadeform"]` so the autoscaler can fall back across providers when one's rental API is in burst-fail mode.

## Why

Today's basilica-backend#350 closeout sweep surfaced an autoscaler concurrency bug (filed as basilica-backend#545):
- Multiple pending pods → autoscaler fans out N parallel NodePool creates targeting the **same** highest-scored offering
- Provider's async broker accepts each `startRental`, returns rental_ids, then revokes most when downstream allocator can't keep up
- Detection commit `b3d79e03` (2026-04-22) catches the revoke and invalidates the offering
- 41+ such events fired today across verda + masscompute (zero baseline in 39h prior)

When ex21 is pinned to verda alone, the burst stays on verda and the example times out on `wait_until_target_world`. Broadening the include-list gives the autoscaler other offerings to pick when one's broker is unhealthy.

## What this is NOT

This PR does **not** fix basilica-backend#545. The autoscaler's same-offering fan-out behavior is unchanged. If multiple providers are simultaneously in burst-fail (observed in some windows today), broadening does not help — only basilica-backend#545's per-offering serialization (or equivalent) does. The recommended fix lives there.

## What `topology_spread="pack"` does

Unchanged. Each UD's workers still land on a single provider (the autoscaler's matcher picks one and packs all ranks onto it). The provider_filter list is a **fallback set**, not a spread directive. The example's stated purpose ("BYO torchrun via client.deploy_distributed") is unchanged.

## Test plan

- Validated end-to-end against prod with broadened filter: deploy + initial 2-rank world up, scale-to-3 still hits the burst issue when concurrent provisioning pressure exists. The broadening is a partial workaround and helps in single-provider-outage windows; the deeper fix is basilica-backend#545.

## Refs

- basilica-backend#544 (verda symptom of the burst class)
- basilica-backend#545 (root cause: autoscaler same-offering fan-out)
- basilica-backend#378 (sibling — original shadeform/masscompute manifestation)
- basilica-backend#350 (umbrella; surfaced during closeout sweep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the distributed training example to demonstrate configuration with multiple providers.
  * Added documentation explaining fallback behavior for provider-side rental disruptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/473)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->