### PR TITLE
test(sdk): filter bench-related deprecations in S2 acceptance tests (refs basilica-backend#661)

### DIFF
--- a/crates/basilica-sdk-python/tests/test_bench_bool_simplification.py
+++ b/crates/basilica-sdk-python/tests/test_bench_bool_simplification.py
@@ -205,13 +205,18 @@ class TestBenchBoolAcceptance:
             warnings.simplefilter("always")
             training = client.deploy_distributed(bench=True, **_deploy_kwargs())
         assert isinstance(training, DistributedTraining)
-        # No DeprecationWarning expected for the canonical bool form.
-        deprecations = [
-            w for w in recorded if issubclass(w.category, DeprecationWarning)
+        # No bench-related DeprecationWarning expected for the canonical
+        # bool form. Other warnings (e.g. the SDK-S1 deprecation of
+        # ``deploy_distributed`` itself in favor of the decorator) are
+        # filtered out here -- this test pins ONLY the bench surface.
+        bench_deprecations = [
+            w for w in recorded
+            if issubclass(w.category, DeprecationWarning)
+            and "bench" in str(w.message).lower()
         ]
-        assert deprecations == [], (
-            f"bench=True must NOT raise DeprecationWarning, got "
-            f"{[str(w.message) for w in deprecations]!r}"
+        assert bench_deprecations == [], (
+            f"bench=True must NOT raise a bench-related DeprecationWarning, "
+            f"got {[str(w.message) for w in bench_deprecations]!r}"
         )
 
     def test_bench_false_accepted_without_warning(self) -> None:
@@ -220,12 +225,14 @@ class TestBenchBoolAcceptance:
             warnings.simplefilter("always")
             training = client.deploy_distributed(bench=False, **_deploy_kwargs())
         assert isinstance(training, DistributedTraining)
-        deprecations = [
-            w for w in recorded if issubclass(w.category, DeprecationWarning)
+        bench_deprecations = [
+            w for w in recorded
+            if issubclass(w.category, DeprecationWarning)
+            and "bench" in str(w.message).lower()
         ]
-        assert deprecations == [], (
-            f"bench=False must NOT raise DeprecationWarning, got "
-            f"{[str(w.message) for w in deprecations]!r}"
+        assert bench_deprecations == [], (
+            f"bench=False must NOT raise a bench-related DeprecationWarning, "
+            f"got {[str(w.message) for w in bench_deprecations]!r}"
         )
 
     def test_bench_true_emits_on_start_on_the_wire(self) -> None:


### PR DESCRIPTION
## Summary

Test-only correctness patch following S1 + S2 PRs landing in sequence:

- `TestBenchBoolAcceptance.test_bench_true_accepted_without_warning`
- `TestBenchBoolAcceptance.test_bench_false_accepted_without_warning`

asserted \"NO ``DeprecationWarning`` fires when ``bench=True`` / ``bench=False``\". After SDK-S1 (PR #484) merged, ``BasilicaClient.deploy_distributed`` emits its own ``DeprecationWarning`` pointing at the ``@basilica.distributed`` decorator, which trips those assertions even though the bench parameter itself is not deprecated.

This patch narrows the assertions to bench-related deprecations only (``\"bench\" in str(message).lower()``), preserving the S2 contract while tolerating the unrelated S1 method-level deprecation.

## Why

S1 and S2 are independent simplifications that both deprecate parts of the existing distributed surface. S2 came first in branch creation order; S1 merged immediately after S2 and added the method-level deprecation. The S2 tests over-asserted by checking for ANY deprecation rather than ONLY bench-related ones.

## Test plan

- [x] `pytest tests/test_bench_bool_simplification.py` — 22/22 passing post-merge
- [x] `pytest tests/test_bench_status_skipped.py` — 18/18 passing (regression check)
- [x] No production code change

## Cross-ref

- SDK-S2 surface PR: #483 (merged, bench=bool + lazy training.bench)
- SDK-S1 surface PR: #484 (merged, DistributedTraining context-manager-able + deploy_distributed deprecation)
- Tracking issue: basilica-backend#661