### PR TITLE
fix(sdk): recognize BenchStatus phase=Skipped as terminal (closes #480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.29.0"
+version = "0.29.4"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.4] - 2026-05-18
+
+### Fixed
+- `BenchStatus` recognises `phase=Skipped` as a terminal state.
+  `_BENCH_TERMINAL_PHASES` now contains all four operator-side terminal
+  phases (`Succeeded`, `Failed`, `TimedOut`, `Skipped`), so
+  `BenchStatus.is_terminal` returns `True` on `Skipped` and
+  `wait_until_bench_complete` / `wait_until_bench_complete_async` return
+  the terminal `BenchStatus` instead of polling until the user-supplied
+  timeout and raising `TimeoutError`. Pre-fix, the SDK had the data
+  (the operator wrote terminal `BenchStatus{phase=Skipped,
+  lastAttemptOutcome="skipped"}` to the UD CR) but did not act on it
+  -- the `TimeoutError` message literally contained `(phase=Skipped)`.
+  Closes #480. Cross-repo reference:
+  `one-covenant/basilica-backend#419` Stage 4 take-5 Cell B and the
+  basilica-backend operator X2 fix (`one-covenant/basilica-backend#650
+  / #653`).
+
+### Added
+- `BenchStatus.is_successful` / `is_failed` / `is_skipped` properties.
+  Pin the semantic that `Skipped` is terminal but neither success nor
+  failure -- the bench probe was not run (e.g. workers exited before
+  the bench-controller observed them). The workload's own exit codes
+  remain the source of truth for run success; bench is an opt-in,
+  best-effort measurement.
+
 ## [0.29.3] - 2026-05-17
 
 ### Fixed

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.3"
+version = "0.29.4"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.3"
+version = "0.29.4"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -215,7 +215,12 @@ BENCH_PHASE_FAILED: str = "Failed"
 BENCH_PHASE_TIMED_OUT: str = "TimedOut"
 
 _BENCH_TERMINAL_PHASES: frozenset = frozenset(
-    {BENCH_PHASE_SUCCEEDED, BENCH_PHASE_FAILED, BENCH_PHASE_TIMED_OUT}
+    {
+        BENCH_PHASE_SUCCEEDED,
+        BENCH_PHASE_FAILED,
+        BENCH_PHASE_TIMED_OUT,
+        BENCH_PHASE_SKIPPED,
+    }
 )
 
 
@@ -235,6 +240,15 @@ class BenchStatus:
     on the bench probe. Most callers should NOT need that; the bench
     is a sanity probe per `basilica_bench.py:75-78`, not a gating
     measurement.
