### PR TITLE
docs(sdk): rewrite README and module docstrings around canonical decorator + context-manager surface (fixes one-covenant/basilica-backend#665)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,92 @@ If the request is about:
 - direct GPU/CPU machines, SSH access, training boxes, or persistent rented hosts: use `basilica-rentals-ops`
 - HTTP services, inference endpoints, public URLs, or self-hosted apps: use `basilica-serverless-ops`
 - Python code, notebooks, scripts, CI automation, or typed programmatic access: use `basilica-sdk-ops`
+- distributed PyTorch / NCCL collective workloads (DDP, DiLoCo, FSDP), multi-rank training with `torch.distributed`: use the `@basilica.distributed` SDK surface (see "Distributed Training" below)
+
+## Distributed Training
+
+When the user wants multi-rank PyTorch training (DDP, DiLoCo, FSDP, any
+NCCL-collective workload), the canonical SDK surface is the
+`@basilica.distributed` decorator. ONE entry point handles both shapes:
+
+```python
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+@basilica.distributed(
+    name="dlc-...",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    world_size=WorldSize(min=2, target=4, max=4),
+    gpu_count=1,
+    gpu_models=["A100"],
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",        # required for direct WG mesh on NCCL
+    bench=True,                    # opt-in NCCL bandwidth probe
+)
+def train():
+    import os, torch, torch.distributed as dist
+    dist.init_process_group(backend="nccl")
+    # ... uses os.environ['RANK'] / ['WORLD_SIZE'] / ['LOCAL_RANK'] ...
+    dist.destroy_process_group()
+
+
+with train() as training:               # auto-cleanup on scope exit
+    training.wait_until_complete(timeout=1800)
+    print(training.bench)               # BenchResult | None
+```
+
+For BYO launchers (torchrun, mpirun, accelerate), pass `command=[...]`
+and `basilica.distributed(...)` returns a `DistributedTraining` directly
+(factory mode):
+
+```python
+training = basilica.distributed(
+    name="dlc-byo-launcher",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    command=[
+        "torchrun",
+        "--rdzv-backend=etcd",
+        "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+        "--rdzv-id=$BASILICA_RDZV_ID",
+        "--nnodes=$BASILICA_WORLD_TARGET",
+        "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+        "/workspace/my_training.py",
+    ],
+    world_size=WorldSize(min=2, target=2, max=4),
+    gpu_count=1,
+    gpu_models=["A100"],
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",
+)
+with training:
+    training.scale(target=3)
+```
+
+Rules:
+
+- ONE canonical surface: `@basilica.distributed` (decorator) or
+  `basilica.distributed(command=[...])` (factory). Both return a
+  `DistributedTraining` context manager.
+- Use `with training:` for mid-run orchestration (`scale()`,
+  `wait_until_*`, `logs()`, `bench`). Bare call is fire-and-forget with
+  auto-cleanup.
+- `bench=True` (bool) opts in to the per-UD NCCL bandwidth probe. Read
+  via `training.bench` (`BenchResult | None`); `None` means "no
+  measurement" regardless of why. Use `training.bench_diagnostics` only
+  for the rare debug case.
+- DO NOT use `client.deploy_distributed_managed(...)`, `bench="on-start"`,
+  `training.bench_status`, or `training.wait_until_bench_complete()` --
+  all four emit `DeprecationWarning` and are collapsed into the
+  canonical surface. See the SDK README's "Migration from the legacy
+  surface" table for the per-parameter mapping.
+- Worked examples: `examples/20_distributed_diloco.py` (decorator +
+  bench + DiLoCo), `examples/21_distributed_torchrun.py` (BYO command +
+  mid-run scale), `examples/22_distributed_with_bench.py` (bench-result
+  inspection + JSON dump).
+- User-facing runbook: `docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md`
+  on basilica-backend. Custom-image guide:
+  `docs/runbooks/BRINGING-YOUR-OWN-TRAINER-IMAGE.md`.
 
 ## Canonical Agent Rules
 
@@ -133,6 +219,8 @@ These files are the best source of truth for agent docs and command behavior:
 - `crates/basilica-sdk-python/README.md`
 - `crates/basilica-sdk-python/python/basilica/__init__.py`
 - `crates/basilica-sdk-python/python/basilica/_deployment.py`
+- `crates/basilica-sdk-python/python/basilica/distributed.py` (distributed-training types + DistributedTraining facade)
+- `crates/basilica-sdk-python/python/basilica/decorators.py` (`@basilica.distributed` + `@basilica.deployment` decorators)
 
 ## Fast Decision Table
 
@@ -140,6 +228,7 @@ These files are the best source of truth for agent docs and command behavior:
 - User wants a public API or app URL: serverless deploy
 - User wants to top up credits: account ops
 - User wants programmatic provisioning in Python: SDK ops
+- User wants multi-rank distributed training (DDP, DiLoCo, FSDP, NCCL collectives): `@basilica.distributed` decorator (see "Distributed Training" above)
 - User wants OpenClaw or Tau specifically: serverless deploy skill
 - User wants huge multi-GPU model serving with lots of manual control: rentals first, deploy second
 

--- a/crates/basilica-sdk-python/README.md
+++ b/crates/basilica-sdk-python/README.md
@@ -386,6 +386,241 @@ deployment = client.deploy(
 )
 ```
 
+## Distributed Training (NCCL collectives)
+
+For `torch.distributed` workloads (DDP, DiLoCo, FSDP, any NCCL-collective workload),
+use the `@basilica.distributed` decorator. The platform provisions GPU spokes,
+wires the WireGuard mesh, runs torchrun with the standard `RANK` / `WORLD_SIZE`
+/ `MASTER_*` env-var contract, and tears down on context exit.
+
+This is a separate surface from `@basilica.deployment` because the lifecycle
+shape is different: a single function body fans out to N rank pods under
+torchrun, the user reads `os.environ["RANK"]` instead of branching on rank in
+SDK code, and the handle exposes `scale()`, `wait_until_*`, `bench`, and
+`rank_exits` instead of `url` and `replicas`.
+
+### Canonical surface: `@basilica.distributed` decorator
+
+```python
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+@basilica.distributed(
+    name="dlc-hello",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    world_size=WorldSize(min=2, target=2, max=2),
+    gpu_count=1,
+    gpu_models=["A100"],
+    min_gpu_memory_gb=40,
+    cpu="8",
+    memory="32Gi",
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",
+    bench=True,
+    nccl_env={"NCCL_DEBUG": "WARN"},
+    ttl_seconds=900,
+)
+def train() -> None:
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    dist.init_process_group(backend="nccl")
+    device = torch.device(f"cuda:{local_rank}")
+
+    x = torch.ones(1024, device=device)
+    dist.all_reduce(x)
+    if rank == 0:
+        print(f"world={world_size} sum={x.sum().item():.0f}", flush=True)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    with train() as training:
+        print(f"Deployed: {training.name}")
+        training.wait_until_complete(timeout=1800)
+        if training.bench is not None:
+            print(f"Measured busbw: {training.bench.busbw_gbps_p50} Gbps")
+```
+
+Calling the decorated function returns a `DistributedTraining` context-manager.
+Use it bare (`train()`) for fire-and-forget with auto-cleanup; use `with
+train() as training:` for mid-run orchestration (`scale()`, `wait_until_*`,
+`logs()`, `bench`).
+
+### BYO launcher: `basilica.distributed(command=[...])` factory
+
+When you want to drive torchrun (or mpirun, or accelerate) yourself, pass
+`command=[...]` instead of decorating a function. The same `basilica.distributed`
+symbol becomes a factory and returns a `DistributedTraining` directly:
+
+```python
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+training = basilica.distributed(
+    name="dlc-torchrun",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    command=[
+        "torchrun",
+        "--rdzv-backend=etcd",
+        "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+        "--rdzv-id=$BASILICA_RDZV_ID",
+        "--nnodes=$BASILICA_WORLD_TARGET",
+        "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+        "/workspace/all_reduce_smoke.py",
+    ],
+    world_size=WorldSize(min=2, target=2, max=4),
+    gpu_count=1,
+    gpu_models=["A100"],
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",
+    ttl_seconds=900,
+)
+
+with training:
+    training.scale(target=3)
+    training.wait_until_target_world(timeout=300)
+    print(training.logs(tail=30))
+```
+
+Same `DistributedTraining` handle as the decorator path. Same context-manager
+cleanup. The only difference is `command=[...]` replaces the decorated function
+body. Inside the launcher, expand `$BASILICA_RDZV_ENDPOINT` / `$BASILICA_RANK` /
+`$BASILICA_WORLD_TARGET` / `$BASILICA_GPUS_PER_POD` — the operator injects
+these into the worker pod environment.
+
+### Lifecycle on the `DistributedTraining` handle
+
+| Method | What it does |
+|--------|--------------|
+| `training.world` | `WorldStatus(ready, target, min, max, below_minimum)` snapshot |
+| `training.phase` | Operator-driven phase: `pending` / `ready` / `succeeded` / `failed` / `cancelled` |
+| `training.ranks` | Per-rank pod observations (`provider`, `region`, `phase`, `restarts`) |
+| `training.rank_exits` | Per-rank exit diagnostics, populated after the UD reaches a terminal state |
+| `training.bench` | `BenchResult \| None` — `None` means "no measurement", regardless of why |
+| `training.bench_diagnostics` | Debug detail when `training.bench` is `None`; rarely needed |
+| `training.scale(target=N)` | Patch `worldSize.target` mid-run; ranks join/drain asynchronously |
+| `training.wait_until_min_world(timeout=...)` | Block until `ready >= min` or raise `BelowMinimumWorld` |
+| `training.wait_until_target_world(timeout=...)` | Block until `ready >= target` |
+| `training.wait_until_complete(timeout=...)` | Block until terminal phase (`succeeded` / `failed` / `cancelled`) |
+| `training.logs(tail=..., follow=...)` | Stream merged-rank logs |
+| `training.delete()` | Explicit teardown; `__exit__` runs this on scope exit |
+
+Every method has an `_async` counterpart (`training.scale_async(...)`,
+`async with training: ...`).
+
+### `bench=True` — the diagnostic for "is my code slow or is the network slow?"
+
+NCCL collective bandwidth varies with provider, region, GPU model, and current
+mesh load. Without a measurement, the user has to guess whether slow training
+is their code or the network.
+
+`bench=True` opts in to a 2-rank `all_reduce_perf` probe that runs alongside
+your workers on the same provider mesh with the same WireGuard transport. The
+result lands on `training.bench` after the UD reaches a terminal state:
+
+```python
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+@basilica.distributed(
+    name="dlc-with-bench",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    world_size=WorldSize(min=2, target=2, max=2),
+    gpu_count=1,
+    gpu_models=["A100"],
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",
+    bench=True,
+)
+def train() -> None:
+    import torch.distributed as dist
+
+    dist.init_process_group(backend="nccl")
+    dist.destroy_process_group()
+
+
+with train() as training:
+    training.wait_until_complete(timeout=1800)
+    if training.bench is not None:
+        print(f"busbw_gbps_p50:      {training.bench.busbw_gbps_p50}")
+        print(f"latency_us_at_1mib:  {training.bench.latency_us_at_1mib}")
+        print(
+            f"probe pair:          {training.bench.probe_node_a} "
+            f"<-> {training.bench.probe_node_b}"
+        )
+    else:
+        # No measurement -- workers too short, probe couldn't co-schedule, etc.
+        print(training.bench_diagnostics)
+```
+
+`None` means "no measurement" regardless of reason. `training.bench_diagnostics`
+exists for the rare case where you want to know WHY the probe didn't land a
+result. Default `bench=False` because the probe costs 2 extra GPU ranks for its
+duration — users who don't need the measurement shouldn't pay for it.
+
+### Running an external script
+
+The canonical input is a Callable (what the decorator captures). For an
+external `.py` file shipped in the trainer image, wrap it in a decorated
+function:
+
+```python
+import basilica
+from basilica import ProviderFilter, WorldSize
+
+
+@basilica.distributed(
+    name="dlc-script",
+    image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    world_size=WorldSize(min=2, target=2, max=2),
+    gpu_count=1,
+    gpu_models=["A100"],
+    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    topology_spread="pack",
+)
+def run_script() -> None:
+    import runpy
+
+    runpy.run_path("/workspace/my_training.py", run_name="__main__")
+```
+
+### Migration from the legacy surface
+
+If you have code on the prior SDK surface, both paths still work but emit
+`DeprecationWarning`. Migration table:
+
+| Legacy | Canonical | SDK version | Plan ticket |
+|--------|-----------|-------------|-------------|
+| `client.deploy_distributed(...)` | `@basilica.distributed(...)` on a function, call it | 0.29.5+ | S1 |
+| `client.deploy_distributed_managed(...)` | `with train() as training:` on the decorated function | 0.29.5+ | S1 |
+| `bench="on-start"` / `bench="off"` (str) | `bench=True` / `bench=False` (bool) | 0.29.5+ | S2 |
+| `training.bench_status` (property) | `training.bench` for the result, `training.bench_diagnostics` for debug | 0.29.5+ | S2 |
+| `training.wait_until_bench_complete(...)` | `training.wait_until_complete(...)` + read `training.bench` | 0.29.5+ | S2 |
+| `client.deploy_distributed_managed(command=[...])` | `basilica.distributed(command=[...])` factory | 0.29.6+ | S3 |
+| `source=Path("./train.py")` / `source="<inline code>"` | decorate a function (Callable shape) | 0.29.7+ | S4 |
+
+The decorator path silences the deprecation warnings — direct calls to
+`deploy_distributed*` warn, but the decorator passes `_emit_deprecation=False`
+internally so the canonical surface stays quiet.
+
+### Worked examples in this repo
+
+| Example | Pattern |
+|---------|---------|
+| `examples/20_distributed_diloco.py` | `@basilica.distributed` decorator + `bench=True` + DiLoCo (NCCL all-reduce in the outer step) |
+| `examples/21_distributed_torchrun.py` | `basilica.distributed(command=[torchrun ...])` factory + mid-run `scale()` |
+| `examples/22_distributed_with_bench.py` | `@basilica.distributed` decorator + bench-result inspection + JSON dump |
+
 ## API Reference
 
 ### BasilicaClient
@@ -470,25 +705,119 @@ class DeploymentStatus:
     def is_pending(self) -> bool # Check if still starting
 ```
 
+### Distributed Training Types
+
+The distributed-training surface lives in `basilica` (re-exported from
+`basilica.distributed`). The canonical entry point is the
+`@basilica.distributed` decorator; `basilica.distributed(command=[...])` is
+the factory shape for BYO launchers.
+
+```python
+@dataclass(frozen=True)
+class WorldSize:
+    """Worker-rank triple. `1 <= min <= target <= max`."""
+    min: int     # below this the run pauses (torchelastic MIN_NODES)
+    target: int  # steady-state replica count
+    max: int     # hard ceiling for scale()
+
+
+@dataclass(frozen=True)
+class ProviderFilter:
+    """Inclusive/exclusive cloud-provider filter for worker scheduling.
+
+    Match is against the `basilica.ai/provider` node label
+    (`hyperstack`, `verda`, `masscompute`, `shadeform`). With
+    `topology_spread="pack"`, the autoscaler picks ONE provider from the
+    include-list and all workers pack on it.
+    """
+    include: List[str] = []
+    exclude: List[str] = []
+
+
+@dataclass(frozen=True)
+class BenchResult:
+    """Per-UD NCCL probe measurement. Read via `training.bench`.
+
+    Bandwidth fields are GB/s (1 GB = 10^9 bytes); latency is at the
+    smallest swept message size. `None`-valued fields mean the probe
+    could not measure them (partial sweep).
+    """
+    measured_at: datetime
+    busbw_gbps_p10: Optional[float]
+    busbw_gbps_p50: Optional[float]
+    busbw_gbps_p90: Optional[float]
+    algbw_gbps_p50: Optional[float]
+    latency_us_at_1mib: Optional[float]
+    size_bytes_swept: List[int]
+    probe_node_a: str
+    probe_node_b: str
+
+
+class DistributedTraining:
+    """Handle returned by `@basilica.distributed` and `basilica.distributed(command=...)`.
+
+    Itself a context manager: `with train() as training:` blocks on the
+    decorator call, yields the handle, and best-effort `delete()`s on
+    scope exit (success OR exception).
+    """
+    name: str
+    namespace: str
+    rendezvous_endpoint: str
+
+    # observation (lazy refresh on first access)
+    world: WorldStatus
+    phase: str            # operator-driven phase
+    is_terminal: bool
+    ranks: List[RankStatus]
+    rank_exits: List[RankExit]
+    bench: Optional[BenchResult]
+    bench_diagnostics: Optional[Dict[str, Any]]
+
+    # lifecycle
+    def scale(target: int) -> WorldStatus: ...
+    def wait_until_min_world(timeout: int = 300) -> None: ...
+    def wait_until_target_world(timeout: int = 600) -> None: ...
+    def wait_until_complete(timeout: int = 1800) -> WorldStatus: ...
+    def logs(tail=None, follow=False, rank=None) -> str: ...
+    def delete() -> None: ...
+
+    # context manager
+    def __enter__(self) -> "DistributedTraining": ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+    # Every method has an `_async` counterpart.
+```
+
+`WorldStatus`, `RankStatus`, `RankExit`, `DistributedMetrics`, and the
+distributed-specific exceptions (`BelowMinimumWorld`, `WorldSizeOutOfBounds`,
+`RendezvousUnavailable`, `UDTerminalState`, `QuotaExceeded`, `DistributedError`)
+are exported from `basilica` directly.
+
 ## Exception Handling
 
 The SDK provides a comprehensive exception hierarchy:
 
 ```python
 from basilica import (
-    BasilicaError,        # Base exception
-    AuthenticationError,  # Invalid/missing token
-    AuthorizationError,   # Permission denied
-    ValidationError,      # Invalid parameters
-    DeploymentError,      # Base deployment error
-    DeploymentNotFound,   # Deployment doesn't exist
-    DeploymentTimeout,    # Timeout waiting for ready
-    DeploymentFailed,     # Deployment crashed
-    ResourceError,        # Resource unavailable
-    StorageError,         # Storage configuration error
-    NetworkError,         # API communication error
-    RateLimitError,       # Rate limit exceeded
-    SourceError,          # Source file error
+    BasilicaError,         # Base exception
+    AuthenticationError,   # Invalid/missing token
+    AuthorizationError,    # Permission denied
+    ValidationError,       # Invalid parameters
+    DeploymentError,       # Base deployment error
+    DeploymentNotFound,    # Deployment doesn't exist
+    DeploymentTimeout,     # Timeout waiting for ready
+    DeploymentFailed,      # Deployment crashed
+    ResourceError,         # Resource unavailable
+    StorageError,          # Storage configuration error
+    NetworkError,          # API communication error
+    RateLimitError,        # Rate limit exceeded
+    SourceError,           # Source file error
+    # Distributed-training specific:
+    DistributedError,      # Base distributed-training error
+    BelowMinimumWorld,     # `ready < min` (timeout or terminal failure)
+    WorldSizeOutOfBounds,  # WorldSize triple or scale() target invalid
+    RendezvousUnavailable, # etcd rendezvous service unreachable
+    UDTerminalState,       # UD is already terminal (e.g. scale on succeeded)
+    QuotaExceeded,         # Namespace rank budget exceeded
 )
 
 try:
@@ -603,6 +932,9 @@ For complete working examples, see the [examples directory](https://github.com/o
 | `12_lobe_chat.py` | Self-hosted chat UI |
 | `13_lobe_chat_vllm.py` | Full AI stack (LobeChat + vLLM) |
 | `14_streamlit.py` | Interactive Streamlit app |
+| `20_distributed_diloco.py` | `@basilica.distributed` + DiLoCo NCCL training |
+| `21_distributed_torchrun.py` | BYO `command=[torchrun ...]` factory + mid-run scale |
+| `22_distributed_with_bench.py` | `bench=True` + reading `training.bench` |
 | `34_gpu_flavour_preferences.py` | Query GPU offerings with flavour filters |
 | `35_deploy_with_flavour.py` | Deploy with interconnect, region, spot preferences |
 | `36_gpu_flavour_cli/` | CLI usage with flavour flags |

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -3,7 +3,7 @@ Basilica SDK for Python
 
 Deploy and manage containerized applications on the Basilica GPU cloud.
 
-Quick Start:
+HTTP services and one-shot containers:
     >>> from basilica import BasilicaClient
     >>> client = BasilicaClient()
     >>>
@@ -16,6 +16,42 @@ Quick Start:
     ...     name="hello",
     ...     source="print('Hello, World!')",
     ... )
+
+Distributed training (NCCL collectives -- DDP, DiLoCo, FSDP):
+    The canonical surface is the ``@basilica.distributed`` decorator. The
+    decorated function is the per-rank entrypoint; calling it returns a
+    ``DistributedTraining`` context-manager. The legacy
+    ``client.deploy_distributed_managed(...)`` factory emits a
+    ``DeprecationWarning`` -- see the SDK README's "Migration from the
+    legacy surface" table for the per-parameter mapping.
+
+    >>> import basilica
+    >>> from basilica import ProviderFilter, WorldSize
+    >>>
+    >>> @basilica.distributed(
+    ...     name="dlc-hello",
+    ...     image="ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest",
+    ...     world_size=WorldSize(min=2, target=2, max=2),
+    ...     gpu_count=1,
+    ...     gpu_models=["A100"],
+    ...     provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    ...     topology_spread="pack",
+    ...     bench=True,
+    ... )
+    ... def train():
+    ...     import os, torch
+    ...     import torch.distributed as dist
+    ...     dist.init_process_group(backend="nccl")
+    ...     # ... uses os.environ['RANK'] / ['WORLD_SIZE'] / ['LOCAL_RANK'] ...
+    ...     dist.destroy_process_group()
+    >>>
+    >>> with train() as training:                       # auto-cleanup on exit
+    ...     training.wait_until_complete(timeout=1800)
+    ...     print(training.bench)                       # BenchResult | None
+
+    For BYO launchers (torchrun / mpirun / accelerate), pass
+    ``command=[...]`` and ``basilica.distributed(...)`` short-circuits the
+    decorator path -- it returns a ``DistributedTraining`` directly.
 
 Authentication:
     Set the BASILICA_API_TOKEN environment variable:

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -548,50 +548,119 @@ def distributed(
        ``.deploy()`` semantics). See basilica-backend issue 662 / SDK-S3.
 
     Args:
-        name: Deployment name (DNS-safe).
-        image: Container image (default: pytorch + cuda runtime).
-        port: Worker container port.
-        cpu, memory, gpu_count, gpu_models, min_gpu_memory_gb: Resources
-            per rank pod.
-        world_size: WorldSize(min, target, max). REQUIRED.
-        provider_filter: ProviderFilter or `{"include": [...], "exclude": [...]}` dict.
-        topology_spread: One of `pack | provider-aware | region-aware | none`.
-        nccl_env: NCCL env vars merged on top of operator defaults.
-        bench: ``True`` to opt in to the per-UD NCCL bench probe; ``False``
-            (default) skips it. Reads back as ``training.bench``
-            (``BenchResult | None``) post-terminal. The legacy str modes
-            ``"on-start"`` / ``"off"`` remain accepted with
+        name: Deployment name. DNS-safe (lowercase, digits, hyphens). The
+            UD's K8s resources and the user-visible handle name both
+            derive from this; pick something that means something to you
+            later when you scan ``basilica deploy ls``.
+        image: Container image for every rank pod. Defaults to a pytorch
+            + CUDA runtime; for distributed NCCL workloads the
+            canonical base is
+            ``ghcr.io/one-covenant/basilica/basilica-distributed-trainer:latest``
+            because stock NGC pytorch images don't include
+            ``python-etcd`` (required by torchelastic's etcd-v2
+            rendezvous backend). See ``BRINGING-YOUR-OWN-TRAINER-IMAGE.md``
+            on basilica-backend for the BYO-image contract.
+        port: Worker container port. Default 18789 matches the operator's
+            headless governance Service; override only if your launcher
+            binds something else.
+        cpu, memory: Resource requests per rank pod. Sized for the
+            decorated function body's needs, not the training step's
+            compute (the GPU does the compute).
+        gpu_count: GPUs per rank pod (``1`` means 1 GPU per rank; set
+            higher for NVLink ranks). Aggregate fleet GPU count is
+            ``world_size.target * gpu_count``.
+        gpu_models: Acceptable GPU models. The autoscaler matches an
+            offering against this AND ``min_gpu_memory_gb``;
+            empty means "any model".
+        min_gpu_memory_gb: Minimum GPU VRAM in GB. Use this to fall back
+            across multiple GPU SKUs (e.g. accept A100-40GB OR H100-80GB
+            on a 30GB workload).
+        world_size: ``WorldSize(min, target, max)``. REQUIRED. ``min`` is
+            the floor below which the run pauses (torchelastic
+            MIN_NODES); ``target`` is the steady-state replica count;
+            ``max`` is the hard ceiling enforced by ``scale()``. The SDK
+            short-circuits on ``WorldSize(...)``-construction if the
+            triple violates ``1 <= min <= target <= max``.
+        provider_filter: ``ProviderFilter(include=[...], exclude=[...])``
+            or the dict equivalent. With ``topology_spread="pack"``, the
+            autoscaler picks ONE provider from ``include`` (cheapest
+            available with capacity, or via your platform's
+            ``secureCloud.preferredProvider``) and packs all workers on
+            it; the include-list is a fallback set, not a multi-provider
+            requirement. Mesh-enabled providers today: ``verda``,
+            ``hyperstack``.
+        topology_spread: One of ``pack | provider-aware | region-aware |
+            none``. ``"pack"`` is recommended for NCCL-collective
+            workloads -- it forces same-provider direct WireGuard mesh,
+            which is 5-10x faster than the hub-relay fallback. Default
+            ``"provider-aware"``.
+        nccl_env: NCCL environment variables merged on top of operator
+            defaults. User values win on collision. Common pattern:
+            ``{"NCCL_DEBUG": "WARN"}`` to surface NCCL diagnostics
+            without flooding logs.
+        bench: ``True`` opts in to the per-UD NCCL bench probe -- a
+            2-rank ``all_reduce_perf`` measurement on the same provider
+            mesh as your workers. Read back as ``training.bench``
+            (``BenchResult | None`` -- ``None`` means "no measurement",
+            regardless of why). Use ``training.bench_diagnostics`` for
+            the rare debug detail. Default ``False`` because the probe
+            costs 2 extra GPU ranks for its duration; users who don't
+            need the measurement shouldn't pay for it. The legacy str
+            modes ``"on-start"`` / ``"off"`` remain accepted with
             ``DeprecationWarning``; removed in the next major. See
-            ``basilica-backend#661`` / SDK-S2.
-        rendezvous_backend: `etcd-v2` (default) | `c10d` | `static`.
-        env: Environment variables passed to the worker pods.
-        pip_packages: Additional pip packages to install.
-        ttl_seconds: Auto-delete after N seconds.
-        timeout: Seconds to wait for `min` ranks to be ready. Default 600.
-        enable_billing: Whether to bill for this deployment.
-        wait_for_bench: `"never"` (default) returns when workers Ready;
-            `"best_effort"` also waits for bench, swallowing failures;
-            `"required"` raises if bench is non-Succeeded. See
-            `BasilicaClient.deploy_distributed`.
-        bench_timeout: Seconds budget for the opt-in bench wait.
-        command: BYO-launcher entry. When set, the call returns a
-            :class:`DistributedTraining` immediately (factory mode) and
-            the operator does NOT wrap with torchrun. Mutually exclusive
-            with the decorator shape -- supplying ``command`` AND
-            subsequently decorating a function is a usage error caught at
-            decoration time. See basilica-backend issue 662 / SDK-S3.
-        args: Args to pass to ``command`` when in factory mode. Ignored
-            unless ``command`` is set.
-        client: Optional :class:`BasilicaClient` used in factory mode.
-            Ignored in decorator mode (the decorator's ``.deploy(client=)``
-            takes precedence). When ``command`` is set and ``client`` is
-            None, a default ``BasilicaClient()`` is constructed lazily.
+            ``basilica-backend`` issue 661 / SDK-S2.
+        rendezvous_backend: ``etcd-v2`` (default) | ``c10d`` | ``static``.
+            Default ``etcd-v2`` is the only backend with full
+            elasticity (mid-run scale, rank join/drain). Pick a
+            non-default only if you know you need it.
+        env: Environment variables passed to the worker pods. The
+            operator wires ``RANK`` / ``WORLD_SIZE`` / ``LOCAL_RANK`` /
+            ``MASTER_*`` / ``BASILICA_*`` automatically -- this
+            parameter is for YOUR app's vars.
+        pip_packages: Additional pip packages to install. Ignored when
+            ``command`` is set (BYO image is expected to carry its own
+            dependencies).
+        ttl_seconds: Auto-delete after N seconds even if the workload is
+            still running. Platform-side ceiling; set this for runaway
+            protection.
+        timeout: Seconds to wait for ``world_size.min`` ranks to be
+            ready before returning from the deploy call. Default 600.
+        enable_billing: Whether to bill for this deployment. Default
+            ``True``.
+        wait_for_bench: ``"never"`` (default) returns when workers
+            Ready; the bench probe runs in the background and shows up
+            on ``training.bench`` once the UD reaches a terminal state.
+            ``"best_effort"`` waits for bench but swallows failures.
+            ``"required"`` raises on a non-Succeeded bench terminal
+            phase. Most users keep the default and read
+            ``training.bench`` after ``wait_until_complete``.
+        bench_timeout: Seconds budget for the
+            ``wait_for_bench != "never"`` paths. Default 1500 (matches
+            the operator's ``BENCH_ACTIVE_DEADLINE_SECONDS``).
+        command: BYO-launcher entry. Setting this short-circuits the
+            decorator path -- the call returns a
+            :class:`DistributedTraining` immediately (factory mode).
+            Mutually exclusive with the decorator shape. Inside the
+            launcher, expand ``$BASILICA_RDZV_ENDPOINT`` /
+            ``$BASILICA_WORLD_TARGET`` / ``$BASILICA_GPUS_PER_POD`` --
+            the operator injects these into the worker pod environment.
+            See basilica-backend issue 662 / SDK-S3.
+        args: Positional args to pass after ``command`` in factory mode.
+            Ignored unless ``command`` is set.
+        client: Optional :class:`BasilicaClient` for factory mode.
+            Ignored in decorator mode (the decorator's
+            ``.deploy(client=)`` takes precedence). When ``command`` is
+            set and ``client`` is None, a default ``BasilicaClient()``
+            is constructed lazily.
 
     Returns:
         - Decorator mode (``command`` is None): a decorator closure that
           wraps the decorated function in a :class:`DistributedFunction`.
-        - Factory mode (``command`` is set): a :class:`DistributedTraining`
-          ready to use under a ``with`` block.
+          Calling the wrapped function deploys and returns a
+          :class:`DistributedTraining` context-manager.
+        - Factory mode (``command`` is set): a
+          :class:`DistributedTraining` ready to use under a ``with``
+          block.
     """
     if world_size is None:
         raise ValueError("@distributed requires world_size")

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -1,15 +1,54 @@
 """
 Distributed-training SDK surface (SDK arch § 4 / § 6 / § 8 / § 9).
 
-User-facing types and the `DistributedTraining` facade returned by
-`client.deploy_distributed(...)` and `@basilica.distributed`. Researchers
-import these from `basilica` directly (re-exported in __init__.py).
+User-facing types and the ``DistributedTraining`` facade. Re-exported
+from ``basilica`` directly; researchers import via ``from basilica
+import ProviderFilter, WorldSize, BenchResult, DistributedTraining``.
+
+Canonical surface (post-S1/S2/S3/S4 simplification):
+
+- ``@basilica.distributed(...)`` on a function -- the function body is
+  the per-rank entrypoint. Calling the decorated function returns a
+  ``DistributedTraining`` context-manager. This is the canonical input
+  shape for "the code workers should run".
+- ``basilica.distributed(command=[...])`` factory -- BYO launcher
+  (torchrun / mpirun / accelerate). The same ``basilica.distributed``
+  symbol short-circuits the decorator path when ``command`` is set and
+  returns a ``DistributedTraining`` directly.
+- ``with training:`` / ``async with training:`` -- the
+  ``DistributedTraining`` is itself a context manager. ``__exit__``
+  best-effort calls ``.delete()`` on scope exit (success OR exception),
+  so the UD does not leak when a mid-run wait raises.
+- ``bench: bool`` -- ``True`` opts in to the per-UD NCCL probe;
+  ``False`` (default) skips it. Read back as ``training.bench``
+  (``BenchResult | None``). Use ``training.bench_diagnostics`` only when
+  you need debug detail for a ``None`` result.
+
+Legacy surface (deprecated, still functional for two minor versions):
+
+- ``client.deploy_distributed(...)`` and
+  ``client.deploy_distributed_managed(...)`` -- both emit
+  ``DeprecationWarning`` on direct calls. The decorator path itself
+  stays silent (it passes ``_emit_deprecation=False`` internally).
+- ``source: Union[str, Path]`` on the legacy ``deploy_distributed``
+  call -- ``Callable`` (via decorator) is canonical; ``str`` and
+  ``Path`` shapes emit ``DeprecationWarning``.
+- ``bench: str`` modes (``"on-start"`` / ``"off"``),
+  ``training.bench_status``, ``training.wait_until_bench_complete()`` --
+  all emit ``DeprecationWarning`` and are collapsed into ``bench: bool``
+  + ``training.bench`` + ``training.bench_diagnostics``.
+- ``DistributedTrainingManaged[Async]`` -- the wrapper that this
+  ``DistributedTraining`` class now subsumes. Kept as a back-compat
+  shim for callers with type annotations against it.
 
 Tenancy invariant (SDK arch § 7): bench data is per-UD. There is NO
-`client.preflight(...)` and NO `client.nccl_baseline(...)` standalone
+``client.preflight(...)`` and NO ``client.nccl_baseline(...)`` standalone
 helper -- those would imply a shared cluster-wide cache, which violates
 the platform's tenancy contract. Bench results live on
-`DistributedTraining.bench` and are owned by the user's namespace.
+``DistributedTraining.bench`` and are owned by the user's namespace.
+
+See the SDK README's "Distributed Training" section for the full
+canonical surface and the legacy-to-canonical migration table.
 """
 
 import asyncio

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,21 @@ Using `@basilica.deployment` decorator:
 | `05_decorator_fastapi.py` | FastAPI + uvicorn | `python3 05_decorator_fastapi.py` |
 | `05_decorator_gpu.py` | GPU decorator | `python3 05_decorator_gpu.py` |
 
+## Distributed Training Examples (20-22)
+
+Multi-rank PyTorch with NCCL collectives via `@basilica.distributed`. The
+decorator wraps the per-rank entrypoint; calling it returns a
+`DistributedTraining` context manager. For BYO launchers (torchrun /
+mpirun / accelerate), pass `command=[...]` and the same
+`basilica.distributed` symbol becomes a factory that returns the
+`DistributedTraining` directly.
+
+| Example | Description | Run |
+|---------|-------------|-----|
+| `20_distributed_diloco.py` | DiLoCo training with `@basilica.distributed` + `bench=True` | `python3 20_distributed_diloco.py` |
+| `21_distributed_torchrun.py` | BYO `command=[torchrun ...]` factory + mid-run `scale()` | `python3 21_distributed_torchrun.py` |
+| `22_distributed_with_bench.py` | Bench-result inspection + JSON dump for offline aggregation | `python3 22_distributed_with_bench.py` |
+
 ## Advanced Examples (06-23)
 
 | Example | Description | Run |


### PR DESCRIPTION
## Summary

Documentation-only rewrite for SDK-S6 of the SDK API simplification plan.
The plan lives on `basilica-backend` at
`docs/plans/SDK-API-SIMPLIFICATION-PLAN.md` and the prior S1-S5 code
work has already merged here (PRs #483 / #484 / #485 / #486 / #487 /
#488). This PR makes the SDK's user-facing docs match the canonical
surface those PRs delivered.

What changes:

- `crates/basilica-sdk-python/README.md`: adds a "Distributed Training
  (NCCL collectives)" section covering the canonical decorator,
  the BYO `command=` factory shape, the `DistributedTraining` lifecycle
  table, the `bench=True` diagnostic with the WHY (is my code slow or
  is the network slow), the `runpy.run_path(...)` escape hatch for
  external scripts, and a legacy-to-canonical migration table. Adds a
  "Distributed Training Types" subsection to the API Reference
  (`WorldSize` / `ProviderFilter` / `BenchResult` / `DistributedTraining`).
  Lists examples 20 / 21 / 22. Adds the six distributed-specific
  exceptions to the exception list.
- `python/basilica/__init__.py`: module docstring now documents the
  distributed surface alongside the existing `client.deploy(...)`
  quickstart.
- `python/basilica/distributed.py`: module docstring lists the canonical
  surface and the legacy (still functional, deprecated) surface
  explicitly.
- `python/basilica/decorators.py`: every parameter on
  `basilica.distributed(...)` now has a WHY explanation, not just a
  type description (per the issue 665 acceptance criterion). The image
  default points at the canonical basilica-distributed-trainer image
  and explains why stock NGC pytorch is incomplete (missing
  `python-etcd`). `topology_spread` explains why `pack` matters for
  NCCL throughput. `bench` explains the diagnostic + default-False
  rationale. `provider_filter` clarifies fallback-set vs multi-provider.
- `AGENTS.md`: adds a "Distributed Training" section to the agent
  guidance with canonical code samples + a DO-NOT list of deprecated
  surfaces. Adds the distributed routing entry and the
  distributed-specific module-source pointers.
- `examples/README.md`: adds a "Distributed Training Examples (20-22)"
  section pointing at the migrated examples 20 / 21 / 22.

What this PR does NOT do:

- No version bump. S6 is docs-only; SDK stays at `0.29.7`.
- No source-code changes beyond the four docstring rewrites.
- No new examples; 20 / 21 / 22 are already on main from S5 (PR #488).

## Test plan

- [x] Snippet validation: every ` ```python ` block in README.md /
  AGENTS.md / examples/README.md plus every `>>>` doctest in the SDK
  module docstrings extracted to scratch files. `ast.parse` passes on
  all 66 new blocks (3 pre-existing API Reference signature-spec
  blocks remain non-runnable as before; unchanged by S6).
- [x] DeprecationWarning probe: all 8 distributed-surface snippets I
  added emit ZERO `basilica.DeprecationWarning` during decorator
  application / factory instantiation. Evidence:
  `basilica-backend:data/evidence/sdk-simpl-665/03-snippet-validation.txt`.
- [x] `pytest crates/basilica-sdk-python/tests/`: 211 tests pass (one
  test file requires the `httpx` extra not in the dev env; skipped).
  Evidence: `basilica-backend:data/evidence/sdk-simpl-665/03-tests.txt`.
- [x] `cargo fmt --all -- --check`: PASS.
- [x] `cargo clippy -p basilica-sdk-python -- -D warnings`: PASS.
- [x] Optional `ruff check` on the 3 modified `.py` files: 37 findings
  vs 38 on the pre-S6 baseline -- S6 introduces zero new lint findings.
- [ ] Post-merge runtime probe of every README snippet against the
  merged main branch (done in the evidence bundle on basilica-backend).

## Cross-references (already merged on this repo)

- PR #483 -- bench: bool surface (refs basilica-backend issue 661, S2)
- PR #484 -- DistributedTraining context manager + deprecate
  deploy_distributed_managed (refs basilica-backend issue 660, S1)
- PR #485 -- filter bench-related deprecations in S2 tests
- PR #486 -- basilica.distributed(command=...) factory shape
  (refs basilica-backend issue 662, S3)
- PR #487 -- deprecate source: Union[str, Path]
  (refs basilica-backend issue 663, S4)
- PR #488 -- migrate examples 20/21/22 to canonical surface
  (refs basilica-backend issue 664, S5)

Fixes one-covenant/basilica-backend#665