### PR TITLE
feat(sdk): collapse @distributed + deploy_distributed_managed (fixes one-covenant/basilica-backend#660)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.29.4"
+version = "0.29.5"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.5] - 2026-05-18
+
+### Added
+- `DistributedTraining` is now itself a context manager (sync and async).
+  `__enter__` / `__exit__` return the handle and best-effort `delete()`
+  the UD on scope exit; `__aenter__` / `__aexit__` are the async
+  counterparts. Replaces the prior `DistributedTrainingManaged` ceremony
+  wrapper -- callers now write `with train() as training:` directly on
+  the decorator-returned object.
+
+### Deprecated
+- `BasilicaClient.deploy_distributed` and `deploy_distributed_async`
+  emit `DeprecationWarning` on direct calls. The decorator
+  `@basilica.distributed` remains the canonical surface; the decorator
+  itself does NOT trip the warning (it passes `_emit_deprecation=False`
+  to the underlying call).
+- `BasilicaClient.deploy_distributed_managed` and
+  `deploy_distributed_managed_async` emit `DeprecationWarning`. The
+  ceremony wrapper they returned is redundant now that
+  `DistributedTraining` is itself context-manager-able. Both methods
+  remain functional for two minor versions; remove at the next major
+  bump.
+
+Closes basilica-backend#660. Refs the SDK API simplification plan
+(`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main)
+ticket SDK-S1.
+
 ## [0.29.4] - 2026-05-18
 
 ### Fixed

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.4"
+version = "0.29.5"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.4"
+version = "0.29.5"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -1126,9 +1126,29 @@ class BasilicaClient:
         enable_billing: bool = True,
         wait_for_bench: Literal["never", "best_effort", "required"] = "never",
         bench_timeout: int = 1500,
+        _emit_deprecation: bool = True,
     ) -> DistributedTraining:
         """
         Deploy a distributed-training UserDeployment (SDK arch § 4).
+
+        .. deprecated:: 0.29.5
+            basilica-backend issue 660 / SDK-S1: prefer the
+            ``@basilica.distributed`` decorator. Calling it returns a
+            :class:`DistributedTraining` that is itself context-manager-able::
+
+                @basilica.distributed(...)
+                def train(): ...
+
+                with train() as training:        # auto-cleanup on scope exit
+                    training.scale(target=3)
+                    training.wait_until_target_world(timeout=300)
+                    print(training.bench)
+
+            This method remains functional for the next two minor versions
+            and emits a :class:`DeprecationWarning` on direct calls. The
+            decorator path itself does NOT trip the warning (the decorator
+            calls this method with ``_emit_deprecation=False`` so the user
+            sees no warning when they use the canonical surface).
 
         Switches the workload from a single-replica Deployment to a
         per-UD StatefulSet + rendezvous Pod + per-rank pods. Use this
@@ -1216,6 +1236,17 @@ class BasilicaClient:
                 `Failed` / `TimedOut` / `Skipped`, or the bench wait timed
                 out without a terminal phase.
         """
+        if _emit_deprecation:
+            warnings.warn(
+                "BasilicaClient.deploy_distributed is deprecated; prefer the "
+                "@basilica.distributed decorator. The decorator returns a "
+                "DistributedTraining that is itself context-manager-able "
+                "(use `with train() as training:` for mid-run orchestration "
+                "or call `train()` bare for fire-and-forget). See "
+                "basilica-backend issue 660 / SDK-S1 for migration details.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if world_size is None:
             raise ValidationError("deploy_distributed requires world_size", field="world_size")
         if wait_for_bench not in ("never", "best_effort", "required"):
@@ -1310,34 +1341,43 @@ class BasilicaClient:
         """
         Context-managed variant of :meth:`deploy_distributed`.
 
-        Defensive sibling of basilica-backend#486 (which fixed UD leak
-        inside ``deploy_distributed`` itself when the initial
-        ``wait_until_min_world`` raised). This variant fixes the
-        *caller-side* leak: when an intermediate wait such as
-        ``wait_until_target_world`` (after ``scale()``) raises, the
-        script aborts before reaching ``delete()``.
+        .. deprecated:: 0.29.5
+            basilica-backend issue 660 / SDK-S1: collapsed into the
+            canonical surface. :class:`DistributedTraining` is itself
+            context-manager-able now, so the wrapper this method returns
+            is redundant. Prefer the ``@basilica.distributed`` decorator::
 
-        Returns a :class:`DistributedTrainingManaged` that, on scope
-        exit (normal OR exceptional), best-effort calls
-        ``training.delete()`` so the UD does not leak.
+                @basilica.distributed(...)
+                def train(): ...
+
+                with train() as training:        # auto-cleanup on scope exit
+                    training.scale(target=3)
+                    training.wait_until_target_world(timeout=300)
+
+            This method remains functional for the next two minor versions
+            and emits a :class:`DeprecationWarning` on direct calls.
 
         All keyword arguments match :meth:`deploy_distributed` exactly
         and are forwarded verbatim. See that method for full semantics.
 
-        Recommended pattern for any ``deploy → use → delete`` flow::
-
-            with client.deploy_distributed_managed(
-                name="dlc-job",
-                image="...",
-                world_size=WorldSize(min=2, target=2, max=4),
-            ) as training:
-                training.scale(target=3)
-                training.wait_until_target_world(timeout=300)
-                ...
-            # `delete()` ran on scope exit, success or exception.
-
-        Refs: basilica-backend#538 (defensive sibling of #486).
+        Refs: basilica-backend#538 (defensive sibling of #486) — the
+        leak-protection contract that this method originally introduced
+        is now built into :class:`DistributedTraining` directly via
+        :py:meth:`DistributedTraining.__exit__`.
         """
+        warnings.warn(
+            "BasilicaClient.deploy_distributed_managed is deprecated; "
+            "DistributedTraining is itself context-manager-able now. "
+            "Prefer the @basilica.distributed decorator and write "
+            "`with train() as training:` to get the same auto-cleanup "
+            "contract. See basilica-backend issue 660 / SDK-S1 for "
+            "migration details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Pass `_emit_deprecation=False` to avoid a double-warning. The
+        # outer warning here is the one the user should see; the inner
+        # `deploy_distributed` call is plumbing.
         training = self.deploy_distributed(
             name=name,
             source=source,
@@ -1364,6 +1404,7 @@ class BasilicaClient:
             enable_billing=enable_billing,
             wait_for_bench=wait_for_bench,
             bench_timeout=bench_timeout,
+            _emit_deprecation=False,
         )
         return DistributedTrainingManaged(training)
 
@@ -2332,15 +2373,31 @@ class BasilicaClient:
         enable_billing: bool = True,
         wait_for_bench: Literal["never", "best_effort", "required"] = "never",
         bench_timeout: int = 1500,
+        _emit_deprecation: bool = True,
     ) -> DistributedTraining:
         """
         Async variant of `deploy_distributed`. Same arguments and semantics
         per SDK arch § 9; uses `run_in_executor` over the underlying Rust
         client and `asyncio.sleep` for the wait loop.
 
+        .. deprecated:: 0.29.5
+            See :py:meth:`deploy_distributed` -- same deprecation, same
+            replacement (``@basilica.distributed`` decorator + ``async with
+            training:`` block).
+
         See `deploy_distributed` for the `wait_for_bench` /
         `bench_timeout` contract.
         """
+        if _emit_deprecation:
+            warnings.warn(
+                "BasilicaClient.deploy_distributed_async is deprecated; "
+                "prefer the @basilica.distributed decorator. The decorator "
+                "returns a DistributedTraining that supports `async with "
+                "training:` directly. See basilica-backend issue 660 / "
+                "SDK-S1 for migration details.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if world_size is None:
             raise ValidationError("deploy_distributed_async requires world_size", field="world_size")
         if wait_for_bench not in ("never", "best_effort", "required"):
@@ -2429,32 +2486,38 @@ class BasilicaClient:
         """
         Async context-managed variant of :meth:`deploy_distributed_async`.
 
-        Returns a :class:`DistributedTrainingManagedAsync` for use
-        directly with ``async with``. The actual deploy runs in
-        ``__aenter__`` (lazy), so this method itself does NOT need to
-        be awaited. On scope exit (normal OR exceptional), best-effort
-        calls ``training.delete_async()`` so the UD does not leak.
+        .. deprecated:: 0.29.5
+            basilica-backend issue 660 / SDK-S1: collapsed into the
+            canonical surface. :class:`DistributedTraining` is itself
+            async-context-manager-able now. Prefer the
+            ``@basilica.distributed`` decorator and write ``async with
+            train() as training:`` -- same auto-cleanup contract,
+            shorter call site.
 
         All keyword arguments match :meth:`deploy_distributed_async`
         exactly and are forwarded verbatim.
 
-        Recommended pattern::
-
-            async with client.deploy_distributed_managed_async(
-                name="dlc-job",
-                image="...",
-                world_size=WorldSize(min=2, target=2, max=4),
-            ) as training:
-                await training.scale_async(target=3)
-                await training.wait_until_target_world_async(timeout=300)
-                ...
-
-        Refs: basilica-backend#538 (defensive sibling of #486).
+        Refs: basilica-backend#538 (defensive sibling of #486) — the
+        leak-protection contract that this method originally introduced
+        is now built into :class:`DistributedTraining` directly via
+        :py:meth:`DistributedTraining.__aexit__`.
         """
+        warnings.warn(
+            "BasilicaClient.deploy_distributed_managed_async is deprecated; "
+            "DistributedTraining is itself async-context-manager-able now. "
+            "Prefer the @basilica.distributed decorator and write "
+            "`async with train() as training:`. See basilica-backend "
+            "issue 660 / SDK-S1 for migration details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         # Capture the deploy invocation as a zero-arg coroutine factory
         # so the manager can defer the deploy until `__aenter__`. Using
         # a factory (not a one-shot coroutine) keeps the manager
-        # idempotent under accidental re-entry.
+        # idempotent under accidental re-entry. `_emit_deprecation=False`
+        # prevents double-warning -- the outer warning above is the one
+        # the user should see; the inner deploy call is plumbing.
         def _factory() -> Any:
             return self.deploy_distributed_async(
                 name=name,
@@ -2482,6 +2545,7 @@ class BasilicaClient:
                 enable_billing=enable_billing,
                 wait_for_bench=wait_for_bench,
                 bench_timeout=bench_timeout,
+                _emit_deprecation=False,
             )
 
         return DistributedTrainingManagedAsync(_factory)

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -419,15 +419,23 @@ class DistributedFunction:
 
         Returns:
             DistributedTraining: facade with scale/wait/logs/bench/delete
-                and `_async` counterparts.
+                and `_async` counterparts. Is itself context-manager-able
+                (basilica-backend issue 660 / SDK-S1) -- use
+                ``with train() as training:`` for mid-run orchestration
+                with auto-cleanup.
         """
         from . import BasilicaClient
 
         client = client or BasilicaClient()
         source = self._extract_source()
 
+        # basilica-backend issue 660 / SDK-S1: the decorator IS the
+        # canonical surface, so the underlying `deploy_distributed`
+        # call must NOT emit its own DeprecationWarning -- the user
+        # opted into the canonical path by using the decorator.
         self._training = client.deploy_distributed(
             source=source,
+            _emit_deprecation=False,
             **self._kwargs,
         )
         return self._training

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -1044,6 +1044,58 @@ class DistributedTraining:
         await asyncio.get_event_loop().run_in_executor(None, self.delete)
 
     # -------------------------------------------------------------------------
+    # Context-manager protocol (basilica-backend issue 660 / SDK-S1).
+    #
+    # `DistributedTraining` is the ONE canonical handle for a distributed
+    # UD. Bare-call paths (`@basilica.distributed` decorator-call,
+    # `client.deploy_distributed(...)`) return this object directly; the
+    # `with training:` block triggers best-effort `.delete()` on scope
+    # exit so callers don't leak the UD when an intermediate operation
+    # (e.g. `wait_until_target_world` after `scale`) raises.
+    #
+    # Replaces the prior `DistributedTrainingManaged` ceremony wrapper.
+    # That wrapper remains as a back-compat shim for callers that already
+    # type-annotate against it; the `deploy_distributed_managed[_async]`
+    # factory emits a `DeprecationWarning` pointing at this surface.
+    # -------------------------------------------------------------------------
+
+    def __enter__(self) -> "DistributedTraining":
+        """Return self so `with training as t:` yields the handle."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """
+        Best-effort cleanup on scope exit. Swallows any delete-time
+        exception so we never mask the (possibly more important) caller
+        exception that is already propagating out of the `with` block.
+        """
+        try:
+            self.delete()
+        except Exception:
+            pass
+
+    async def __aenter__(self) -> "DistributedTraining":
+        """Async variant of `__enter__`; returns self."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Async best-effort cleanup; same swallow contract as `__exit__`."""
+        try:
+            await self.delete_async()
+        except Exception:
+            pass
+
+    # -------------------------------------------------------------------------
     # Logs and debug
     # -------------------------------------------------------------------------
 

--- a/crates/basilica-sdk-python/tests/test_distributed_canonical_surface.py
+++ b/crates/basilica-sdk-python/tests/test_distributed_canonical_surface.py
@@ -1,0 +1,359 @@
+"""
+Unit tests pinning the canonical distributed-training SDK surface
+(basilica-backend issue 660 / SDK-S1).
+
+WHY this file exists (read the issue body for the full plan):
+
+Today the SDK exposes THREE deploy paths for a distributed UD:
+- `@basilica.distributed(...)` -- decorator-call returns DistributedTraining
+   (fire-and-forget) but the returned object is NOT itself a
+   context-manager, so the user cannot write
+   `with train() as training:` to orchestrate mid-run.
+- `client.deploy_distributed_managed(...)` -- ceremony wrapper returning a
+   `DistributedTrainingManaged` shim whose `__enter__` yields the
+   underlying Training. Different name, different shape, same outcome.
+- `client.deploy_distributed(...)` -- explicit-cleanup factory (still
+   used internally; callers must `.delete()` themselves).
+
+The user has to learn the trade-off before they pick. The
+SDK-API-SIMPLIFICATION-PLAN (`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md`
+on basilica-backend main) calls this an "engineer around the same
+problem 1000 different ways" anti-pattern.
+
+Target after S1:
+- `DistributedTraining` IS itself context-manager-able (defines
+  `__enter__` / `__exit__` and the async variants).
+- The decorator-call returns `DistributedTraining` directly -- bare call
+  is fire-and-forget (callers can `.delete()` explicitly OR let TTL
+  expire), `with train() as training:` opens the context.
+- `deploy_distributed_managed` + `deploy_distributed_managed_async`
+  remain available for two minor versions but emit
+  `DeprecationWarning` on use, pointing at `@basilica.distributed`.
+- `deploy_distributed` + `deploy_distributed_async` remain available
+  for two minor versions but emit `DeprecationWarning` on use,
+  pointing at `@basilica.distributed`.
+
+These tests:
+1. PRE-FIX: fail (they assert the post-fix shape, which today's SDK
+   does not provide).
+2. POST-FIX: pass.
+
+Stubbing pattern mirrors `test_deploy_distributed_managed.py`: bypass
+`BasilicaClient.__init__` and stub the PyO3 binding so no auth /
+network calls fire.
+"""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+import basilica
+from basilica import (
+    BasilicaClient,
+    DistributedTraining,
+    WorldSize,
+)
+
+
+# =============================================================================
+# Shared stub helpers (intentionally a near-clone of
+# test_deploy_distributed_managed.py's helpers so the two test files exercise
+# the same client wiring shape).
+# =============================================================================
+
+
+def _make_client_with_stub(
+    name: str = "dlc-s1-canonical-test",
+    namespace: str = "u-test",
+) -> BasilicaClient:
+    """BasilicaClient with PyO3 binding fully stubbed; bypasses __init__."""
+    client = BasilicaClient.__new__(BasilicaClient)
+    inner = MagicMock()
+
+    create_response = MagicMock()
+    create_response.instance_name = name
+    inner.create_distributed_deployment = MagicMock(return_value=create_response)
+
+    get_response = MagicMock()
+    get_response.namespace = namespace
+    get_response.instance_name = name
+    get_response.distributed = {
+        "worldSize": {
+            "ready": 2,
+            "target": 2,
+            "min": 2,
+            "max": 4,
+            "belowMinimum": False,
+        },
+    }
+    get_response.image = "ghcr.io/example/trainer:latest"
+    get_response.phase = "ready"
+    get_response.message = None
+    get_response.share_token = None
+    get_response.share_url = None
+    get_response.public_metadata = None
+    inner.get_deployment = MagicMock(return_value=get_response)
+
+    inner.delete_deployment = MagicMock(return_value=None)
+
+    client._client = inner
+    return client
+
+
+def _deploy_kwargs() -> Dict[str, Any]:
+    """Minimum kwargs accepted by deploy_distributed[_managed]."""
+    return {
+        "name": "dlc-s1-canonical-test",
+        "image": "ghcr.io/example/trainer:latest",
+        "world_size": WorldSize(min=2, target=2, max=4),
+        "command": ["python3", "/workspace/noop.py"],
+        "timeout": 0,
+    }
+
+
+# =============================================================================
+# Target 1: DistributedTraining itself is context-manager-able.
+#
+# Today: DistributedTraining has neither __enter__ nor __exit__. Users who
+# want auto-cleanup-on-scope-exit go through deploy_distributed_managed.
+# Post-S1: the Training handle is the ONLY thing the user touches, with or
+# without `with`.
+# =============================================================================
+
+
+class TestDistributedTrainingIsContextManagerable:
+    def test_distributed_training_defines_enter(self) -> None:
+        assert hasattr(DistributedTraining, "__enter__"), (
+            "issue 660: DistributedTraining must define __enter__ so callers "
+            "can write `with training:` directly (no wrapper class). "
+            "Today they go through deploy_distributed_managed; that "
+            "ceremony is the anti-pattern S1 collapses."
+        )
+
+    def test_distributed_training_defines_exit(self) -> None:
+        assert hasattr(DistributedTraining, "__exit__"), (
+            "issue 660: DistributedTraining must define __exit__ so the "
+            "`with` block triggers auto-cleanup."
+        )
+
+    def test_distributed_training_defines_aenter(self) -> None:
+        assert hasattr(DistributedTraining, "__aenter__"), (
+            "issue 660: DistributedTraining must define __aenter__ so "
+            "callers can write `async with training:` directly."
+        )
+
+    def test_distributed_training_defines_aexit(self) -> None:
+        assert hasattr(DistributedTraining, "__aexit__"), (
+            "issue 660: DistributedTraining must define __aexit__."
+        )
+
+    def test_with_training_runs_delete_on_normal_exit(self) -> None:
+        """`with training: ...` cleans up the UD on scope exit."""
+        client = _make_client_with_stub()
+        training = DistributedTraining(client, "dlc-s1-canonical-test")
+        training.refresh()
+        with training as t:
+            assert t is training
+        assert client._client.delete_deployment.call_count == 1
+        client._client.delete_deployment.assert_called_with(
+            "dlc-s1-canonical-test"
+        )
+
+    def test_with_training_runs_delete_on_exception(self) -> None:
+        """Exception inside `with` propagates; delete still fires once."""
+        client = _make_client_with_stub()
+        training = DistributedTraining(client, "dlc-s1-canonical-test")
+        training.refresh()
+
+        class _Boom(RuntimeError):
+            pass
+
+        with pytest.raises(_Boom, match="caller-error"):
+            with training:
+                raise _Boom("caller-error")
+
+        assert client._client.delete_deployment.call_count == 1
+
+    def test_with_training_swallows_delete_failure(self) -> None:
+        """If delete itself raises, the failure is swallowed (best-effort)."""
+        client = _make_client_with_stub()
+        client._client.delete_deployment = MagicMock(
+            side_effect=RuntimeError("delete failed")
+        )
+        training = DistributedTraining(client, "dlc-s1-canonical-test")
+        training.refresh()
+        # Normal exit + delete raises -> __exit__ must swallow it.
+        with training:
+            pass
+        assert client._client.delete_deployment.call_count == 1
+
+    def test_with_training_does_not_mask_caller_exception_on_delete_failure(
+        self,
+    ) -> None:
+        """delete() raising must NOT replace the propagating exception."""
+        client = _make_client_with_stub()
+        client._client.delete_deployment = MagicMock(
+            side_effect=RuntimeError("delete failed")
+        )
+        training = DistributedTraining(client, "dlc-s1-canonical-test")
+        training.refresh()
+
+        class _CallerErr(RuntimeError):
+            pass
+
+        with pytest.raises(_CallerErr, match="primary"):
+            with training:
+                raise _CallerErr("primary")
+
+        assert client._client.delete_deployment.call_count == 1
+
+
+# =============================================================================
+# Target 2: @basilica.distributed decorator-call returns a DistributedTraining
+# directly (the wrapper class -- DistributedFunction -- still exists, but the
+# returned object FROM __call__ is the Training, not a separate wrapper).
+#
+# Today: DistributedFunction.__call__ already returns DistributedTraining,
+# so this part is mostly a pin against regression. The behaviour change is
+# that the Training is context-manager-able (Target 1) -- the decorator
+# itself does not gain new return type.
+# =============================================================================
+
+
+class TestDecoratorReturnsContextManagerableTraining:
+    def test_decorator_call_returns_distributed_training(self) -> None:
+        """Decorator-call returns Training (not a wrapper) -- pin against regression."""
+        # We do NOT actually invoke the decorator-call here (that would
+        # require a stubbed BasilicaClient + the whole deploy plumbing).
+        # We pin the return-type annotation instead. The behavioural test
+        # lives in the post-fix examples and the runtime verification.
+        import inspect
+
+        from basilica.decorators import DistributedFunction
+
+        sig = inspect.signature(DistributedFunction.__call__)
+        # The return annotation IS DistributedTraining today; this test
+        # just locks it.
+        annotation = sig.return_annotation
+        # When the annotation is a string (forward reference), accept that
+        # too; we only care that it isn't a managed wrapper.
+        if isinstance(annotation, str):
+            assert "DistributedTraining" in annotation, (
+                f"DistributedFunction.__call__ must return DistributedTraining, "
+                f"got annotation={annotation!r}"
+            )
+        else:
+            assert annotation is DistributedTraining, (
+                f"DistributedFunction.__call__ must return DistributedTraining, "
+                f"got {annotation!r}"
+            )
+
+
+# =============================================================================
+# Target 3: deploy_distributed_managed emits DeprecationWarning.
+#
+# Per the issue acceptance criteria: "deploy_distributed_managed and
+# deploy_distributed emit DeprecationWarning when used".
+#
+# The wrapper class DistributedTrainingManaged stays for two minor versions
+# (back-compat for callers that already type-annotate their code), but the
+# factory method on BasilicaClient warns to steer new code to the canonical
+# `@basilica.distributed` / `with training:` path.
+# =============================================================================
+
+
+class TestDeprecatedManagedSurfaceWarns:
+    def test_deploy_distributed_managed_emits_deprecation_warning(self) -> None:
+        client = _make_client_with_stub()
+        with pytest.warns(DeprecationWarning, match=r"@basilica\.distributed"):
+            with client.deploy_distributed_managed(**_deploy_kwargs()):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_deploy_distributed_managed_async_emits_deprecation_warning(
+        self,
+    ) -> None:
+        client = _make_client_with_stub()
+        with pytest.warns(DeprecationWarning, match=r"@basilica\.distributed"):
+            async with client.deploy_distributed_managed_async(
+                **_deploy_kwargs()
+            ):
+                pass
+
+
+# =============================================================================
+# Target 4: deploy_distributed emits DeprecationWarning.
+#
+# Same plan-target as above. The method stays callable (the decorator path
+# uses it internally), but a USER call must warn.
+# =============================================================================
+
+
+class TestDeprecatedExplicitDeploySurfaceWarns:
+    def test_deploy_distributed_emits_deprecation_warning(self) -> None:
+        client = _make_client_with_stub()
+        with pytest.warns(DeprecationWarning, match=r"@basilica\.distributed"):
+            training = client.deploy_distributed(**_deploy_kwargs())
+            # Cleanup so the test does not leave the stubbed UD "alive".
+            training.delete()
+
+    @pytest.mark.asyncio
+    async def test_deploy_distributed_async_emits_deprecation_warning(
+        self,
+    ) -> None:
+        client = _make_client_with_stub()
+        with pytest.warns(DeprecationWarning, match=r"@basilica\.distributed"):
+            training = await client.deploy_distributed_async(**_deploy_kwargs())
+            await training.delete_async()
+
+
+# =============================================================================
+# Target 5: internal callers (the decorator path) MUST NOT trip the
+# DeprecationWarning. The decorator deploys through `deploy_distributed`
+# internally, but users see the decorator -- not the underlying method.
+#
+# We pin an internal escape hatch (`_skip_deprecation_warning=True` or
+# similar) so the decorator path stays silent while user-facing calls warn.
+# =============================================================================
+
+
+class TestDecoratorInternalPathDoesNotWarn:
+    def test_decorator_deploys_without_emitting_deprecation_warning(self) -> None:
+        """
+        The decorator class (`DistributedFunction`) deploys through the
+        underlying client method, but the user did not call that method
+        directly -- they used the canonical decorator surface. So no
+        DeprecationWarning should leak to them.
+        """
+        client = _make_client_with_stub()
+
+        @basilica.distributed(
+            name="dlc-s1-canonical-test",
+            image="ghcr.io/example/trainer:latest",
+            world_size=WorldSize(min=2, target=2, max=4),
+            timeout=0,
+        )
+        def train() -> None:
+            """Per-rank entrypoint -- body is irrelevant for the warning test."""
+            pass
+
+        # The decorator's deploy(client=...) is the internal path; the user
+        # invoked it via the decorator -- no warning should fire.
+        import warnings as _warnings
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            training = train.deploy(client=client)
+            training.delete()
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert not deprecation_warnings, (
+            f"Decorator internal deploy path emitted DeprecationWarning(s): "
+            f"{[str(w.message) for w in deprecation_warnings]}. "
+            f"Users of @basilica.distributed must not see deprecation warnings "
+            f"from the underlying deploy_distributed call -- only direct "
+            f"callers of deploy_distributed[_managed] should."
+        )


### PR DESCRIPTION
## Summary

Collapses three distributed-training deploy paths into ONE canonical surface, per the SDK API simplification plan (`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main).

- `DistributedTraining` becomes itself context-manager-able (`__enter__` / `__exit__` / `__aenter__` / `__aexit__`).
- `BasilicaClient.deploy_distributed[_managed][_async]` emit `DeprecationWarning` on direct calls; the `@basilica.distributed` decorator path stays silent via an internal `_emit_deprecation=False` flag.
- Version bumped 0.29.4 -> 0.29.5 (API-surface change).
- New unit-test file `test_distributed_canonical_surface.py` pins every acceptance criterion.

After this PR, users write ONE thing:

```python
@basilica.distributed(...)
def train(): ...

# Fire-and-forget
train()

# OR -- mid-run orchestration
with train() as training:
    training.scale(target=3)
    training.wait_until_target_world(timeout=300)
    print(training.bench)
```

Same handle, same semantics, no second factory to learn.

## Why

Three names for the same operation taxed every new user. The decorator hid the Training handle (no `.scale()` / `.bench` mid-run), so anyone who wanted orchestration switched to `deploy_distributed_managed` -- a different name, different shape, same outcome. Collapsing the surface makes the decorator the canonical entry-point and keeps the same auto-cleanup contract whether you write `with train()` or call it bare.

## Cross-repo references

- Tracking issue: one-covenant/basilica-backend#660 (this PR's merge auto-closes it via the `fixes` keyword in the title).
- Plan doc: `docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main (SDK-S1 row in the wave map).
- Part of basilica-backend issue 419 follow-on work (cross-ref only -- no auto-close).

## Implementation

### `crates/basilica-sdk-python/python/basilica/distributed.py`
Added sync + async context-manager protocol to `DistributedTraining`. Best-effort `delete()` on scope exit, swallows delete-time exceptions so we never mask a caller-side exception that's already propagating. `DistributedTrainingManaged` is unchanged (still re-exported for type-annotation back-compat).

### `crates/basilica-sdk-python/python/basilica/__init__.py`
Added `_emit_deprecation: bool = True` to `deploy_distributed` and `deploy_distributed_async`. Body-level `warnings.warn(..., DeprecationWarning, stacklevel=2)` when set. `deploy_distributed_managed[_async]` emit their own warning at entry and pass `_emit_deprecation=False` to the underlying deploy call (no double-warn).

### `crates/basilica-sdk-python/python/basilica/decorators.py`
`DistributedFunction.deploy()` passes `_emit_deprecation=False` to `client.deploy_distributed(...)`. The user opted into the canonical surface by using the decorator -- they should not see a warning that points at the surface they're already on.

### `crates/basilica-sdk-python/tests/test_distributed_canonical_surface.py`
14 new tests pinning every ticket acceptance criterion. Pre-fix run: 12/14 fail (proving the anti-pattern exists). Post-fix run: 14/14 pass.

### Version bump
- `crates/basilica-sdk-python/Cargo.toml`: 0.29.4 -> 0.29.5
- `crates/basilica-sdk-python/pyproject.toml`: 0.29.4 -> 0.29.5
- `Cargo.lock`: regenerated via `cargo update -p basilica-sdk-python`
- `CHANGELOG.md`: `## [0.29.5] - 2026-05-18` entry with Added + Deprecated sections.

## Test plan

- [x] New tests: 14/14 pass (`test_distributed_canonical_surface.py`)
- [x] Full SDK test suite: 171 passed (the pre-existing httpx-missing skip on `test_dns_propagation_e2e.py` is unrelated)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p basilica-sdk --all-targets --all-features -- -D warnings` clean
- [x] Version consistency check (Cargo.toml vs pyproject.toml): both 0.29.5
- [ ] Runtime verification deferred -- the changes are SDK-internal API-shape (context-manager protocol + warnings); no operator / autoscaler / CRD surface touched. Runtime behaviour for an existing decorator user is byte-identical (Training is still returned; existing `.scale()`/`.delete()`/`.bench` paths still work). Existing example scripts 20/21/22 continue to function; they will migrate in SDK-S5 (separate ticket).

## Migration for callers

- `client.deploy_distributed_managed(...) as t:` -> `@basilica.distributed(...)` + `with train() as t:`
- `client.deploy_distributed(...)` + manual `.delete()` -> same decorator + `with` block (auto-cleanup) OR continue calling and silence the warning (still works for two minor versions).
- Type annotations against `DistributedTrainingManaged` keep working -- the class is unchanged and still re-exported.

## What is NOT in this PR

- `command=` parameter on `@basilica.distributed` (SDK-S3, separate ticket).
- `source: Union[str, Path]` deprecation in favor of Callable-only (SDK-S4).
- `bench: bool` + lazy `training.bench: BenchResult | None` collapse (SDK-S2).
- Example file migration to the new surface (SDK-S5).
- Removal of deprecated methods (SDK-S7, next major bump).