+
+    Terminal semantics (closes #480): four phases are terminal --
+    `Succeeded`, `Failed`, `TimedOut`, and `Skipped`. `Skipped` is the
+    operator's "the bench probe was not run because preconditions
+    weren't met" signal (e.g. workers exited before the bench-controller
+    observed them, see basilica-backend X2 fix). It is NOT a success
+    and NOT a failure; it means "wasn't run". Callers should treat the
+    workload's own exit codes as the source of truth for run success;
+    bench is a separate, opt-in measurement.
     """
 
     mode: str
@@ -248,8 +262,44 @@ class BenchStatus:
 
     @property
     def is_terminal(self) -> bool:
-        """True iff phase is `Succeeded`, `Failed`, or `TimedOut`."""
+        """
+        True iff phase is `Succeeded`, `Failed`, `TimedOut`, or `Skipped`.
+
+        Closes #480: `Skipped` is terminal -- the operator has decided
+        the bench probe will not run (workers exited before the
+        bench-controller observed them, or another precondition failed),
+        and there is nothing further to wait for.
+        """
         return self.phase in _BENCH_TERMINAL_PHASES
+
+    @property
+    def is_successful(self) -> bool:
+        """True iff the bench probe ran and produced a measurement (`phase == Succeeded`)."""
+        return self.phase == BENCH_PHASE_SUCCEEDED
+
+    @property
+    def is_failed(self) -> bool:
+        """
+        True iff the bench probe ran and errored (`phase in {Failed, TimedOut}`).
+
+        Closes #480: `Skipped` is NOT a failure. It means the probe was
+        not run at all; the workers may still be perfectly healthy.
+        Callers that branch on bench-side errors should use this; the
+        operator never sets `Failed` / `TimedOut` for a skipped probe.
+        """
+        return self.phase in (BENCH_PHASE_FAILED, BENCH_PHASE_TIMED_OUT)
+
+    @property
+    def is_skipped(self) -> bool:
+        """
+        True iff the operator decided not to run the bench probe
+        (`phase == Skipped`).
+
+        Closes #480: terminal, but neither success nor failure. See
+        `self.message` for the operator's reason (e.g. "workers exited
+        before bench-controller observed them").
+        """
+        return self.phase == BENCH_PHASE_SKIPPED
 
     @classmethod
     def from_status_dict(cls, raw: Dict[str, Any]) -> "BenchStatus":
@@ -668,12 +718,30 @@ class DistributedTraining:
         the bench measurement before continuing (e.g. a research run
         that records busbw metadata into checkpoint headers).
 
-        Returns the terminal :py:class:`BenchStatus` (`phase` is one
-        of `Succeeded` | `Failed` | `TimedOut`). If `bench.mode != on-start`
-        returns `None` immediately. Polls every 5s.
+        Returns the terminal :py:class:`BenchStatus` once `phase`
+        enters a terminal state. Closes #480: the four terminal phases
+        are:
+
+        - `Succeeded` -- bench probe produced a measurement; the result
+          payload is on `BenchStatus.result` (mirrored on
+          `DistributedTraining.bench` for backward compatibility).
+        - `Failed` -- bench probe ran but errored. See `message`.
+        - `TimedOut` -- bench probe's own deadline elapsed before
+          completion. See `message`.
+        - `Skipped` -- the operator decided not to run the bench probe
+          (e.g. workers exited before the bench-controller observed
+          them). See `message` for the reason. NOT a failure; the
+          workload itself may have completed cleanly.
+
+        If `bench.mode != on-start` returns `None` immediately (nothing
+        to wait on). Polls every 5s.
 
         Default timeout matches the operator's `BENCH_ACTIVE_DEADLINE_SECONDS`
-        (1500s = 25 min). Raises `TimeoutError` past the deadline.
+        (1500s = 25 min). Raises `TimeoutError` past the deadline if the
+        bench has not reached a terminal phase. Callers handling a
+        terminal `Skipped` should branch on `bs.is_skipped` (or
+        `bs.phase != "Succeeded"`); see `examples/20_distributed_diloco.py`
+        and `examples/22_distributed_with_bench.py`.
         """
         deadline = time.monotonic() + max(timeout, 0)
         while time.monotonic() < deadline:
@@ -698,7 +766,12 @@ class DistributedTraining:
     async def wait_until_bench_complete_async(
         self, timeout: int = 1500
     ) -> Optional[BenchStatus]:
-        """Async variant of :py:meth:`wait_until_bench_complete`."""
+        """
+        Async variant of :py:meth:`wait_until_bench_complete`.
+
+        Same terminal-phase set: `Succeeded` | `Failed` | `TimedOut` |
+        `Skipped` (closes #480). Same `None`-on-bench-off semantics.
+        """
         deadline = asyncio.get_event_loop().time() + max(timeout, 0)
         while asyncio.get_event_loop().time() < deadline:
             await self.refresh_async()

