### PR TITLE
feat(sdk): deprecate source: Union[str, Path]; Callable canonical (fixes one-covenant/basilica-backend#663)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.29.6"
+version = "0.29.7"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.7] - 2026-05-18
+
+### Deprecated
+- `BasilicaClient.deploy_distributed(source=...)` (and its async sibling)
+  emits a `DeprecationWarning` when `source` is a `str` or
+  `pathlib.Path`. The `Callable` shape -- what the
+  `@basilica.distributed` decorator already passes internally -- stays
+  silent. The canonical input shape is now "decorate a function", which
+  the SDK extracts via `inspect.getsource(...)`; the `str`/`Path`
+  variants add maintenance surface (file IO + base64 edge cases + AST
+  quirks) without product value. Users who need to ship an external
+  script wrap it via `runpy.run_path("/workspace/...")` inside a
+  decorated function. Both deprecated input shapes remain functional
+  for two minor versions; remove at the next major alongside
+  `deploy_distributed*` itself.
+- The decorator path stays silent because
+  `DistributedFunction.deploy(...)` passes `_emit_deprecation=False` to
+  the underlying call -- the same gate that already silenced the S1
+  `deploy_distributed`-itself deprecation now also silences the S4
+  source-shape deprecation.
+
+Closes basilica-backend#663. Refs the SDK API simplification plan
+(`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on basilica-backend main)
+ticket SDK-S4 ("source parameter accepts Callable only; deprecate
+Union[str, Path]").
+
 ## [0.29.6] - 2026-05-18
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.29.6"
+version = "0.29.7"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.29.6"
+version = "0.29.7"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -245,6 +245,59 @@ def _normalize_bench_param(bench: Any) -> str:
     return bench  # type: ignore[return-value]
 
 
+def _normalize_source_param(
+    source: Optional[Union[str, Path, Callable]],
+    *,
+    emit_deprecation: bool = True,
+) -> Optional[Union[str, Path, Callable]]:
+    """
+    basilica-backend#663 / SDK-S4: collapse the ``source`` parameter to a
+    ``Callable``-only surface via the ``@basilica.distributed`` decorator.
+
+    The decorator is the canonical input shape for "the code workers
+    should run". Direct user calls to ``deploy_distributed`` (and its
+    async sibling) that pass ``source=<str>`` or ``source=<Path>`` get a
+    ``DeprecationWarning`` pointing at the decorator. The string and
+    path shapes remain functional for the next two minor versions, then
+    are removed (alongside ``deploy_distributed*`` itself in SDK-S7).
+
+    The ``Callable`` shape is silent because the decorator's
+    ``DistributedFunction.deploy(...)`` actually extracts the body into a
+    ``str`` and forwards it as ``source=<str>``; that internal call sets
+    ``_emit_deprecation=False``, which we honor here via the
+    ``emit_deprecation`` keyword to keep the canonical surface quiet.
+
+    Args:
+        source: User-supplied source value. ``Callable`` is the canonical
+            shape; ``str`` and ``Path`` are accepted with deprecation.
+        emit_deprecation: When ``False``, this normalizer is a no-op (the
+            caller is the canonical surface and the user did NOT opt into
+            the deprecated parameter directly). Mirrors the existing
+            ``_emit_deprecation`` plumbing on ``deploy_distributed``.
+
+    Returns:
+        ``source`` unchanged. The wire-shape decoding stays in
+        ``_build_distributed_request`` -- this helper only emits the
+        warning.
+    """
+    if not emit_deprecation:
+        return source
+    if source is None or callable(source):
+        return source
+    if isinstance(source, (str, Path)):
+        type_label = "Path" if isinstance(source, Path) else "str"
+        warnings.warn(
+            f"source={type_label!r}-typed value is deprecated and will be "
+            f"removed in the next major. Use the @basilica.distributed "
+            f"decorator on a Callable (the canonical surface), or wrap an "
+            f"external script via `runpy.run_path('/workspace/...')` inside "
+            f"a decorated function. See basilica-backend#663 / SDK-S4.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return source
+
+
 def _shell_join_preserving_vars(command: List[str]) -> str:
     """
     Join an argv list into a single shell command string for the operator's
@@ -1284,6 +1337,12 @@ class BasilicaClient:
                 DeprecationWarning,
                 stacklevel=2,
             )
+        # basilica-backend#663 / SDK-S4: collapse the source parameter to
+        # a Callable-only surface (via the decorator). str/Path inputs
+        # remain accepted with DeprecationWarning; the decorator's
+        # internal source=<str> call sets _emit_deprecation=False, which
+        # this helper honors so the canonical surface stays silent.
+        source = _normalize_source_param(source, emit_deprecation=_emit_deprecation)
         if world_size is None:
             raise ValidationError("deploy_distributed requires world_size", field="world_size")
         if wait_for_bench not in ("never", "best_effort", "required"):
@@ -2440,6 +2499,10 @@ class BasilicaClient:
                 DeprecationWarning,
                 stacklevel=2,
             )
+        # basilica-backend#663 / SDK-S4: same Callable-only collapse as the
+        # sync path. _emit_deprecation gates both the S1 deprecation
+        # (above) and the S4 source-shape deprecation (below).
+        source = _normalize_source_param(source, emit_deprecation=_emit_deprecation)
         if world_size is None:
             raise ValidationError("deploy_distributed_async requires world_size", field="world_size")
         if wait_for_bench not in ("never", "best_effort", "required"):

--- a/crates/basilica-sdk-python/tests/test_source_param_deprecation.py
+++ b/crates/basilica-sdk-python/tests/test_source_param_deprecation.py
@@ -1,0 +1,428 @@
+"""
+Unit tests pinning the SDK-S4 simplification surface
+(basilica-backend issue 663): ``source: Union[str, Path]`` deprecated in
+favour of the ``Callable``-via-decorator path.
+
+WHY this file exists (read the issue body for the full plan):
+
+Today ``deploy_distributed(source=...)`` accepts THREE shapes:
+- ``source='<inline python>'`` -- string literal (or triple-quoted)
+- ``source=Path('./train.py')`` -- file path
+- ``source=my_function`` -- a Callable
+
+Three input shapes for "the code workers should run". The Callable form
+is what the decorator already uses. Strings and Paths add maintenance
+surface without clear product value (file IO + base64 edge cases + AST
+quirks). The plan
+(``docs/plans/SDK-API-SIMPLIFICATION-PLAN.md`` on basilica-backend main,
+Problem 2) calls for collapsing to ``Callable``-only via the decorator.
+
+Target after S4:
+- ``source: str`` -> ``DeprecationWarning`` pointing at the decorator
+  (or the ``runpy.run_path(...)`` pattern for users genuinely shipping a
+  script file).
+- ``source: pathlib.Path`` -> ``DeprecationWarning`` (same target).
+- ``source: Callable`` -> silent (canonical; what the decorator passes).
+- Decorator path stays silent: ``DistributedFunction.deploy(...)`` passes
+  ``_emit_deprecation=False`` (the existing gate that already silences
+  the S1 ``deploy_distributed`` deprecation when called from the
+  canonical surface). The same gate also silences this source-shape
+  deprecation so users of ``@basilica.distributed`` see NO warnings.
+
+These tests:
+1. PRE-FIX: fail (no DeprecationWarning is emitted today for str/Path
+   source inputs).
+2. POST-FIX: pass.
+
+Stubbing pattern mirrors ``test_distributed_canonical_surface.py`` and
+``test_distributed_command_factory.py``: bypass
+``BasilicaClient.__init__`` and stub the PyO3 binding so no auth /
+network calls fire.
+"""
+
+import os
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+import basilica
+from basilica import (
+    BasilicaClient,
+    WorldSize,
+)
+
+
+# =============================================================================
+# Shared stub helpers (near-clone of ``test_distributed_canonical_surface.py``
+# and ``test_distributed_command_factory.py`` so the three test files exercise
+# the same client wiring shape).
+# =============================================================================
+
+
+def _make_client_with_stub(
+    name: str = "dlc-s4-source-test",
+    namespace: str = "u-test",
+) -> BasilicaClient:
+    """BasilicaClient with PyO3 binding fully stubbed; bypasses __init__."""
+    client = BasilicaClient.__new__(BasilicaClient)
+    inner = MagicMock()
+
+    create_response = MagicMock()
+    create_response.instance_name = name
+    inner.create_distributed_deployment = MagicMock(return_value=create_response)
+
+    get_response = MagicMock()
+    get_response.namespace = namespace
+    get_response.instance_name = name
+    get_response.distributed = {
+        "worldSize": {
+            "ready": 2,
+            "target": 2,
+            "min": 2,
+            "max": 4,
+            "belowMinimum": False,
+        },
+    }
+    get_response.image = "ghcr.io/example/trainer:latest"
+    get_response.phase = "ready"
+    get_response.message = None
+    get_response.share_token = None
+    get_response.share_url = None
+    get_response.public_metadata = None
+    inner.get_deployment = MagicMock(return_value=get_response)
+
+    inner.delete_deployment = MagicMock(return_value=None)
+
+    client._client = inner
+    return client
+
+
+def _common_kwargs() -> Dict[str, Any]:
+    """Shared minimum kwargs; tests fill in ``source`` per case."""
+    return {
+        "name": "dlc-s4-source-test",
+        "image": "ghcr.io/example/trainer:latest",
+        "world_size": WorldSize(min=2, target=2, max=4),
+        "timeout": 0,
+    }
+
+
+@pytest.fixture
+def tmp_script_path() -> Path:
+    """A real, readable Python file the SDK's SourcePackager can ingest."""
+    fd, path = tempfile.mkstemp(suffix=".py")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("print('hello from a script file')\n")
+        yield Path(path)
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+# =============================================================================
+# Target 1: ``source`` as a ``str`` (inline code) emits DeprecationWarning.
+#
+# Today: silently accepted. After S4: ``DeprecationWarning`` pointing at
+# the ``@basilica.distributed`` decorator (or the ``runpy.run_path(...)``
+# pattern for users who must ship an external script).
+# =============================================================================
+
+
+def _source_shape_warnings(caught: list) -> list:
+    """
+    Filter ``caught`` warnings down to just the source-shape deprecations.
+
+    The S1 ``deploy_distributed``-itself deprecation also mentions
+    ``@basilica.distributed`` (the canonical surface it points users
+    at), so a plain ``match=r"@basilica\\.distributed"`` matches both
+    the S1 warning AND the new S4 source-shape warning. To distinguish,
+    we look for ``"source"`` in the message text (case-insensitive) --
+    only S4 talks about the source parameter.
+    """
+    return [
+        w for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "source" in str(w.message).lower()
+    ]
+
+
+class TestSourceStringEmitsDeprecation:
+    def test_source_inline_string_emits_deprecation_warning(self) -> None:
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = client.deploy_distributed(
+                source="print('inline hello')\n",
+                **_common_kwargs(),
+            )
+            training.delete()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning. Got: "
+            f"{[str(w.message) for w in caught]}"
+        )
+
+    def test_source_inline_string_warning_points_at_decorator(self) -> None:
+        """
+        The warning should point users at the canonical alternatives:
+        decorator + Callable OR ``runpy.run_path`` for external scripts.
+        We assert the message mentions the decorator name. The runpy hint
+        is recommended-but-not-strictly-asserted to keep the test stable
+        under future rewordings.
+        """
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = client.deploy_distributed(
+                source="print('inline hello')\n",
+                **_common_kwargs(),
+            )
+            training.delete()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning. Got: "
+            f"{[str(w.message) for w in caught]}"
+        )
+        assert any(
+            "@basilica.distributed" in str(w.message)
+            for w in sw
+        ), (
+            f"Source deprecation warning must mention the decorator. "
+            f"Got: {[str(w.message) for w in sw]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_source_inline_string_emits_deprecation_warning_async(self) -> None:
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = await client.deploy_distributed_async(
+                source="print('inline hello')\n",
+                **_common_kwargs(),
+            )
+            await training.delete_async()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning (async). Got: "
+            f"{[str(w.message) for w in caught]}"
+        )
+
+
+# =============================================================================
+# Target 2: ``source`` as a ``pathlib.Path`` emits DeprecationWarning.
+#
+# Today: silently accepted (``SourcePackager`` reads the file). After S4:
+# same DeprecationWarning as the ``str`` form, since both shapes are
+# being collapsed into the Callable-via-decorator surface.
+# =============================================================================
+
+
+class TestSourcePathEmitsDeprecation:
+    def test_source_pathlib_path_emits_deprecation_warning(
+        self, tmp_script_path: Path
+    ) -> None:
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = client.deploy_distributed(
+                source=tmp_script_path,
+                **_common_kwargs(),
+            )
+            training.delete()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning for Path input. "
+            f"Got: {[str(w.message) for w in caught]}"
+        )
+
+    def test_source_str_filepath_emits_deprecation_warning(
+        self, tmp_script_path: Path
+    ) -> None:
+        """
+        A ``str`` that resolves to a file goes through the same
+        ``SourcePackager`` file-reading path as ``Path``. Both are the
+        anti-pattern S4 collapses; both must warn.
+        """
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = client.deploy_distributed(
+                source=str(tmp_script_path),
+                **_common_kwargs(),
+            )
+            training.delete()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning for str filepath. "
+            f"Got: {[str(w.message) for w in caught]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_source_pathlib_path_emits_deprecation_warning_async(
+        self, tmp_script_path: Path
+    ) -> None:
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = await client.deploy_distributed_async(
+                source=tmp_script_path,
+                **_common_kwargs(),
+            )
+            await training.delete_async()
+        sw = _source_shape_warnings(caught)
+        assert sw, (
+            f"Expected a source-shape DeprecationWarning (async, Path). "
+            f"Got: {[str(w.message) for w in caught]}"
+        )
+
+
+# =============================================================================
+# Target 3: ``source`` as a ``Callable`` does NOT emit DeprecationWarning.
+#
+# The Callable form is what the decorator already uses; it is the
+# canonical input shape going forward. Users who construct a
+# ``deploy_distributed(source=callable)`` call directly should NOT see
+# the source-shape warning -- only the S1 ``deploy_distributed``-itself
+# deprecation (which is a separate concern handled by SDK-S1).
+# =============================================================================
+
+
+def _callable_for_source_tests() -> None:
+    """
+    Fixture for the Callable-form source-deprecation tests.
+
+    Defined at module scope so ``inspect.getsource`` can read the body
+    (functions defined inside test methods raise ``OSError`` from
+    ``inspect.getsourcelines`` when not in a frame). The body itself is
+    irrelevant -- the stubbed deploy never executes it.
+    """
+    print("rank-up via callable")
+
+
+class TestSourceCallableStaysSilent:
+    def test_source_callable_does_not_emit_source_deprecation(self) -> None:
+        """
+        The Callable form is the canonical input. ``deploy_distributed``
+        is itself S1-deprecated, so a direct call still warns about that,
+        but NOT about the source shape -- the Callable is the target shape.
+        """
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = client.deploy_distributed(
+                source=_callable_for_source_tests,
+                **_common_kwargs(),
+            )
+            training.delete()
+        sw = _source_shape_warnings(caught)
+        assert not sw, (
+            f"Callable source must NOT trigger a source-shape "
+            f"DeprecationWarning. Got: {[str(w.message) for w in sw]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_source_callable_does_not_emit_source_deprecation_async(
+        self,
+    ) -> None:
+        client = _make_client_with_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = await client.deploy_distributed_async(
+                source=_callable_for_source_tests,
+                **_common_kwargs(),
+            )
+            await training.delete_async()
+        sw = _source_shape_warnings(caught)
+        assert not sw, (
+            f"Callable source (async) must NOT trigger a source-shape "
+            f"DeprecationWarning. Got: {[str(w.message) for w in sw]}"
+        )
+
+
+# =============================================================================
+# Target 4: the decorator path stays silent.
+#
+# Users using ``@basilica.distributed`` see NO warnings -- including the
+# new source-shape one. The decorator internally extracts the function
+# body to a string and calls ``deploy_distributed(source=<str>, ...,
+# _emit_deprecation=False)``. The existing ``_emit_deprecation=False``
+# gate already silences the S1 deprecation; the same gate must also
+# silence the new source-shape deprecation.
+# =============================================================================
+
+
+class TestDecoratorPathDoesNotEmitSourceDeprecation:
+    def test_decorator_deploys_without_emitting_source_deprecation(self) -> None:
+        """
+        The decorator extracts the function body into a ``str`` and
+        forwards it as ``source=<str>``. Without the silencing gate, S4
+        would warn here -- the user opted into the canonical surface
+        and must not be warned about an internal plumbing detail.
+        """
+        client = _make_client_with_stub()
+
+        @basilica.distributed(
+            name="dlc-s4-source-test",
+            image="ghcr.io/example/trainer:latest",
+            world_size=WorldSize(min=2, target=2, max=4),
+            timeout=0,
+        )
+        def train() -> None:
+            """Per-rank entrypoint; body irrelevant for the warning test."""
+            pass
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = train.deploy(client=client)
+            training.delete()
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert not deprecation_warnings, (
+            f"Decorator internal deploy path emitted DeprecationWarning(s): "
+            f"{[str(w.message) for w in deprecation_warnings]}. "
+            f"@basilica.distributed users must not see any "
+            f"DeprecationWarnings -- the decorator IS the canonical "
+            f"surface; the source=<str> internal call is plumbing."
+        )
+
+    def test_command_factory_does_not_emit_source_deprecation(self) -> None:
+        """
+        The S3 ``basilica.distributed(command=[...])`` factory path is the
+        canonical BYO-launcher surface; it has NO source= argument at all.
+        Pin that the factory path does not surface a source-shape warning
+        (the factory path forwards ``source=None`` to ``deploy_distributed``
+        with ``_emit_deprecation=False``, so it must stay silent).
+        """
+        client = _make_client_with_stub()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            training = basilica.distributed(
+                name="dlc-s4-source-test",
+                image="ghcr.io/example/trainer:latest",
+                world_size=WorldSize(min=2, target=2, max=4),
+                command=["python3", "/workspace/noop.py"],
+                timeout=0,
+                client=client,
+            )
+            training.delete()
+
+        deprecation_warnings = [
+            w for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "source" in str(w.message).lower()
+        ]
+        assert not deprecation_warnings, (
+            f"S3 command-factory path emitted source-shape "
+            f"DeprecationWarning(s): "
+            f"{[str(w.message) for w in deprecation_warnings]}."
+        )


### PR DESCRIPTION
## Summary

Collapse the `BasilicaClient.deploy_distributed(source=...)` parameter to a Callable-only surface via the `@basilica.distributed` decorator. The `str` and `pathlib.Path` shapes remain functional for the next two minor versions, but now emit a `DeprecationWarning` pointing at the canonical alternatives.

This ships SDK-S4 in the SDK API simplification plan (`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on `one-covenant/basilica-backend@main`, Problem 2 / SDK-S4). Sits in the converging surface alongside the previously-merged S1, S2 and S3 work.

