### PR TITLE
fix(sdk): @basilica.distributed decorator captures module-level imports (fixes #477)

### DIFF
--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.2] - 2026-05-16
+
+### Fixed
+- `@basilica.distributed` and `@basilica.deployment` now capture the
+  defining module's top-level `import` and `from ... import ...`
+  statements and prepend them to the source shipped to the worker pod.
+  Before this fix, only the function body was shipped; module-level
+  names referenced inside the body (e.g. the `import os` in
+  `examples/20_distributed_diloco.py`) raised `NameError` at worker
+  runtime. Closes #477. Cross-repo reference:
+  `one-covenant/basilica-backend#419` Stage 4 take-3 Cell B. The same
+  capture is applied in `SourcePackager.from_function()` for the
+  lower-level packaging path.
+
 ## [0.29.1] - 2026-05-09
 
 ### Fixed

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.1"
+version = "0.29.2"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -4,8 +4,10 @@ Decorator-based deployment API.
 Provides @deployment decorator for declarative function deployments and
 @distributed decorator for distributed-training (NCCL collective) jobs.
 """
+import ast
 import functools
 import inspect
+import sys
 import textwrap
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
@@ -15,6 +17,52 @@ from .volume import Volume
 
 if TYPE_CHECKING:
     from basilica._basilica import HealthCheckConfig
+
+
+def _extract_module_level_imports(func: Callable) -> str:
+    """
+    Extract module-level `import` and `from ... import ...` statements
+    from the module that defines `func`.
+
+    The decorator-based deploy path ships only the function source via
+    `inspect.getsource(func)`; module-level imports the body references
+    would otherwise be missing on the worker. Walking the defining
+    module's AST keeps just the import statements (not arbitrary
+    top-level state), so the shipped source can be exec'd in a clean
+    namespace without `NameError`.
+
+    Returns an empty string if the module source is unavailable
+    (interactive sessions, exec/eval contexts, frozen modules).
+
+    Refs: one-covenant/basilica#477,
+    one-covenant/basilica-backend#419 (Stage 4 take-3 Cell B).
+    """
+    module = sys.modules.get(getattr(func, "__module__", "") or "")
+    if module is None:
+        return ""
+    try:
+        module_source = inspect.getsource(module)
+    except (OSError, TypeError):
+        return ""
+    try:
+        tree = ast.parse(module_source)
+    except SyntaxError:
+        return ""
+    lines: List[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            try:
+                lines.append(ast.unparse(node))
+            except AttributeError:
+                # Python < 3.9 has no `ast.unparse`; SDK requires
+                # >= 3.10 per pyproject.toml so this branch is unreachable
+                # at runtime, but keep it defensive.
+                lines.append(
+                    inspect.getsource(module).splitlines()[node.lineno - 1]
+                )
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
 
 
 class DeployedFunction:
@@ -90,7 +138,12 @@ class DeployedFunction:
         return self._deployment
 
     def _extract_source(self) -> str:
-        """Extract function body as executable source code."""
+        """Extract function body as executable source code.
+
+        Captures the defining module's top-level `import` statements
+        (via :func:`_extract_module_level_imports`) so the body's
+        references to module-level names resolve on the worker.
+        """
         full_source = inspect.getsource(self._func)
         lines = full_source.split('\n')
 
@@ -107,9 +160,14 @@ class DeployedFunction:
         func_source = '\n'.join(func_lines)
         func_source = textwrap.dedent(func_source)
 
+        # Prepend the defining module's top-level imports so names like
+        # `os`, `time`, `Optional` resolve when the body runs on the
+        # worker pod. Refs one-covenant/basilica#477.
+        imports = _extract_module_level_imports(self._func)
+
         # Generate entry point that calls the function
         func_name = self._func.__name__
-        return f'''{func_source}
+        return f'''{imports}{func_source}
 
 {func_name}()
 '''
@@ -317,6 +375,12 @@ class DistributedFunction:
         but emits a torchrun-friendly shape: the body runs once per
         rank, each rank's torchrun invocation provides
         `BASILICA_RANK`/`BASILICA_WORLD_*` env vars.
+
+        Captures the defining module's top-level `import` statements
+        (via :func:`_extract_module_level_imports`) so the body's
+        references to module-level names resolve on the worker pod.
+        Refs one-covenant/basilica#477,
+        one-covenant/basilica-backend#419 (Stage 4 take-3 Cell B).
         """
         full_source = inspect.getsource(self._func)
         lines = full_source.split("\n")