--- a/crates/basilica-sdk-python/tests/test_bench_status_skipped.py
+++ b/crates/basilica-sdk-python/tests/test_bench_status_skipped.py
@@ -1,0 +1,283 @@
+"""
+Tests for `BenchStatus(phase="Skipped")` terminal-phase recognition.
+
+Closes #480. Cross-repo reference: `one-covenant/basilica-backend#419`
+Stage 4 take-5 Cell B and the basilica-backend operator X2 fix
+(`one-covenant/basilica-backend#650 / #653`), which emits a terminal
+`BenchStatus{phase=Skipped, lastAttemptOutcome="skipped",
+lastAttemptAt=...}` on the UD CR when workers exit before the
+bench-controller observes them. The SDK must recognise this as
+terminal and return cleanly from `wait_until_bench_complete` instead
+of polling until the user-supplied timeout and raising `TimeoutError`.
+
+Coverage
+--------
+- `_BENCH_TERMINAL_PHASES` contains all four terminal phases
+  (`Succeeded`, `Failed`, `TimedOut`, `Skipped`).
+- `BENCH_PHASE_SKIPPED` is importable from the top-level `basilica`
+  package (export check).
+- `BenchStatus(phase="Skipped")` properties:
+  `is_terminal=True`, `is_skipped=True`, `is_successful=False`,
+  `is_failed=False`.
+- The matching properties for the other five phases (`Succeeded`,
+  `Failed`, `TimedOut`, `Pending`, `Running`) are consistent (e.g.
+  `Failed` -> `is_failed=True, is_successful=False, is_skipped=False`).
+- `wait_until_bench_complete` returns the `BenchStatus` on `Skipped`
+  without raising, mirroring the existing `Succeeded` / `Failed`
+  / `TimedOut` paths.
+- `wait_until_bench_complete_async` honours the same contract.
+- `BenchStatus.from_status_dict` round-trips the operator's
+  `phase=Skipped, lastAttemptOutcome=skipped` shape verbatim.
+"""
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import basilica
+from basilica import BenchStatus, DistributedTraining
+from basilica.distributed import (
+    BENCH_PHASE_FAILED,
+    BENCH_PHASE_PENDING,
+    BENCH_PHASE_RUNNING,
+    BENCH_PHASE_SKIPPED,
+    BENCH_PHASE_SUCCEEDED,
+    BENCH_PHASE_TIMED_OUT,
+    _BENCH_TERMINAL_PHASES,
+)
+
+
+def _make_bench_status(
+    phase: str,
+    message: str = "",
+    last_attempt_outcome: str = "",
+) -> BenchStatus:
+    """Build a `BenchStatus` mirroring the operator's wire shape."""
+    return BenchStatus(
+        mode="on-start",
+        phase=phase,
+        result=None,
+        started_at=None,
+        completed_at=None,
+        message=message or None,
+        last_attempt_at=None,
+        last_attempt_outcome=last_attempt_outcome or None,
+    )
+
+
+def _make_status_dict_for_phase(phase: str, message: str = "") -> Any:
+    """PyO3-shape fake response with a bench block at `phase`."""
+    bench: Dict[str, Any] = {
+        "mode": "on-start",
+        "phase": phase,
+    }
+    if phase != "Pending":
+        bench["startedAt"] = "2026-05-18T00:46:25Z"
+    if phase in {"Succeeded", "Failed", "TimedOut"}:
+        bench["completedAt"] = "2026-05-18T01:01:31Z"
+    if phase == "Skipped":
+        bench["lastAttemptAt"] = "2026-05-18T01:15:50Z"
+        bench["lastAttemptOutcome"] = "skipped"
+    if message:
+        bench["message"] = message
+
+    class FakeDeployment:
+        instance_name = "ud-bench-skipped"
+        user_id = "u-test"
+        namespace = "u-test"
+        image = "pytorch/pytorch"
+        state = "running"
+        url = "https://x"
+        created_at = "2026-05-18T00:46:25Z"
+        updated_at = "2026-05-18T01:15:50Z"
+        phase = "succeeded"
+        message = None
+        share_token = None
+        share_url = None
+        public_metadata = False
+        distributed = {
+            "worldSize": {
+                "ready": 0,
+                "target": 4,
+                "min": 2,
+                "max": 4,
+                "belowMinimum": True,
+            },
+            "ranks": [],
+            "transport": "hub-relay",
+            "bench": bench,
+        }
+
+    return FakeDeployment()
+
+
+class TestTerminalPhaseFrozenset:
+    def test_skipped_is_in_terminal_frozenset(self) -> None:
+        assert BENCH_PHASE_SKIPPED in _BENCH_TERMINAL_PHASES
+
+    def test_frozenset_contains_all_four_terminal_phases(self) -> None:
+        assert _BENCH_TERMINAL_PHASES == frozenset(
+            {
+                BENCH_PHASE_SUCCEEDED,
+                BENCH_PHASE_FAILED,
+                BENCH_PHASE_TIMED_OUT,
+                BENCH_PHASE_SKIPPED,
+            }
+        )
+
+    def test_non_terminal_phases_excluded(self) -> None:
+        assert BENCH_PHASE_PENDING not in _BENCH_TERMINAL_PHASES
+        assert BENCH_PHASE_RUNNING not in _BENCH_TERMINAL_PHASES
+
+
+class TestSkippedConstantExport:
+    def test_bench_phase_skipped_top_level_export(self) -> None:
+        """`from basilica import BENCH_PHASE_SKIPPED` resolves."""
+        assert basilica.BENCH_PHASE_SKIPPED == "Skipped"
+
+    def test_all_phase_constants_consistent_across_exports(self) -> None:
+        """Top-level re-exports match the distributed-module constants."""
+        assert basilica.BENCH_PHASE_SKIPPED == BENCH_PHASE_SKIPPED
+        assert basilica.BENCH_PHASE_SUCCEEDED == BENCH_PHASE_SUCCEEDED
+        assert basilica.BENCH_PHASE_FAILED == BENCH_PHASE_FAILED
+        assert basilica.BENCH_PHASE_TIMED_OUT == BENCH_PHASE_TIMED_OUT
+
+
+class TestBenchStatusSkippedProperties:
+    def test_skipped_is_terminal(self) -> None:
+        bs = _make_bench_status(
+            "Skipped",
+            message="bench skipped: workers exited before bench-controller observed them",
+            last_attempt_outcome="skipped",
+        )
+        assert bs.is_terminal is True
+
+    def test_skipped_is_not_successful(self) -> None:
+        bs = _make_bench_status("Skipped")
+        assert bs.is_successful is False
+
+    def test_skipped_is_not_failed(self) -> None:
+        bs = _make_bench_status("Skipped")
+        assert bs.is_failed is False
+
+    def test_skipped_is_skipped(self) -> None:
+        bs = _make_bench_status("Skipped")
+        assert bs.is_skipped is True
+
+
+class TestOtherPhasePropertyMatrix:
+    """Property invariants across the full phase enum -- guards against
+    Skipped semantics accidentally bleeding into the other phases."""
+
+    def test_succeeded(self) -> None:
+        bs = _make_bench_status("Succeeded")
+        assert bs.is_terminal is True
+        assert bs.is_successful is True
+        assert bs.is_failed is False
+        assert bs.is_skipped is False
+
+    def test_failed(self) -> None:
+        bs = _make_bench_status("Failed", message="err")
+        assert bs.is_terminal is True
+        assert bs.is_successful is False
+        assert bs.is_failed is True
+        assert bs.is_skipped is False
+
+    def test_timed_out(self) -> None:
+        bs = _make_bench_status("TimedOut", message="deadline elapsed")
+        assert bs.is_terminal is True
+        assert bs.is_successful is False
+        assert bs.is_failed is True
+        assert bs.is_skipped is False
+
+    def test_pending(self) -> None:
+        bs = _make_bench_status("Pending")
+        assert bs.is_terminal is False
+        assert bs.is_successful is False
+        assert bs.is_failed is False
+        assert bs.is_skipped is False
+
+    def test_running(self) -> None:
+        bs = _make_bench_status("Running")
+        assert bs.is_terminal is False
+        assert bs.is_successful is False
+        assert bs.is_failed is False
+        assert bs.is_skipped is False
+
+
+class TestFromStatusDictSkipped:
+    def test_roundtrip_operator_skipped_shape(self) -> None:
+        raw: Dict[str, Any] = {
+            "mode": "on-start",
+            "phase": "Skipped",
+            "message": "bench skipped: workers exited before bench-controller observed them",
+            "lastAttemptAt": "2026-05-18T01:15:50.448532222+00:00",
+            "lastAttemptOutcome": "skipped",
+        }
+        bs = BenchStatus.from_status_dict(raw)
+        assert bs.phase == "Skipped"
+        assert bs.is_terminal is True
+        assert bs.is_skipped is True
+        assert bs.is_successful is False
+        assert bs.is_failed is False
+        assert bs.mode == "on-start"
+        assert bs.result is None
+        assert bs.last_attempt_outcome == "skipped"
+        assert (
+            bs.message
+            == "bench skipped: workers exited before bench-controller observed them"
+        )
+        assert bs.last_attempt_at is not None
+
+
+class TestWaitUntilBenchCompleteSkipped:
+    """Closes #480: `wait_until_bench_complete` returns the `Skipped`
+    BenchStatus rather than polling until the user-supplied timeout and
+    raising `TimeoutError`."""
+
+    def test_returns_skipped_status_without_raising(self) -> None:
+        client = MagicMock()
+        client.get.return_value = _make_status_dict_for_phase(
+            "Skipped",
+            message="bench skipped: workers exited before bench-controller observed them",
+        )
+        training = DistributedTraining(client, "ud-bench-skipped")
+        bs = training.wait_until_bench_complete(timeout=10)
+        assert bs is not None
+        assert bs.phase == "Skipped"
+        assert bs.is_terminal is True
+        assert bs.is_skipped is True
+        assert bs.is_successful is False
+        assert bs.is_failed is False
+        assert bs.last_attempt_outcome == "skipped"
+        assert bs.message is not None
+        assert "workers exited" in bs.message
+
+    def test_async_returns_skipped_status_without_raising(self) -> None:
+        client = MagicMock()
+        client.get.return_value = _make_status_dict_for_phase(
+            "Skipped",
+            message="bench skipped: workers exited before bench-controller observed them",
+        )
+        training = DistributedTraining(client, "ud-bench-skipped")
+
+        async def _run() -> BenchStatus:
+            result = await training.wait_until_bench_complete_async(timeout=10)
+            assert result is not None
+            return result
+
+        bs = asyncio.run(_run())
+        assert bs.phase == "Skipped"
+        assert bs.is_terminal is True
+        assert bs.is_skipped is True
+
+    def test_other_terminal_phases_unaffected(self) -> None:
+        """Regression guard: Succeeded / Failed / TimedOut still terminate."""
+        for phase in ("Succeeded", "Failed", "TimedOut"):
+            client = MagicMock()
+            client.get.return_value = _make_status_dict_for_phase(phase)
+            training = DistributedTraining(client, "ud-bench-" + phase.lower())
+            bs = training.wait_until_bench_complete(timeout=10)
+            assert bs is not None, f"phase={phase} returned None"
+            assert bs.phase == phase
+            assert bs.is_terminal is True