## What changed

Implementation in `crates/basilica-sdk-python/python/basilica/__init__.py`:

- New `_normalize_source_param(source, *, emit_deprecation=True)` helper (lines 248-298) that:
  - returns `source` unchanged when it is `None`, a `Callable`, or when `emit_deprecation=False`;
  - emits a `DeprecationWarning` (`stacklevel=3`) for `str` and `pathlib.Path` inputs, pointing the user at the `@basilica.distributed` decorator and the `runpy.run_path('/workspace/...')` wrapping pattern for external scripts;
  - cites `basilica-backend#663 / SDK-S4` in the warning message itself.
- The sync path (`deploy_distributed`, lines 1340-1346) and the async path (`deploy_distributed_async`, lines 2502-2506) call the helper immediately after the existing S1 `_emit_deprecation` gate, before request building. The same gate that already silences the S1 `deploy_distributed`-itself deprecation now also silences the S4 source-shape deprecation, so users on the canonical surface (`@basilica.distributed` decorator or the S3 `basilica.distributed(command=[...])` factory) see no warnings.

## Wire contract

Untouched. This is a Python-side ergonomics warning only. The request payload still ships the same `command`/`args`/`source` shape over JSON; the operator's decoding path is unchanged. The Callable shape is already what the decorator passes internally (via `inspect.getsource(...)`); S4 formalises that the decorator IS the canonical input surface.

