### PR TITLE
feat(sdk): basilica.distributed(command=...) factory shape (fixes one-covenant/basilica-backend#662)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.29.5"
+version = "0.29.6"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.6] - 2026-05-18
+
+### Added
+- `basilica.distributed(command=[...], ...)` now works as a factory and
+  returns a `DistributedTraining` directly (no decorator wrapping). The
+  same `basilica.distributed` symbol handles both shapes: decorator on
+  a function (per-rank entrypoint) and factory with BYO launcher. The
+  factory short-circuits when `command` is set, deploys immediately
+  through `deploy_distributed(_emit_deprecation=False)`, and returns
+  the canonical context-manager handle. Pass `client=` to inject an
+  existing `BasilicaClient`; otherwise a default one is built lazily.
+
+Closes basilica-backend#662. Refs the SDK API simplification plan
+(`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main)
+ticket SDK-S3 ("command= parameter on @basilica.distributed for BYO
+launcher; drop the _managed suffix as the canonical entry point").
+
 ## [0.29.5] - 2026-05-18
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.5"
+version = "0.29.6"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.5"
+version = "0.29.6"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -500,15 +500,52 @@ def distributed(
     enable_billing: bool = True,
     wait_for_bench: str = "never",
     bench_timeout: int = 1500,
-) -> Callable[[Callable], DistributedFunction]:
+    command: Optional[List[str]] = None,
+    args: Optional[List[str]] = None,
+    client: Optional[Any] = None,
+) -> Union[Callable[[Callable], DistributedFunction], DistributedTraining]:
     """
-    Decorator marking a function as the per-rank entrypoint for a
+    Decorator-or-factory marking the per-rank entrypoint of a
     distributed-training UserDeployment. SDK arch § 5.
 
-    The decorated function body is what each rank executes. The standard
-    PyTorch idiom applies: `dist.init_process_group(backend="nccl")` then
-    your training loop. torchrun + the operator handle fan-out; you do
-    NOT branch on `rank == 0`.
+    Two shapes share the same call site:
+
+    1. Decorator (function body): the decorated function is the per-rank
+       entrypoint. The standard PyTorch idiom applies --
+       ``dist.init_process_group(backend="nccl")`` then your training
+       loop. torchrun + the operator handle fan-out; you do NOT branch
+       on ``rank == 0``::
+
+           @basilica.distributed(name="dlc-llama-7b", world_size=...,
+                                 gpu_count=1, gpu_models=["H100"])
+           def train():
+               import torch.distributed as dist
+               dist.init_process_group(backend="nccl")
+               ...
+
+           training = train()  # deploys, returns DistributedTraining
+
+    2. Factory (BYO launcher): passing ``command=[...]`` deploys
+       immediately (no function to decorate) and returns a
+       :class:`DistributedTraining` directly. Mirrors the prior
+       ``deploy_distributed_managed(command=...)`` call site without
+       the ``_managed`` suffix::
+
+           training = basilica.distributed(
+               name="dlc-torchrun",
+               command=["torchrun", "--rdzv-backend=etcd",
+                        "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT", ...],
+               world_size=WorldSize(min=2, target=4, max=8),
+               gpu_count=1, gpu_models=["A100", "H100"],
+           )
+           with training:
+               training.scale(target=4)
+
+       The factory short-circuits when ``command`` is set: the call
+       returns :class:`DistributedTraining`, NOT a decorator closure.
+       Use ``client=`` to inject an existing :class:`BasilicaClient`
+       (otherwise a fresh one is built lazily, matching the decorator's
+       ``.deploy()`` semantics). See basilica-backend issue 662 / SDK-S3.
 
     Args:
         name: Deployment name (DNS-safe).
@@ -537,31 +574,24 @@ def distributed(
             `"required"` raises if bench is non-Succeeded. See
             `BasilicaClient.deploy_distributed`.
         bench_timeout: Seconds budget for the opt-in bench wait.
+        command: BYO-launcher entry. When set, the call returns a
+            :class:`DistributedTraining` immediately (factory mode) and
+            the operator does NOT wrap with torchrun. Mutually exclusive
+            with the decorator shape -- supplying ``command`` AND
+            subsequently decorating a function is a usage error caught at
+            decoration time. See basilica-backend issue 662 / SDK-S3.
+        args: Args to pass to ``command`` when in factory mode. Ignored
+            unless ``command`` is set.
+        client: Optional :class:`BasilicaClient` used in factory mode.
+            Ignored in decorator mode (the decorator's ``.deploy(client=)``
+            takes precedence). When ``command`` is set and ``client`` is
+            None, a default ``BasilicaClient()`` is constructed lazily.
 
     Returns:
-        DistributedFunction wrapper. Calling it deploys; `.local()` runs
-        in-process for single-rank testing; `.deploy(client=...)` for
-        explicit-client usage.
-
-    Example:
-        >>> import basilica
-        >>> from basilica import WorldSize
-        >>>
-        >>> @basilica.distributed(
-        ...     name="dlc-llama-7b",
-        ...     world_size=WorldSize(min=4, target=8, max=16),
-        ...     gpu_count=1,
-        ...     gpu_models=["H100"],
-        ... )
-        ... def train():
-        ...     import os
-        ...     import torch.distributed as dist
-        ...     dist.init_process_group(backend="nccl")
-        ...     rank = dist.get_rank()
-        ...     # ... DiLoCo loop ...
-        >>>
-        >>> training = train()  # deploys, returns DistributedTraining
-        >>> training.scale(target=12)
+        - Decorator mode (``command`` is None): a decorator closure that
+          wraps the decorated function in a :class:`DistributedFunction`.
+        - Factory mode (``command`` is set): a :class:`DistributedTraining`
+          ready to use under a ``with`` block.
     """
     if world_size is None:
         raise ValueError("@distributed requires world_size")
@@ -597,7 +627,49 @@ def distributed(
         "bench_timeout": bench_timeout,
     }
 
+    # basilica-backend issue 662 / SDK-S3: factory mode. When the caller
+    # supplies a BYO launcher (``command=[...]``), short-circuit the
+    # decorator path and deploy immediately. The decorator path bakes
+    # ``_emit_deprecation=False`` into the inner deploy call so the
+    # canonical surface stays quiet; the factory does the same.
+    if command is not None:
+        return _deploy_command_factory(
+            kwargs=kwargs,
+            command=command,
+            args=args,
+            client=client,
+        )
+
     def decorator(func: Callable) -> DistributedFunction:
         return DistributedFunction(func, kwargs)
 
     return decorator
+
+
+def _deploy_command_factory(
+    kwargs: Dict[str, Any],
+    command: List[str],
+    args: Optional[List[str]],
+    client: Optional[Any],
+) -> DistributedTraining:
+    """
+    basilica-backend issue 662 / SDK-S3: BYO-launcher factory path.
+
+    Invoked by :func:`distributed` when ``command`` is set. Materializes
+    a :class:`BasilicaClient` if none was supplied, forwards ``command``
+    / ``args`` plus the shared kwargs to ``deploy_distributed`` with
+    ``_emit_deprecation=False`` (the canonical surface must not warn),
+    and returns the :class:`DistributedTraining` handle.
+
+    Kept separate from :func:`distributed` so the decorator path's hot
+    loop stays a closure constructor (no extra branch on every call).
+    """
+    from . import BasilicaClient  # local import to avoid circular dep
+
+    bound_client = client if client is not None else BasilicaClient()
+    return bound_client.deploy_distributed(
+        command=command,
+        args=args,
+        _emit_deprecation=False,
+        **kwargs,
+    )

--- a/crates/basilica-sdk-python/tests/test_distributed_command_factory.py
+++ b/crates/basilica-sdk-python/tests/test_distributed_command_factory.py
@@ -1,0 +1,307 @@
+"""
+Unit tests pinning the SDK-S3 simplification surface
+(basilica-backend issue 662): ``basilica.distributed(command=[...], ...)``
+collapses the BYO-launcher path into the same ``@basilica.distributed``
+surface used for function-body deploys, dropping the ``_managed``
+suffix as the canonical entry point.
+
+WHY this file exists (read the issue body for the full plan):
+
+Today BYO-launcher deploys go through
+``client.deploy_distributed_managed(command=[...])``. The ``_managed``
+suffix signals SDK plumbing (back-compat shim returning the cleanup
+wrapper) rather than a user-facing semantic. After SDK-S3 the same
+``basilica.distributed`` symbol handles both shapes:
+
+- Function body: ``@basilica.distributed(...) def train(): ...`` ->
+  decorator returning ``DistributedFunction``; ``train()`` deploys.
+- BYO launcher: ``basilica.distributed(command=[...], ...)`` invoked
+  WITHOUT a decorated function -> factory returning ``DistributedTraining``
+  directly. ``with training:`` opens the context manager (already wired
+  in S1).
+
+The decorator form gates on whether a ``Callable`` is supplied. The
+factory form gates on ``command`` being present. The two shapes share
+configuration semantics and produce the same end-state object
+(``DistributedTraining`` is the canonical handle).
+
+Stubbing pattern mirrors ``test_distributed_canonical_surface.py``
+and ``test_deploy_distributed_managed.py``: bypass ``__init__`` and
+stub the PyO3 binding so no auth / network calls fire.
+"""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+import basilica
+from basilica import (
+    BasilicaClient,
+    DistributedTraining,
+    WorldSize,
+)
+
+
+# =============================================================================
+# Shared stub helpers (near-clone of
+# ``test_distributed_canonical_surface.py``'s helpers so the two test
+# files exercise the same client wiring shape).
+# =============================================================================
+
+
+def _make_client_with_stub(
+    name: str = "dlc-s3-factory-test",
+    namespace: str = "u-test",
+) -> BasilicaClient:
+    """BasilicaClient with PyO3 binding fully stubbed; bypasses __init__."""
+    client = BasilicaClient.__new__(BasilicaClient)
+    inner = MagicMock()
+
+    create_response = MagicMock()
+    create_response.instance_name = name
+    inner.create_distributed_deployment = MagicMock(return_value=create_response)
+
+    get_response = MagicMock()
+    get_response.namespace = namespace
+    get_response.instance_name = name
+    get_response.distributed = {
+        "worldSize": {
+            "ready": 2,
+            "target": 2,
+            "min": 2,
+            "max": 4,
+            "belowMinimum": False,
+        },
+    }
+    get_response.image = "ghcr.io/example/trainer:latest"
+    get_response.phase = "ready"
+    get_response.message = None
+    get_response.share_token = None
+    get_response.share_url = None
+    get_response.public_metadata = None
+    inner.get_deployment = MagicMock(return_value=get_response)
+
+    inner.delete_deployment = MagicMock(return_value=None)
+
+    client._client = inner
+    return client
+
+
+def _factory_kwargs() -> Dict[str, Any]:
+    """Minimum kwargs accepted by the BYO-launcher factory shape."""
+    return {
+        "name": "dlc-s3-factory-test",
+        "image": "ghcr.io/example/trainer:latest",
+        "world_size": WorldSize(min=2, target=2, max=4),
+        "command": ["python3", "/workspace/noop.py"],
+        "timeout": 0,
+    }
+
+
+# =============================================================================
+# Target 1: ``basilica.distributed(command=[...], ...)`` invoked WITHOUT a
+# decorated function returns ``DistributedTraining`` directly.
+#
+# Today: ``basilica.distributed(...)`` always returns a decorator factory
+# (``Callable[[Callable], DistributedFunction]``), so calling it without
+# subsequently decorating a function yields a closure -- not a Training.
+# Post-S3: when ``command=`` is set, the call short-circuits the decorator
+# path and produces a ``DistributedTraining`` immediately, using a default
+# client (or the supplied ``client=``).
+# =============================================================================
+
+
+class TestDistributedCommandFactory:
+    def test_factory_call_with_command_returns_distributed_training(
+        self,
+    ) -> None:
+        """``basilica.distributed(command=[...], ...)`` -> Training (no decorator)."""
+        client = _make_client_with_stub()
+        training = basilica.distributed(client=client, **_factory_kwargs())
+        try:
+            assert isinstance(training, DistributedTraining), (
+                f"issue 662: basilica.distributed(command=[...], ...) must "
+                f"return DistributedTraining directly (factory shape), got "
+                f"{type(training).__name__}. Today this call returns a "
+                f"decorator closure -- the _managed-suffix anti-pattern."
+            )
+            assert training.name == "dlc-s3-factory-test"
+        finally:
+            # Cleanup so the stubbed UD does not stay "alive".
+            training.delete()
+
+    def test_factory_training_is_context_manager_able(self) -> None:
+        """Returned Training opens via ``with`` (relies on S1 wiring)."""
+        client = _make_client_with_stub()
+        training = basilica.distributed(client=client, **_factory_kwargs())
+        with training as t:
+            assert t is training
+        # __exit__ ran delete exactly once.
+        assert client._client.delete_deployment.call_count == 1
+        client._client.delete_deployment.assert_called_with(
+            "dlc-s3-factory-test"
+        )
+
+    def test_factory_call_does_not_emit_deprecation_warning(self) -> None:
+        """
+        Canonical surface MUST stay silent: the user opted into the
+        post-S3 form, so the underlying ``deploy_distributed`` call must
+        be invoked with ``_emit_deprecation=False`` (same contract as the
+        decorator path).
+        """
+        client = _make_client_with_stub()
+        import warnings as _warnings
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            training = basilica.distributed(client=client, **_factory_kwargs())
+            training.delete()
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert not deprecation_warnings, (
+            f"basilica.distributed(command=[...]) factory path emitted "
+            f"DeprecationWarning(s): "
+            f"{[str(w.message) for w in deprecation_warnings]}. "
+            f"The factory form IS the canonical surface and must not warn."
+        )
+
+    def test_factory_uses_default_client_when_none_supplied(self) -> None:
+        """
+        With no ``client=`` kwarg, the factory must build a
+        ``BasilicaClient()`` lazily. Mirror the decorator-call pattern.
+        """
+        # We patch the BasilicaClient constructor so no auth bootstrap fires.
+        import basilica as _basilica_pkg
+
+        stub_client = _make_client_with_stub()
+        orig_init = BasilicaClient.__init__
+
+        def _stub_init(self: BasilicaClient, *args: Any, **kwargs: Any) -> None:
+            # Inherit the already-stubbed inner from `stub_client` so this
+            # test does not actually hit the auth bootstrap. We mutate
+            # `self` to look like `stub_client` without touching globals.
+            self._client = stub_client._client
+
+        try:
+            BasilicaClient.__init__ = _stub_init  # type: ignore[method-assign]
+            training = _basilica_pkg.distributed(**_factory_kwargs())
+            try:
+                assert isinstance(training, DistributedTraining)
+            finally:
+                training.delete()
+        finally:
+            BasilicaClient.__init__ = orig_init  # type: ignore[method-assign]
+
+
+# =============================================================================
+# Target 2: Decorator form is unchanged -- callable-on-function continues to
+# return a ``DistributedFunction`` wrapper. Pin against regression.
+# =============================================================================
+
+
+class TestDecoratorFormStillWorks:
+    def test_decorator_on_function_returns_distributed_function(self) -> None:
+        """``@basilica.distributed(...) def train(): ...`` -> wrapper."""
+        from basilica.decorators import DistributedFunction
+
+        @basilica.distributed(
+            name="dlc-s3-decorator-test",
+            image="ghcr.io/example/trainer:latest",
+            world_size=WorldSize(min=2, target=2, max=4),
+            timeout=0,
+        )
+        def train() -> None:
+            pass
+
+        assert isinstance(train, DistributedFunction), (
+            f"issue 662 regression: @basilica.distributed must continue to "
+            f"return DistributedFunction when decorating a function; got "
+            f"{type(train).__name__}."
+        )
+
+    def test_decorator_call_still_deploys_via_wrapper(self) -> None:
+        """Decorator path delegates to ``deploy_distributed`` as before."""
+        client = _make_client_with_stub(name="dlc-s3-decorator-deploy")
+
+        @basilica.distributed(
+            name="dlc-s3-decorator-deploy",
+            image="ghcr.io/example/trainer:latest",
+            world_size=WorldSize(min=2, target=2, max=4),
+            timeout=0,
+        )
+        def train() -> None:
+            pass
+
+        training = train.deploy(client=client)
+        try:
+            assert isinstance(training, DistributedTraining)
+            assert training.name == "dlc-s3-decorator-deploy"
+        finally:
+            training.delete()
+
+
+# =============================================================================
+# Target 3: ``deploy_distributed_managed`` continues to emit
+# DeprecationWarning (re-pin of S1's contract; the warning message must
+# steer callers at the canonical ``basilica.distributed`` surface for
+# BYO-launcher use cases too -- not just the decorator form).
+# =============================================================================
+
+
+class TestManagedBYORedirection:
+    def test_managed_with_command_emits_deprecation_warning(self) -> None:
+        """
+        BYO launcher through ``deploy_distributed_managed(command=...)``
+        warns just like S1's decorator-replacement contract. The warning
+        text must mention ``basilica.distributed`` as the canonical
+        replacement (already covered by the S1 wording; this test pins
+        that BYO callers see the same redirection).
+        """
+        client = _make_client_with_stub(name="dlc-s3-managed-byo")
+        with pytest.warns(DeprecationWarning, match=r"@basilica\.distributed"):
+            with client.deploy_distributed_managed(
+                name="dlc-s3-managed-byo",
+                image="ghcr.io/example/trainer:latest",
+                world_size=WorldSize(min=2, target=2, max=4),
+                command=["torchrun", "/workspace/noop.py"],
+                timeout=0,
+            ):
+                pass
+
+
+# =============================================================================
+# Target 4: argument validation -- the factory must reject calls that pass
+# neither ``command`` nor a decoratable function. Today ``basilica.distributed()``
+# always returns a decorator closure; without ``command=`` the caller MUST
+# subsequently decorate a function. The new factory shape only activates
+# when ``command`` is set.
+# =============================================================================
+
+
+class TestFactoryArgumentValidation:
+    def test_factory_without_command_returns_decorator_closure(self) -> None:
+        """
+        Backwards-compat: when ``command`` is NOT set, the symbol
+        behaves as today -- returns a decorator. This pins that the
+        S3 change is additive (gated on ``command``) and does not
+        silently break callers that decorate a function.
+        """
+        from basilica.decorators import DistributedFunction
+
+        decorator_closure = basilica.distributed(
+            name="dlc-s3-no-command-test",
+            image="ghcr.io/example/trainer:latest",
+            world_size=WorldSize(min=2, target=2, max=4),
+            timeout=0,
+        )
+        assert callable(decorator_closure), (
+            "issue 662: basilica.distributed(...) with no command= must "
+            "still return a decorator closure for the function-body path."
+        )
+
+        def train() -> None:
+            pass
+
+        wrapped = decorator_closure(train)
+        assert isinstance(wrapped, DistributedFunction)


### PR DESCRIPTION
## Summary

SDK-S3 from the SDK API simplification plan. Collapses BYO-launcher deploys
into the canonical `basilica.distributed` surface, dropping the `_managed`
suffix as the user-facing entry point.

- **Today**: `client.deploy_distributed_managed(command=[...])` for BYO
  launcher. The `_managed` suffix signals SDK plumbing; users must learn
  both suffixed/unsuffixed variants and pick on cleanup-contract grounds.
- **After**: `basilica.distributed(command=[...], ...)` invoked WITHOUT a
  decorated function returns a `DistributedTraining` directly (factory
  mode). Same symbol still works as a decorator on a function (decorator
  mode unchanged). `with training:` opens the canonical context manager
  (wired in SDK-S1).

## Plan + ticket

- Plan: `docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main, Problem 4
- Tracking issue: `one-covenant/basilica-backend#662`
- Builds on S1 (`one-covenant/basilica#484`, merge `0860a995`) and S2
  (`one-covenant/basilica#483`, merge `ca2d2e75`; `#485` test patch merge
  `b7ce2bdc`). Both already landed `DistributedTraining.__enter__` /
  `__exit__` and the `_emit_deprecation=False` plumbing that this S3
  factory path reuses.

## Implementation

- `crates/basilica-sdk-python/python/basilica/decorators.py`
  - Add `command: Optional[List[str]]`, `args: Optional[List[str]]`, and
    `client: Optional[BasilicaClient]` parameters to `distributed(...)`.
  - When `command` is set, short-circuit to `_deploy_command_factory`
    (new helper) which materializes a `BasilicaClient` if none was
    supplied, calls `deploy_distributed(..., _emit_deprecation=False)`,
    and returns the `DistributedTraining` directly.
  - Decorator mode (no `command`) is byte-for-byte identical to the
    pre-fix shape; the new branch is additive.
  - Return type widened to `Union[Callable[[Callable], DistributedFunction], DistributedTraining]`.
- `crates/basilica-sdk-python/tests/test_distributed_command_factory.py`
  - 8 new tests (file:line of the fix targets: `decorators.py:481-650`).
  - 4 pre-fix-failing tests pin the new factory shape
    (`TestDistributedCommandFactory`).
  - 4 pre-fix-passing tests pin regressions
    (`TestDecoratorFormStillWorks`, `TestManagedBYORedirection`,
    `TestFactoryArgumentValidation`).
- Version: `0.29.5` -> `0.29.6` (`pyproject.toml`, `Cargo.toml`,
  `Cargo.lock`). CHANGELOG entry under `[0.29.6]`.

## Failing-then-passing test evidence

Pre-fix (against `main` source):
```
FAILED ...test_factory_call_with_command_returns_distributed_training
FAILED ...test_factory_training_is_context_manager_able
FAILED ...test_factory_call_does_not_emit_deprecation_warning
FAILED ...test_factory_uses_default_client_when_none_supplied
========================= 4 failed, 4 passed in 0.18s ==========================
```

Post-fix (this branch):
```
8 passed in 0.13s
```

Full SDK suite post-fix (excluding pre-existing `test_dns_propagation_e2e.py`
which needs `httpx`): **201 passed, 0 failed**.

## Cross-repo deserialization impact

None. The wire shape stays unchanged -- `command` and `args` already
flow through `deploy_distributed` -> `_build_distributed_request` ->
`spec.distributed.command` / `spec.command`. This PR only changes the
Python user-facing entry point; no operator / CRD / basilica-backend
deserializer touched. Per `feedback_cross_repo_types.md` audited.

## Lint / CI gates

- `cargo fmt --all -- --check` clean
- `cargo check -p basilica-sdk-python` clean
- `cargo clippy -p basilica-sdk-python -- -D warnings` clean
- Example syntax-check clean (no examples touched)
- Version-consistency: Cargo.toml + pyproject.toml + Cargo.lock all on 0.29.6

## What is NOT in this PR

- Removal of `deploy_distributed_managed` / `deploy_distributed` /
  `DistributedTrainingManaged[Async]` -- they stay deprecated-but-functional
  for two minor versions per the plan; removed in SDK-S7 at the next major.
- Migration of `examples/21_distributed_torchrun.py` and
  `examples/22_distributed_with_bench.py` to the factory form -- that is
  SDK-S5.
- `source: Union[str, Path]` deprecation -- that is SDK-S4.
- PyPI publish of `0.29.6` -- pending separate user authorization.

## Test plan

- [x] Failing pre-fix tests captured (8 tests, 4 fail pre-fix)
- [x] Post-fix tests pass (8/8)
- [x] Full SDK suite green (201/201)
- [x] `cargo fmt --check` / `cargo check` / `cargo clippy -- -D warnings` clean
- [x] Version drift check passes (Cargo.toml / pyproject.toml / Cargo.lock)
- [ ] CI green on this PR
- [ ] Merged via `--merge` (NOT `--squash`)