### PR DESCRIPTION
## Summary

Closes #480.

`crates/basilica-sdk-python/python/basilica/distributed.py` defined `BENCH_PHASE_SKIPPED = "Skipped"` (line 210) but omitted it from `_BENCH_TERMINAL_PHASES` (lines 217-219). As a result `BenchStatus(phase="Skipped").is_terminal` returned `False`, and `wait_until_bench_complete` polled until the user-supplied timeout, then raised `TimeoutError` whose message contained `(phase=Skipped)` — proving the SDK already had the terminal data but did not act on it.

The basilica-backend operator (X2 fix, `one-covenant/basilica-backend#650 / #653`) emits a terminal `BenchStatus{phase=Skipped, lastAttemptOutcome="skipped", lastAttemptAt=...}` plus a `BenchSkipped` Event when workers exit before the bench-controller observes them. The SDK must recognise this as terminal.

This is a multi-file Skipped-as-terminal alignment, not a one-line frozenset edit.

## Surface changes

### `python/basilica/distributed.py`

- `_BENCH_TERMINAL_PHASES` adds `BENCH_PHASE_SKIPPED`; the existing `BenchStatus.is_terminal` property picks the change up by construction.
- `BenchStatus` gains three explicit semantic properties:
  - `is_successful` — `True` iff `phase == Succeeded`.
  - `is_failed` — `True` iff `phase in {Failed, TimedOut}`. **Skipped is NOT a failure.**
  - `is_skipped` — `True` iff `phase == Skipped` (terminal-but-not-run).
  These pin the semantic that Skipped is terminal but neither success nor failure: the probe was not run; the workload itself may have completed cleanly.
