### PR TITLE
feat(sdk): migrate examples 20/21/22 to canonical decorator + bench bool + context-manager surface (fixes one-covenant/basilica-backend#664)

### DIFF
--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -1,27 +1,28 @@
 """
 Distributed training example: DiLoCo with @basilica.distributed.
 
-Demonstrates the decorator-style entry point for distributed training:
-- Decorate a function that becomes the per-rank entrypoint.
-- Calling the wrapper deploys; the operator wraps with torchrun.
-- Returns DistributedTraining with scale/wait/logs/bench.
+Demonstrates the canonical decorator surface for distributed training:
 
-Runs in well under 10 minutes on a 4-H100 cluster: 20 outer DiLoCo steps
-on a tiny 6M-parameter MLP. The point is to verify the SDK -> API ->
-operator -> rendezvous -> NCCL chain end-to-end, not to train anything
-useful.
+- ``@basilica.distributed(...)`` decorates the per-rank entrypoint.
+- Calling the wrapped function (or using ``with train() as training:``)
+  deploys and returns a :class:`DistributedTraining` context manager.
+- ``bench=True`` opts in to the per-UD NCCL bench probe; the result
+  reads back as ``training.bench`` (``BenchResult | None``) once the UD
+  reaches a terminal state.
+
+Runs in well under 10 minutes on a 4-rank A100/H100 cluster: 20 outer
+DiLoCo steps on a tiny 6M-parameter MLP. The point is to verify the
+SDK -> API -> operator -> rendezvous -> NCCL chain end-to-end, not to
+train anything useful.
 
 Prereqs:
-- BASILICA_API_TOKEN set, account with H100 access.
-- ~4 ranks of A100 or H100 available.
+- ``BASILICA_API_TOKEN`` set, account with A100/H100 access.
+- ~4 ranks available across the included providers.
 
 Cleanup:
-- The function returns DistributedTraining; call .delete() when done
-  (or rely on ttl_seconds=600 below).
+- The ``with`` block calls ``training.delete()`` on exit (success or
+  exception). ``ttl_seconds=900`` is the platform-side ceiling.
 """
-
-import os
-import time
 
 import basilica
 from basilica import ProviderFilter, WorldSize
@@ -30,11 +31,12 @@ from basilica import ProviderFilter, WorldSize
 @basilica.distributed(
     name="dlc-example-diloco",
     # The basilica-distributed-trainer image is the canonical base for
-    # distributed UDs: it ships torch + `python-etcd` (the latter is
-    # required by torchrun's `--rdzv-backend=etcd` legacy backend that
-    # the operator currently maps `etcd-v2` to; see operator
-    # distributed.rs build_worker_command). A bare pytorch image does
-    # not include `python-etcd` so torchrun would fail at rendezvous.
+    # distributed UDs: it ships torch + ``python-etcd`` (the latter is
+    # required by torchrun's ``--rdzv-backend=etcd`` legacy backend that
+    # the operator currently maps ``etcd-v2`` to; see operator
+    # ``distributed.rs::build_worker_command``). A bare pytorch image
+    # does not include ``python-etcd`` so torchrun would fail at
+    # rendezvous.
     image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
     world_size=WorldSize(min=2, target=4, max=4),
     gpu_count=1,
@@ -42,15 +44,26 @@ from basilica import ProviderFilter, WorldSize
     min_gpu_memory_gb=40,
     cpu="8",
     memory="32Gi",
+    # ``provider_filter`` is a fallback set, not a multi-provider
+    # requirement; ``topology_spread="pack"`` keeps workers on a single
+    # provider for direct WG mesh throughput on NCCL collectives. See
+    # ``docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md`` for the WHY.
     provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
-    topology_spread="provider-aware",
-    bench="on-start",  # 2-rank NCCL bench probe; result on training.bench.
+    topology_spread="pack",
+    # Opt in to the per-UD NCCL bench probe. ``True`` -> the platform
+    # schedules a 2-rank ``all_reduce_perf`` probe alongside the workers
+    # and surfaces the measurement on ``training.bench``. Replaces the
+    # legacy ``"on-start"`` / ``"off"`` string modes (still accepted with
+    # ``DeprecationWarning``; removed in the next major).
+    bench=True,
     nccl_env={"NCCL_DEBUG": "WARN"},
     ttl_seconds=900,
     timeout=900,
 )
 def train() -> None:
     """Per-rank DiLoCo step. Each rank executes this body once under torchrun."""
+    import os
+
     import torch
     import torch.distributed as dist
     import torch.nn as nn
@@ -102,8 +115,11 @@ def train() -> None:
             outer.step()
 
         if rank == 0 and outer_step % 5 == 0:
-            print(f"[rank 0] outer_step={outer_step}/{OUTER_STEPS} "
-                  f"world_size={world_size}", flush=True)
+            print(
+                f"[rank 0] outer_step={outer_step}/{OUTER_STEPS} "
+                f"world_size={world_size}",
+                flush=True,
+            )
 
     if rank == 0:
         print("[rank 0] training complete", flush=True)
@@ -111,44 +127,33 @@ def train() -> None:
 
 
 if __name__ == "__main__":
-    # The decorator call deploys; the returned DistributedTraining lets
-    # us follow + clean up.
-    training = train()
-    print(f"Deployed: {training.name}")
-    print(f"Namespace: {training.namespace}")
-    print(f"Rendezvous: {training.rendezvous_endpoint}")
-    print(f"World: {training.world}")
+    # ``train()`` deploys and returns a DistributedTraining; the ``with``
+    # block calls ``training.delete()`` on scope exit (success OR
+    # exception), so the UD does not leak if a mid-run wait raises.
+    with train() as training:
+        print(f"Deployed: {training.name}")
+        print(f"Namespace: {training.namespace}")
+        print(f"Rendezvous: {training.rendezvous_endpoint}")
+        print(f"World: {training.world}")
 
-    # Refs #506: bench probe wait is OPT-IN. The deploy returned as soon
-    # as workers were Ready; here we explicitly block on the bench probe
-    # so the example still demonstrates measuring NCCL bandwidth.
-    # A bench failure no longer makes the whole run look failed.
-    print("Waiting for bench probe (opt-in)...")
-    bench_status = training.wait_until_bench_complete(timeout=1200)
-    if bench_status is None:
-        print("Bench was not enabled on this UD.")
-    elif bench_status.phase == "Succeeded" and training.bench is not None:
-        r = training.bench
-        print(
-            f"Bench result: busbw_gbps_p50={r.busbw_gbps_p50} "
-            f"latency_us_at_1mib={r.latency_us_at_1mib}"
-        )
-    else:
-        print(
-            f"Bench did NOT complete with a measurement: "
-            f"phase={bench_status.phase} message={bench_status.message}"
-        )
+        # Block until the workers reach a terminal phase. Raises
+        # ``BelowMinimumWorld`` on failure or timeout; the ``with``
+        # block's ``__exit__`` cleans up either way.
+        training.wait_until_complete(timeout=1800)
+        print(f"Workers done: {training.world}")
 
-    # Wait for the run to finish (heuristic: poll until ranks all exit
-    # 'Running' state, or 30 minutes elapsed -- whichever first).
-    deadline = time.time() + 1800
-    while time.time() < deadline:
-        training.refresh()
-        ws = training.world
-        if ws.ready == 0:
-            print("All ranks finished; cleaning up.")
-            break
-        time.sleep(15)
-
-    training.delete()
-    print("Cleanup complete.")
+        # ``training.bench`` is the canonical surface for the per-UD
+        # NCCL bench result. Returns ``BenchResult | None`` — ``None``
+        # means "no measurement" (workers too short, probe couldn't
+        # co-schedule, etc.) regardless of why. Use
+        # ``training.bench_diagnostics`` for the rare debug detail.
+        if training.bench is not None:
+            r = training.bench
+            print(
+                f"Bench result: busbw_gbps_p50={r.busbw_gbps_p50} "
+                f"latency_us_at_1mib={r.latency_us_at_1mib}"
+            )
+        else:
+            print("Bench did not measure on this run.")
+            if training.bench_diagnostics is not None:
+                print(f"Bench diagnostics: {training.bench_diagnostics}")

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -1,68 +1,73 @@
 """
-Distributed training example: BYO torchrun via client.deploy_distributed.
+Distributed training example: BYO torchrun via ``basilica.distributed(command=...)``.
 
-Demonstrates the lower-level path for users who want to control the
-torchrun invocation explicitly (custom rdzv config, nproc-per-node tweaks,
-or a non-standard launcher entirely).
+Demonstrates the canonical factory shape for users who want to control
+the torchrun invocation explicitly (custom rdzv config, nproc-per-node
+tweaks, or a non-standard launcher entirely).
 
 Contrast with example 20 (decorator path): there, the operator's
-`command="auto"` builds the torchrun command. Here, you pass `command=`
-explicitly and the operator passes it through verbatim. Env vars
-BASILICA_RDZV_ENDPOINT / BASILICA_WORLD_TARGET / BASILICA_RANK are still
-injected by the init container so your launcher can consume them.
+``command="auto"`` builds the torchrun command around the decorated
+function body. Here, you pass ``command=`` explicitly and the operator
+passes it through verbatim. Env vars ``BASILICA_RDZV_ENDPOINT`` /
+``BASILICA_WORLD_TARGET`` / ``BASILICA_RANK`` are still injected by the
+init container so your launcher can consume them.
+
+When ``command`` is set, ``basilica.distributed(...)`` short-circuits
+the decorator path and returns a :class:`DistributedTraining` directly
+(factory mode). Use it under a ``with`` block to get auto-cleanup.
 
 Prereqs:
-- BASILICA_API_TOKEN set.
+- ``BASILICA_API_TOKEN`` set.
 - A training script accessible to the trainer image (here we use the
-  basilica-distributed-trainer image which ships an `all_reduce_smoke.py`
-  fixture for exactly this purpose).
+  basilica-distributed-trainer image which ships an
+  ``all_reduce_smoke.py`` fixture for exactly this purpose).
 """
 
 import time
 
-from basilica import BasilicaClient, ProviderFilter, WorldSize
+import basilica
+from basilica import ProviderFilter, WorldSize
 
 
 def main() -> None:
     """
-    Wrapped in main() so importing the module (e.g. from doc tooling or
-    a test runner) does NOT spin up a paid distributed cluster. Per the
-    coding guidelines, deploy/start_*_rental calls are cost-bearing and
-    must be tied to an explicit script run.
+    Wrapped in ``main()`` so importing the module (e.g. from doc tooling
+    or a test runner) does NOT spin up a paid distributed cluster. Per
+    the coding guidelines, deploy/start_*_rental calls are cost-bearing
+    and must be tied to an explicit script run.
     """
-    client = BasilicaClient()
-
-    # BYO-launcher: pass `command=` explicitly. The operator's CRD has
-    # no "use image ENTRYPOINT, just pass args" mode -- distributed UDs
-    # must specify either `source=` (auto-torchrun wrapping) or
-    # `command=` (verbatim launcher). See operator's CRD § 4 / SDK
-    # arch § 4 footnote on auto-torchrun wrapping. The basilica-
-    # distributed-trainer image's `/workspace/all_reduce_smoke.py`
-    # fixture is the smoke target.
-    # NOTE on `--rdzv-backend=etcd` (not `etcd-v2`): refs #368 / #490.
-    # The torchelastic `etcd-v2` backend (DynamicRendezvousHandler over
+    # BYO launcher: pass ``command=`` to ``basilica.distributed(...)``.
+    # The operator's CRD has no "use image ENTRYPOINT, just pass args"
+    # mode -- distributed UDs must specify either an auto-torchrun-wrapped
+    # function body (decorator path; see example 20) or ``command=``
+    # (verbatim launcher). See operator's CRD § 4 / SDK arch § 4 footnote
+    # on auto-torchrun wrapping. The basilica-distributed-trainer image's
+    # ``/workspace/all_reduce_smoke.py`` fixture is the smoke target.
+    #
+    # NOTE on ``--rdzv-backend=etcd`` (not ``etcd-v2``): refs #368 / #490.
+    # The torchelastic ``etcd-v2`` backend (DynamicRendezvousHandler over
     # etcd v3 gRPC) has an upstream regression in torch 2.5.0a0+nv24.10
     # that returns RendezvousClosedError on the FIRST connect to a fresh
-    # etcd. The legacy `etcd` backend (EtcdRendezvousHandler over
+    # etcd. The legacy ``etcd`` backend (EtcdRendezvousHandler over
     # python-etcd / v2 KV API) works against the same etcd Pod with
-    # --enable-v2=true. The operator's "auto" command-build path
-    # (basilica-operator: distributed.rs::build_worker_command) maps the
-    # CRD value `etcd-v2` -> the working `etcd` torchrun arg until
-    # upstream resolves it; BYO commands (this example) need to do the
-    # same. When #368 closes, flip both back to `etcd-v2`.
-    # NOTE on `--rdzv-conf=timeout=1500`: refs #490. torchelastic's
-    # rendezvous handlers default to a ~600 s join timeout; on slow
+    # ``--enable-v2=true``. The operator's "auto" command-build path
+    # (basilica-operator: ``distributed.rs::build_worker_command``) maps
+    # the CRD value ``etcd-v2`` -> the working ``etcd`` torchrun arg
+    # until upstream resolves it; BYO commands (this example) need to do
+    # the same. When #368 closes, flip both back to ``etcd-v2``.
+    #
+    # NOTE on ``--rdzv-conf=timeout=1500``: refs #490. torchelastic's
+    # rendezvous handlers default to a ~600s join timeout; on slow
     # cold-starts (image pull blip, transient registry slowness, GPU
     # node first boot) rank-0 can raise RendezvousClosedError before
-    # rank-N joins. The operator's "auto" command-build path injects
-    # this same value; BYO commands need to mirror it.
-    # `deploy_distributed_managed` is the defensive sibling of
-    # `deploy_distributed` (refs basilica-backend#538): on scope exit
-    # (success OR exception) it best-effort calls `training.delete()`
-    # so the UD does not leak when an intermediate wait such as
-    # `wait_until_target_world` after `scale()` raises before the
-    # explicit `delete()` line is reached.
-    with client.deploy_distributed_managed(
+    # rank-N joins. The operator's auto path injects this same value;
+    # BYO commands need to mirror it.
+    #
+    # The ``with`` block calls ``training.delete()`` on scope exit
+    # (success OR exception) -- so an intermediate wait such as
+    # ``wait_until_target_world`` after ``scale()`` raising before the
+    # explicit cleanup line does not leak the UD.
+    training = basilica.distributed(
         name="dlc-example-torchrun",
         image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
         command=[
@@ -82,14 +87,15 @@ def main() -> None:
         min_gpu_memory_gb=40,
         cpu="8",
         memory="32Gi",
-        # Broadened provider include-list (refs basilica-backend#544): pinning
-        # to a single provider exposed the example to provider-side
-        # rental-revoke transients (the autoscaler's `Rental disappeared from
-        # provider` failure mode). Including the four providers we onboard
-        # today lets the autoscaler fall back across them when one provider's
-        # rental API is misbehaving under burst load. The `topology_spread="pack"`
-        # below still keeps the workers on a single provider per UD; this list
-        # is a fallback set, not a spread directive.
+        # Broadened provider include-list (refs basilica-backend#544):
+        # pinning to a single provider exposed the example to provider-
+        # side rental-revoke transients (the autoscaler's "Rental
+        # disappeared from provider" failure mode). Including the four
+        # providers we onboard today lets the autoscaler fall back across
+        # them when one provider's rental API is misbehaving under burst
+        # load. ``topology_spread="pack"`` below still keeps the workers
+        # on a single provider per UD; this list is a fallback set, not
+        # a spread directive.
         provider_filter=ProviderFilter(
             include=["verda", "hyperstack", "masscompute", "shadeform"]
         ),
@@ -97,27 +103,29 @@ def main() -> None:
         nccl_env={"NCCL_DEBUG": "WARN"},
         ttl_seconds=600,
         timeout=900,
-    ) as training:
+    )
+
+    with training:
         print(f"Deployed: {training.name}")
         print(f"Namespace: {training.namespace}")
         print(f"World: {training.world}")
 
-        # Scale up by one rank, mid-run. Demonstrates Phase 2 elasticity:
-        # torchelastic re-rendezvouses workers when the StatefulSet replica count
-        # changes, and the new rank joins.
+        # Scale up by one rank, mid-run. Demonstrates elastic scaling:
+        # torchelastic re-rendezvouses workers when the StatefulSet
+        # replica count changes, and the new rank joins.
         time.sleep(30)
         new_world = training.scale(target=3)
         print(f"Scaled to target=3; world now: {new_world}")
 
         # Wait for the new rank to join. If this raises (e.g. operator
-        # leader transfer mid-rollout), the managed `with` block runs
-        # `delete()` on its way out so the UD does not leak.
+        # leader transfer mid-rollout), the ``with`` block runs
+        # ``delete()`` on its way out so the UD does not leak.
         training.wait_until_target_world(timeout=300)
         print(f"All 3 ranks ready: {training.world}")
 
-        # Tail logs briefly so the example surfaces "is it actually running".
-        # Phase 5b: per-rank filtering not yet supported by the API; logs are
-        # returned merged across ranks.
+        # Tail logs briefly so the example surfaces "is it actually
+        # running". Per-rank filtering is not yet supported by the API;
+        # logs are returned merged across ranks.
         print("--- merged logs ---")
         print(training.logs(tail=30))
 

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -1,75 +1,72 @@
 """
 Distributed training example: per-UD NCCL bench probe (SDK arch § 7).
 
-Demonstrates the per-UD bench surface. Launching a UD with
-`bench="on-start"` schedules a 2-rank NCCL `all_reduce_perf` Job in the
+Demonstrates the per-UD bench surface via the canonical decorator.
+``bench=True`` schedules a 2-rank NCCL ``all_reduce_perf`` Job in the
 user's namespace alongside the workers. The probe runs in parallel; the
-result lands on `training.bench` once the probe Job completes.
+result lands on ``training.bench`` once the UD reaches a terminal state.
 
 Why this matters: the platform-internal NCCL benchmark matrix
 (architecture doc § 12) does NOT serve user-facing queries -- a
 shared cluster-wide cache would violate the platform's tenancy
-invariant (SDK arch § 1). User-visible bench data is per-UD,
-measured on the user's actual nodes, billed against the user's
-GPU minutes, scoped to the user's namespace.
+invariant (SDK arch § 1). User-visible bench data is per-UD, measured
+on the user's actual nodes, billed against the user's GPU minutes,
+scoped to the user's namespace.
 
-There is intentionally NO `client.preflight(...)` and NO
-`client.nccl_baseline(...)` standalone helper. That surface implied a
-shared cache. Use this per-UD pattern instead.
+There is intentionally NO ``client.preflight(...)`` and NO
+``client.nccl_baseline(...)`` standalone helper. That surface implied
+a shared cache. Use this per-UD pattern instead.
 
-Bench wait is OPT-IN (refs #506): `deploy_distributed` returns as soon
-as workers are Ready, regardless of bench probe state. This script
-demonstrates the opt-in pattern via
-`training.wait_until_bench_complete(...)`. A bench failure no longer
-makes the deploy look failed -- the workers are healthy and you can
-choose what to do with the measurement (or its absence).
+Bench is OPT-IN. ``bench=True`` schedules the probe; ``bench=False``
+(default) skips it. The result reads back as ``training.bench``
+(``BenchResult | None``); ``None`` means "no measurement" regardless
+of why (workers too short, probe couldn't co-schedule, etc.). For
+debug detail on a ``None`` result, inspect ``training.bench_diagnostics``.
 
 Prereqs:
-- BASILICA_API_TOKEN set.
+- ``BASILICA_API_TOKEN`` set.
 - Account with verda A100 access (or adjust the provider filter).
 - Namespace rank budget >= 4 (worker(2) + bench(2)).
 """
 
 import json
 
-from basilica import BasilicaClient, ProviderFilter, WorldSize
+import basilica
+from basilica import ProviderFilter, WorldSize
 
 
-def main() -> None:
+@basilica.distributed(
+    name="dlc-example-bench",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    world_size=WorldSize(min=2, target=2, max=2),
+    gpu_count=1,
+    gpu_models=["A100"],
+    min_gpu_memory_gb=40,
+    cpu="8",
+    memory="32Gi",
+    provider_filter=ProviderFilter(include=["verda"]),
+    topology_spread="pack",  # Pack for the smallest measured pair.
+    bench=True,  # Schedule the 2-rank NCCL probe.
+    nccl_env={"NCCL_DEBUG": "WARN"},
+    ttl_seconds=900,
+    timeout=900,
+)
+def workload() -> None:
     """
-    Wrapped in main() so importing the module does NOT spin up a paid
-    distributed cluster. Per the coding guidelines, deploy/start_*_rental
-    calls are cost-bearing and must be tied to an explicit script run.
+    Per-rank entrypoint. Each rank runs this body under torchrun;
+    ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` / ``MASTER_*`` are wired
+    by torchrun. The body just reads them from ``os.environ``.
+
+    Contrast with example 21 (BYO ``command=`` for full launcher
+    control); here the decorator hands the body to the operator's
+    ``command="auto"`` torchrun wrapper.
     """
-    client = BasilicaClient()
+    import os
+    import time
 
-    # `source=` (string) is the recommended path for typical SDK users:
-    # the SDK ships the source via base64 to /tmp/__basilica_source.py and
-    # the operator's BYO renderer exec's torchrun on it. RANK / WORLD_SIZE
-    # / MASTER_* are set by torchrun -- the user code just reads them.
-    #
-    # Contrast with `command=["python3", "/workspace/foo.py"]` which skips
-    # torchrun entirely; ranks would crash with `RANK env var missing`.
-    # For users who want full control over the launcher, see example 21
-    # (BYO torchrun via `command=[...]`).
-    # `deploy_distributed_managed` (refs basilica-backend#538) auto-
-    # deletes the UD on scope exit, even when the script aborts via
-    # `raise SystemExit(1)` on a bench-Succeeded-but-no-result path.
-    # The exit propagates through the `with` block; `__exit__` cleans
-    # up; the script exits 1 as before -- no behavioral change beyond
-    # closing the leak window.
-    with client.deploy_distributed_managed(
-        name="dlc-example-bench",
-        image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
-        source="""\
-import os
-import time
+    import torch
+    import torch.distributed as dist
 
-import torch
-import torch.distributed as dist
-
-
-def main() -> None:
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
@@ -80,8 +77,8 @@ def main() -> None:
 
     # Brief NCCL all_reduce loop -- proves the workers rendezvoused and
     # the collective fabric is up. Each step sums a 1024-float tensor
-    # across all ranks; expected sum at step k is world_size (because we
-    # start from ones and re-fill each step).
+    # across all ranks; expected sum at step k is world_size * 1024
+    # (because we start from ones and re-fill each step).
     for step in range(5):
         x = torch.ones(1024, device=device)
         dist.all_reduce(x)
@@ -97,63 +94,37 @@ def main() -> None:
     print(f"[rank {rank}] done", flush=True)
 
 
-if __name__ == "__main__":
-    main()
-""",
-        world_size=WorldSize(min=2, target=2, max=2),
-        gpu_count=1,
-        gpu_models=["A100"],
-        min_gpu_memory_gb=40,
-        cpu="8",
-        memory="32Gi",
-        provider_filter=ProviderFilter(include=["verda"]),
-        topology_spread="pack",  # Pack for the smallest measured pair.
-        bench="on-start",  # Schedule the 2-rank NCCL probe.
-        nccl_env={"NCCL_DEBUG": "WARN"},
-        ttl_seconds=900,
-        timeout=900,
-    ) as training:
+def main() -> None:
+    """
+    Deploy + collect the bench measurement. Wrapped in ``main()`` so
+    importing the module does NOT spin up a paid distributed cluster.
+    """
+    # ``workload()`` deploys; the ``with`` block calls
+    # ``training.delete()`` on scope exit (success OR exception), so
+    # the UD does not leak when a mid-run wait raises.
+    with workload() as training:
         print(f"Deployed: {training.name}")
         print("Bench probe scheduled (rank-budget cost: worker(2) + bench(2) = 4)")
 
-        # Refs #506: deploy_distributed now returns when workers are Ready;
-        # the bench probe is decoupled. Use the opt-in waiter to block on it.
-        # `bench_timeout=1200` (20 min) matches the prior implicit budget.
-        print("Waiting for bench probe (opt-in via wait_until_bench_complete)...")
-        bench_status = training.wait_until_bench_complete(timeout=1200)
+        # Block until workers reach a terminal phase. Raises
+        # ``BelowMinimumWorld`` on failure or timeout; the ``with``
+        # block's ``__exit__`` cleans up either way.
+        training.wait_until_complete(timeout=1800)
+        print(f"Workers done: {training.world}")
 
-        if bench_status is None:
-            # mode=off — caller did not request a bench probe. Not reachable
-            # in this example (we set bench="on-start" above), but kept for
-            # symmetry with the API contract. Managed `__exit__` deletes
-            # the UD as the SystemExit propagates.
-            print("Bench was not enabled on this UD.")
-            raise SystemExit(1)
-
-        if bench_status.phase != "Succeeded":
-            # Workers were Ready -- the deploy is fine -- but the bench
-            # didn't measure. Print the lifecycle detail; do NOT exit non-zero
-            # for a bench-only failure (the workload itself is healthy).
-            # `return` falls through the managed exit which deletes the UD.
-            print("Bench probe did NOT complete with a measurement.")
-            print(f"  phase:              {bench_status.phase}")
-            print(f"  message:            {bench_status.message}")
-            print(f"  last_attempt_at:    {bench_status.last_attempt_at}")
-            print(f"  last_attempt:       {bench_status.last_attempt_outcome}")
-            print("Workers are still Ready; the UD itself is healthy.")
-            print("Inspect via `kubectl get job -n <ns> -l basilica.ai/distributed-role=bench`.")
-            return
-
-        # bench_status.phase == "Succeeded"; the result payload is on
-        # `training.bench` (or `bench_status.result`).
+        # ``training.bench`` is the canonical surface for the bench
+        # measurement. ``None`` means "no measurement" regardless of
+        # why -- workers too short, probe couldn't co-schedule, etc.
+        # 99% of users only ever read this attribute.
         result = training.bench
         if result is None:
-            # Defensive: phase=Succeeded but no result payload -- this would
-            # be an operator-side invariant break. Surface it explicitly;
-            # SystemExit propagates through the managed `with`, which
-            # deletes the UD on its way out.
-            print("Bench phase=Succeeded but no result payload available.")
-            raise SystemExit(1)
+            print("Bench did not measure on this run.")
+            # The rare debug case: inspect ``bench_diagnostics`` for
+            # operator-side detail on why the probe didn't land a result.
+            if training.bench_diagnostics is not None:
+                print(f"Bench diagnostics: {training.bench_diagnostics}")
+            return
+
         print("--- Bench result ---")
         print(f"  measured_at:        {result.measured_at}")
         print(f"  busbw_gbps_p10:     {result.busbw_gbps_p10}")
@@ -165,9 +136,10 @@ if __name__ == "__main__":
         print(f"  probe_node_a:       {result.probe_node_a}")
         print(f"  probe_node_b:       {result.probe_node_b}")
 
-        # Researchers writing papers can serialize this to JSON and aggregate
-        # across many UDs offline -- each measurement is on their own nodes,
-        # billed against their own usage, with no cross-tenant shared cache.
+        # Researchers writing papers can serialize this to JSON and
+        # aggregate across many UDs offline -- each measurement is on
+        # their own nodes, billed against their own usage, with no
+        # cross-tenant shared cache.
         out = {
             "name": training.name,
             "world_size": {
@@ -185,8 +157,6 @@ if __name__ == "__main__":
         with open(f"/tmp/{training.name}-bench.json", "w") as f:
             json.dump(out, f, indent=2, default=str)
         print(f"Saved bench result: /tmp/{training.name}-bench.json")
-
-    print("Cleanup complete.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

S5 of the SDK API simplification plan ([docs/plans/SDK-API-SIMPLIFICATION-PLAN.md](https://github.com/one-covenant/basilica-backend/blob/main/docs/plans/SDK-API-SIMPLIFICATION-PLAN.md) on basilica-backend). Migrates the three flagship distributed-training examples to the canonical surface delivered by S1-S4 (PRs #483, #484, #485, #486, #487).

Examples now use:
- `@basilica.distributed(...)` decorator (or `basilica.distributed(command=...)` factory) — no `_managed` suffix
- `bench=True` bool (not `bench='on-start'` string)
- `with training:` context manager for orchestration + auto-cleanup
- lazy `training.bench` for the bench result; `training.bench_diagnostics` for the rare debug case
- no `wait_until_bench_complete`, no `bench_status.phase` ceremony

## Per-example diff

### `examples/20_distributed_diloco.py`
- `bench="on-start"` (str, deprecated by S2) -> `bench=True` (bool)
- Removed `time` import + manual poll loop after the decorator call
- Removed `training.wait_until_bench_complete(timeout=1200)` + 4-phase enum check
- Added `with train() as training:` block (auto-cleanup on success OR exception)
- Added `training.wait_until_complete(timeout=1800)` for terminal-phase block
- Added canonical `training.bench` / `training.bench_diagnostics` reads
- `topology_spread="provider-aware"` -> `topology_spread="pack"` (mesh-throughput recommendation per the user runbook)

### `examples/21_distributed_torchrun.py`
- `client.deploy_distributed_managed(command=[...])` (S1-deprecated) -> `basilica.distributed(command=[...])` (S3 factory shape)
- Dropped explicit `BasilicaClient()` instantiation (factory creates one lazily; mirrors decorator semantics)
- All other behaviour unchanged: same `with training:` block, same `scale(target=3)`, same `wait_until_target_world(timeout=300)`, same `logs(tail=30)`

### `examples/22_distributed_with_bench.py`
- `client.deploy_distributed_managed(source=<inline str>, bench="on-start")` -> `@basilica.distributed(..., bench=True)` decorator (S1+S2+S4 collapse)
- Removed inline `source=` string with embedded torch script
- Per-rank entrypoint is now the decorated `workload()` function body (Callable shape; the canonical input per S4)
- Removed `wait_until_bench_complete` + 4-phase enum checks + `bench_status.phase != "Succeeded"` branch
- Added `training.wait_until_complete(timeout=1800)` for terminal-phase block
- `training.bench` is the only bench read; `training.bench_diagnostics` is shown for the rare `None` case

## Why this matters

The plan calls out three anti-patterns the SDK exposes today: `deploy_distributed_managed` overlapping with `@distributed`, `bench: str` modes + 4-phase `BenchStatus` enum + 3 access paths for one diagnostic, `source: Union[str, Path, Callable]` taking three forms for one input. After S1-S4 landed (PRs #483-#487), the canonical surface exists but the flagship examples were still showing the deprecated forms to users. S5 closes the gap: the examples now demonstrate the same surface the user runbook (`docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md` on basilica-backend) describes.

## Verification

### Pre-fix DeprecationWarning capture

Captured before any changes (saved in basilica-backend `data/evidence/sdk-simpl-664/01-deprecation-warnings-pre-fix.txt`):

- ex20 emitted: `bench='on-start' (str) is deprecated` (S2), `wait_until_bench_complete is deprecated` (S2)
- ex21 emitted: `BasilicaClient.deploy_distributed_managed is deprecated` (S1)
- ex22 emitted: `BasilicaClient.deploy_distributed_managed is deprecated` (S1), `wait_until_bench_complete is deprecated` (S2), `source='str'-typed value is deprecated` (S4)

### Post-fix DeprecationWarning audit

Captured after the migration (saved in basilica-backend `data/evidence/sdk-simpl-664/02-deprecation-warnings-post-fix.txt`):

```
=== ex20 (post-fix) ===
[probe] ex20 import-time SDK DeprecationWarnings: 0
[probe] ex20 bench=True normalisation SDK DeprecationWarnings: 0
[probe] ex20 training.bench + bench_diagnostics SDK DeprecationWarnings: 0

=== ex21 (post-fix) ===
[probe] ex21 basilica.distributed(command=...) SDK DeprecationWarnings: 0

=== ex22 (post-fix) ===
[probe] ex22 import-time SDK DeprecationWarnings: 0
[probe] ex22 bench=True normalisation SDK DeprecationWarnings: 0
[probe] ex22 training.bench + bench_diagnostics SDK DeprecationWarnings: 0
```

### SDK test suite

`pytest tests/ -q` on the full SDK Python test suite (excluding `test_dns_propagation_e2e.py` which needs `httpx` not in the venv): **211 passed**, 76 warnings (all from existing S1-S4 acceptance tests that exercise the deprecated paths). No regression.

### Runtime end-to-end (ex21 against api.basilica.ai)

Ran `python examples/21_distributed_torchrun.py` against the live API:

```
Deployed: f01dd43a-760b-428b-abdd-c43e20d6dce2
Namespace: u-github-434149
World: WorldStatus(ready=2, target=3, min=2, max=4, below_minimum=False)
Scaled to target=3; world now: WorldStatus(ready=1, target=3, min=2, max=4, below_minimum=True)
BelowMinimumWorld: ... ready=2, required_min=3 ...
```

Surface-validated:
- `basilica.distributed(command=[...])` factory deployed successfully
- mid-run `training.scale(target=3)` succeeded
- `with` block's `__exit__` ran `delete()` on the BelowMinimumWorld exception (post-run `basilica deploy status` returned "Deployment not found")
- **Zero DeprecationWarning** in the runtime stdout/stderr under `-W default`

The `BelowMinimumWorld` is a provider-capacity event (3rd rank could not be scheduled in 300s), not a SDK/API issue. The pre-S5 example would have hit the same outcome.

### Runtime gap

ex22 is verda-pinned per the existing example contract; verda has no A100 capacity at PR time (a stale `dlc-example-bench` UD from May-4 is still occupying the slot). ex20 needs 4 ranks A100/H100. These were not executed end-to-end here; both were validated via module-import-time DeprecationWarning capture (which exercises every SDK surface the example touches except the actual network call).

## What is NOT in this PR

- No SDK source changes (S5 is examples-only; S1-S4 already shipped the canonical surface)
- No version bump (`pyproject.toml` + `Cargo.toml` stay at 0.29.7)
- No CHANGELOG entry (the changelog tracks API surface changes; this is an examples-only refresh)
- No removal of the deprecated APIs (that is SDK-S7's job, on the next major bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated distributed training examples to showcase simplified deployment patterns with improved resource lifecycle management.
  * Enhanced example documentation demonstrating cleaner usage patterns for benchmark result handling and distributed job monitoring.
  * Examples now guide users through best practices for graceful cleanup and system state inspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->