@@ -329,8 +393,9 @@ class DistributedFunction:
 
         func_lines = lines[def_idx:]
         func_source = textwrap.dedent("\n".join(func_lines))
+        imports = _extract_module_level_imports(self._func)
         func_name = self._func.__name__
-        return f"""{func_source}
+        return f"""{imports}{func_source}
 
 if __name__ == "__main__":
     {func_name}()

--- a/crates/basilica-sdk-python/python/basilica/source.py
+++ b/crates/basilica-sdk-python/python/basilica/source.py
@@ -23,12 +23,51 @@ Example:
     >>> packager = SourcePackager.from_function(my_app)
 """
 
+import ast
 import inspect
 import os
+import sys
 from pathlib import Path
 from typing import Callable, List, Optional, Union
 
 from .exceptions import SourceError
+
+
+def _extract_module_level_imports(func: Callable) -> str:
+    """
+    Extract module-level `import` / `from ... import ...` statements
+    from the module that defines `func`.
+
+    Walking the defining module's AST keeps just the import statements
+    (not arbitrary top-level state), so the shipped source can be exec'd
+    in a clean namespace without `NameError` on the worker pod.
+
+    Returns an empty string if the module source is unavailable
+    (interactive sessions, exec/eval contexts, frozen modules).
+
+    Refs one-covenant/basilica#477.
+    """
+    module = sys.modules.get(getattr(func, "__module__", "") or "")
+    if module is None:
+        return ""
+    try:
+        module_source = inspect.getsource(module)
+    except (OSError, TypeError):
+        return ""
+    try:
+        tree = ast.parse(module_source)
+    except SyntaxError:
+        return ""
+    lines: List[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            try:
+                lines.append(ast.unparse(node))
+            except AttributeError:
+                lines.append(module_source.splitlines()[node.lineno - 1])
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
 
 
 class SourcePackager:
@@ -376,6 +415,13 @@ class SourcePackager:
         # Dedent the source in case it was defined inside another scope
         import textwrap
         source = textwrap.dedent(source)
+
+        # Prepend the defining module's top-level imports so names the
+        # body relies on resolve on the worker pod. Refs
+        # one-covenant/basilica#477.
+        imports = _extract_module_level_imports(func)
+        if imports:
+            source = imports + source
 
         # Append function call if requested
         if call:

--- a/crates/basilica-sdk-python/tests/test_decorator_source_extraction.py
+++ b/crates/basilica-sdk-python/tests/test_decorator_source_extraction.py
@@ -1,0 +1,172 @@
+"""
+Tests for `@basilica.deployment` and `@basilica.distributed` source extraction.
+
+The decorators ship the wrapped function's source to a worker pod via a
+base64-encoded string. The extraction must include the module-level
+`import` statements that the function body relies on; otherwise the
+worker raises `NameError` at runtime (see one-covenant/basilica#477).
+
+These tests pin the import-capture contract so a future refactor that
+drops the module-level scan does not regress silently.
+"""
+
+# Module-level imports that the decorated test fixtures reference.
+import os
+import time
+from typing import Optional
+
+import pytest
+
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+# =============================================================================
+# @basilica.distributed source extraction
+# =============================================================================
+
+
+@basilica.distributed(
+    name="test-dist-imports",
+    image="ignored:latest",
+    world_size=WorldSize(min=1, target=1, max=1),
+    gpu_count=1,
+    gpu_models=["H100"],
+    provider_filter=ProviderFilter(include=["hyperstack"]),
+)
+def _train_with_module_imports() -> None:
+    """Fixture: references `os` and `time` from module-level scope."""
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    started = time.time()
+    print(f"rank={local_rank} started={started}", flush=True)
+
+
+@basilica.distributed(
+    name="test-dist-aliased",
+    image="ignored:latest",
+    world_size=WorldSize(min=1, target=1, max=1),
+    gpu_count=1,
+    gpu_models=["H100"],
+    provider_filter=ProviderFilter(include=["hyperstack"]),
+)
+def _train_with_aliased_import() -> None:
+    """Fixture: references `Optional` from a `from typing import Optional`."""
+    x: Optional[int] = 0
+    print(x)
+
+
+@basilica.distributed(
+    name="test-dist-no-imports",
+    image="ignored:latest",
+    world_size=WorldSize(min=1, target=1, max=1),
+    gpu_count=1,
+    gpu_models=["H100"],
+    provider_filter=ProviderFilter(include=["hyperstack"]),
+)
+def _train_no_module_imports() -> None:
+    """Fixture: only references built-ins, no module-level imports."""
+    print("hello")
+
+
+class TestDistributedSourceCapturesModuleImports:
+    """
+    Pin contract: `@basilica.distributed`'s extracted source must include
+    the module-level `import` statements the function body relies on, so
+    the wrapped script does not raise `NameError` on the worker pod.
+    """
+
+    def test_extracted_source_contains_module_level_imports(self) -> None:
+        source = _train_with_module_imports._extract_source()
+        # Header should carry the module-level imports the body uses.
+        head = source.split("def ")[0]
+        assert "import os" in head, (
+            "Expected `import os` to be captured from module scope; "
+            f"produced source head was:\n{head!r}"
+        )
+        assert "import time" in head, (
+            "Expected `import time` to be captured from module scope; "
+            f"produced source head was:\n{head!r}"
+        )
+
+    def test_extracted_source_contains_from_imports(self) -> None:
+        source = _train_with_aliased_import._extract_source()
+        head = source.split("def ")[0]
+        assert "from typing import" in head and "Optional" in head, (
+            "Expected `from typing import Optional` to be captured; "
+            f"produced source head was:\n{head!r}"
+        )
+
+    def test_extracted_source_with_no_imports_still_works(self) -> None:
+        source = _train_no_module_imports._extract_source()
+        # Must still contain the function definition and call.
+        assert "def _train_no_module_imports()" in source
+        assert "_train_no_module_imports()" in source
+
+    def test_extracted_source_executes_without_name_error(self) -> None:
+        """
+        Compile + exec the produced source with `__name__ == "__main__"`
+        so the trailing call actually runs the body. Pre-fix this raised
+        `NameError: name 'os' is not defined`. This is the canonical
+        bug from one-covenant/basilica#477.
+        """
+        source = _train_with_module_imports._extract_source()
+        ns: dict = {"__name__": "__main__"}
+        compiled = compile(source, "<test-source>", "exec")
+        # Must not raise NameError on the module-level names used inside
+        # the body.
+        exec(compiled, ns)
+        assert "_train_with_module_imports" in ns
+
+
+# =============================================================================
+# @basilica.deployment source extraction (same code path, same bug)
+# =============================================================================
+
+
+@basilica.deployment(name="test-dep-imports", port=8000)
+def _serve_with_module_imports() -> None:
+    """Fixture: references `os` from module-level scope."""
+    port = int(os.environ.get("PORT", 8000))
+    print(f"port={port}", flush=True)
+
+
+class TestDeploymentSourceCapturesModuleImports:
+    """
+    `@basilica.deployment` uses the same source-extraction shape as
+    `@basilica.distributed`. Same fix, same contract.
+    """
+
+    def test_extracted_source_contains_module_level_imports(self) -> None:
+        source = _serve_with_module_imports._extract_source()
+        head = source.split("def ")[0]
+        assert "import os" in head, (
+            "Expected `import os` to be captured from module scope; "
+            f"produced source head was:\n{head!r}"
+        )
+
+    def test_extracted_source_executes_without_name_error(self) -> None:
+        source = _serve_with_module_imports._extract_source()
+        # The deployment decorator appends a call; we want to test that
+        # the *body* is well-formed and references resolve, not that the
+        # call actually runs. Re-write the call to a no-op by trimming
+        # everything after the def for this exec.
+        # Simpler: compile and instantiate without running the trailing
+        # call. We do this by stopping at the trailing call line.
+        lines = source.splitlines()
+        # Strip trailing call (the decorator appends `<name>()`).
+        while lines and not lines[-1].strip().startswith("def "):
+            # Stop trimming if we've hit the function def itself.
+            tail = lines[-1].strip()
+            if tail == "" or tail == f"{_serve_with_module_imports.__name__}()":
+                lines.pop()
+                continue
+            break
+        trimmed = "\n".join(lines) + "\n"
+        ns: dict = {"__name__": "not-main"}
+        compiled = compile(trimmed, "<test-source>", "exec")
+        exec(compiled, ns)
+        assert "_serve_with_module_imports" in ns
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #477. Fixes the canonical `NameError: name 'os' is not defined` failure mode in `examples/20_distributed_diloco.py` documented at `one-covenant/basilica-backend#419` Stage 4 take-3 Cell B.

## Bug

The decorator-based deploy path ships only the wrapped function body via `inspect.getsource(fn)`:

- `DistributedFunction._extract_source` in `crates/basilica-sdk-python/python/basilica/decorators.py:313-337` (pre-fix)
- `DeployedFunction._extract_source` in `crates/basilica-sdk-python/python/basilica/decorators.py:92-115` (pre-fix)
- `SourcePackager.from_function` in `crates/basilica-sdk-python/python/basilica/source.py:336-389` (pre-fix)

Module-level `import` statements in the user's source file are not in scope inside the body when the body is exec'd on the worker pod. Any reference to a module-level name raises `NameError`. The failure was visible end-to-end on every worker rank of ex20:

```
Traceback (most recent call last):
  File "/tmp/__basilica_source.py", line 10, in <module>
    local_rank = int(os.environ.get("LOCAL_RANK", 0))
                     ^^
NameError: name 'os' is not defined
```

## Fix

New helper `_extract_module_level_imports(func)` walks the AST of `sys.modules[func.__module__]` and emits every top-level `ast.Import` / `ast.ImportFrom` node via `ast.unparse`. Only import statements are captured; other top-level state (function defs, dataclasses, constants) is NOT leaked into the shipped source.

Applied at all three extraction sites. Each produces source whose first lines are now:

```python
import os
import time
import basilica
from basilica import ProviderFilter, WorldSize
def train() -> None:
    ...
```

## Tests

New `tests/test_decorator_source_extraction.py` pins the import-capture contract with 6 cases:

- `@basilica.distributed` captures `import os` / `import time` from module scope
- `@basilica.distributed` captures `from typing import Optional` (from-imports)
- `@basilica.distributed` with a body that uses no module-level names still produces a valid call
- `@basilica.distributed` body can be `exec`'d in a clean namespace with `__name__ == "__main__"` without raising `NameError` (the canonical pre-fix failure mode)
- `@basilica.deployment` captures `import os` from module scope (same code path)
- `@basilica.deployment` body can be `exec`'d in a clean namespace

Pre-fix:
- 3 head-content tests FAIL (empty head: no imports captured)
- 1 exec test FAILS with `NameError: name 'os' is not defined` — exactly the worker-pod failure mode from `one-covenant/basilica-backend#419` Cell B

Post-fix:
- All 6 new tests PASS
- Full SDK test suite: 138 passed, 0 failed (132 existing + 6 new; zero regressions)

## Test plan

- [x] Failing tests pre-fix (4 failures including the canonical `NameError`)
- [x] Tests pass post-fix (all 138)
- [x] Existing examples still py_compile cleanly
- [x] `import basilica` still works post-fix
- [x] Version bumped to 0.29.2 (patch-level; bug fix)
- [x] CHANGELOG entry added
- [ ] Runtime verification on a real cluster (ex20 worker pod produces `/tmp/__basilica_source.py` that includes `import os`, and the NameError is gone). Will be exercised against `api.basilica.ai` after CI green and merge.

## Cross-repo trace

- Filed: #477
- Cross-repo evidence: `one-covenant/basilica-backend#419` Stage 4 take-3 Cell B (`data/evidence/419-stage-4-take-3/B-example20-diloco/`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NameError exceptions in distributed and deployment decorators by ensuring module-level import statements are properly captured and shipped to worker environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->