- `wait_until_bench_complete` and `wait_until_bench_complete_async` docstrings now enumerate **all four** terminal phases (Succeeded, Failed, TimedOut, Skipped) and reference the example consumers.

### `examples/`

`examples/20_distributed_diloco.py` and `examples/22_distributed_with_bench.py` already branch on `phase != "Succeeded"`, so the natural Skipped path is the existing phase-aware `print(...)` + clean return. **No example refactor required**; the existing else-branch now handles the operator's Skipped phase end-to-end once the waiter returns instead of raising.

### `tests/test_bench_status_skipped.py` (new)

18 new tests covering:

- Frozenset membership: `Skipped` in `_BENCH_TERMINAL_PHASES`; `Pending` / `Running` excluded; full four-phase composition.
- `BENCH_PHASE_SKIPPED` importable from the top-level `basilica` package and consistent with the per-module constant.
- `BenchStatus(phase=...)` property matrix across all six phases (Succeeded, Failed, TimedOut, Skipped, Pending, Running) — pins `is_terminal` / `is_successful` / `is_failed` / `is_skipped`.
- `BenchStatus.from_status_dict` round-trip of the operator's `Skipped` JSON shape (mode, phase, message, lastAttemptAt, lastAttemptOutcome).
- `wait_until_bench_complete` returns the `Skipped` BenchStatus without raising.
- `wait_until_bench_complete_async` honours the same contract.
- Regression guard: Succeeded / Failed / TimedOut still terminate cleanly via the waiter.