## Tests

New file `crates/basilica-sdk-python/tests/test_source_param_deprecation.py` (10 tests, sync + async coverage):

- `TestSourceStringEmitsDeprecation`: `source='<inline python>'` warns; warning message mentions `@basilica.distributed`.
- `TestSourcePathEmitsDeprecation`: `source=Path(...)` AND `source='<filepath>'` both warn (both flow through the same SourcePackager file-reading path).
- `TestSourceCallableStaysSilent`: `source=<function>` does NOT emit a source-shape warning (only the S1 `deploy_distributed`-itself warning, which is a separate concern handled by SDK-S1).
- `TestDecoratorPathDoesNotEmitSourceDeprecation`: both the decorator path (`@basilica.distributed` -> `deploy()`) and the S3 factory path (`basilica.distributed(command=[...], client=...)`) emit NO warnings — the `_emit_deprecation=False` gate covers both S1 and S4.

Test pattern (`BasilicaClient.__new__` + `MagicMock` stub for the PyO3 binding) mirrors `test_distributed_canonical_surface.py` and `test_distributed_command_factory.py`. No network or auth calls fire.

### Evidence

- Pre-fix (in basilica-backend at `data/evidence/sdk-simpl-663/01-failing-test-pre-fix.txt`): 6 of the new tests fail — captures the anti-pattern (no warning today for `str`/`Path` source inputs).
- Post-fix (at `data/evidence/sdk-simpl-663/02-tests-pass-post-fix.txt`): **211 passed** in the full SDK Python suite (the unrelated `test_dns_propagation_e2e.py` is excluded because it requires `httpx`, which is not in the SDK dev deps and not installed in CI either — CI's `pytest tests/ -v || echo` swallows the collection error).
- Runtime evidence (at `data/evidence/sdk-simpl-663/05-runtime-verify/00-runtime-warnings.txt`): captures the actual `DeprecationWarning` text the runtime emits to stderr when a user calls `deploy_distributed(source='<str>', ...)`.

## Cross-references

- SDK API simplification plan: `docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` on `one-covenant/basilica-backend@main` (Problem 2 / SDK-S4).
- Tracking issue: one-covenant/basilica-backend#663.
- S1: one-covenant/basilica#484 (merged) — `deploy_distributed` deprecated in favour of the decorator.
- S2: one-covenant/basilica#483 + #485 (merged) — `bench` collapsed to bool.
- S3: one-covenant/basilica#486 (merged) — `basilica.distributed(command=[...])` factory shape.

## Version bump

`crates/basilica-sdk-python` bumped `0.29.6 -> 0.29.7` across `Cargo.toml`, `pyproject.toml`, and `Cargo.lock`. This satisfies the basilica-sdk-python version-drift guard in `.github/workflows/ci.yml` (`Check basilica-sdk-python version consistency` step).

## Test plan

- [x] New unit tests in `test_source_param_deprecation.py` (10 tests) pass on the worktree.
- [x] Full SDK Python suite: 211 passed (e2e excluded; same as CI behaviour).
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo clippy -p basilica-sdk-python -- -D warnings`: no warnings introduced.
- [x] Runtime smoke: `python -c "import basilica; ..."` produces the expected `DeprecationWarning` to stderr.
- [ ] CI green (will block on this before merge).

Fixes one-covenant/basilica-backend#663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Passing file paths or strings as source parameters to distributed deployments now emits deprecation warnings. Users should migrate to the decorator-based approach instead.

* **Tests**
  * Added comprehensive test coverage for source parameter deprecation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->