### Version bump

- `CHANGELOG.md`: `[0.29.4] - 2026-05-18` entry under `Fixed` + `Added`.
- `pyproject.toml`: `0.29.3` -> `0.29.4`.
- `Cargo.toml`: `0.29.3` -> `0.29.4`.
- `Cargo.lock`: regenerated.

## Test plan

- [x] `python -m pytest crates/basilica-sdk-python/tests/ -v --ignore=tests/test_dns_propagation_e2e.py` -- 157 passed (18 new + 139 pre-existing). The `test_dns_propagation_e2e.py` collection error is pre-existing (`httpx` not in venv) and unrelated.
- [x] Manual smoke: `BenchStatus(phase="Skipped").is_terminal == True`; `is_skipped == True`; `is_successful == False`; `is_failed == False`.
- [x] Manual smoke: `wait_until_bench_complete` against a fake client emitting `phase=Skipped` returns the BenchStatus rather than raising.
- [ ] CI: `test-python-sdk` matrix (3.10 / 3.11 / 3.12 / 3.13).
- [ ] CI: version-consistency guard (`Cargo.toml == pyproject.toml`).
- [ ] **Runtime verification**: re-run `examples/20_distributed_diloco.py` against `api.basilica.ai` once this lands; expect exit 0 with phase-aware Skipped message instead of the prior `TimeoutError`.

## Cross-ref

`one-covenant/basilica-backend#419` Stage 4 take-5 Cell B captured the runtime artefact that surfaced this. Operator-side X2 fix is `one-covenant/basilica-backend#650 / #653`.

Cross-ref: one-covenant/basilica-backend#419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `BenchStatus` to treat `Skipped` phase as terminal, preventing timeouts in wait operations.

* **New Features**
  * Added `is_successful`, `is_failed`, and `is_skipped` boolean properties to `BenchStatus` for improved phase checking.

* **Tests**
  * Added comprehensive test coverage for `Skipped` bench status handling.

* **Chores**
  * Bumped version to 0.29.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->