### PR TITLE
fix(sdk): inject rdzv last_call_timeout to cover autoscaler provisioning windows (refs basilica-backend#419)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -278,10 +278,31 @@ def _shell_join_preserving_vars(command: List[str]) -> str:
     return " ".join(parts)
 
 
-# refs basilica-backend#419: rendezvous timeout default (~600 s) is too short
-# for image-pull skew between a warm node and a freshly-provisioned node;
-# 1500 s (25 min) is the same knob the operator's auto-path injects.
-_RDZV_TIMEOUT_INJECT = "--rdzv-conf=timeout=1500"
+# refs basilica-backend#419: torchelastic rendezvous defaults are too short
+# for autoscaler-driven distributed UDs.
+#
+# `timeout=1500` (25 min) — total `next_rendezvous()` budget. Default ~600 s
+# is consumed by image-pull skew between a warm node and a freshly-
+# provisioned node.
+#
+# `last_call_timeout=900` (15 min) — extra wait AFTER min-workers have
+# joined, before the rendezvous is finalised and `status` flips to
+# `closed`. Default is 30 s
+# (torch.distributed.elastic.rendezvous.etcd_rendezvous._DEFAULT_LAST_CALL_TIMEOUT).
+# ex20 take 6 surfaced the gap: workers 0/1 came up in ~30 s on the warm
+# verda node and triggered the 30 s last-call window. The autoscaler was
+# still provisioning the second verda node for workers 2/3 (minutes), so
+# the rendezvous transitioned to `status: closed` with `participants: [0, 1]`
+# before ranks 2/3 arrived. Late ranks then hit RendezvousClosedError.
+# 900 s leaves headroom over typical autoscaler scale-up windows (1-5 min
+# observed) while staying well under the 1500 s total budget.
+#
+# torchrun's `--rdzv-conf` is a SINGLE arg (not action="append" —
+# torch/distributed/run.py:443-450); the LAST `--rdzv-conf=` on the
+# command line wins. So both knobs must be packed into one
+# comma-separated value (parsed by
+# torch.distributed.elastic.rendezvous.utils._parse_rendezvous_config).
+_RDZV_TIMEOUT_INJECT = "--rdzv-conf=timeout=1500,last_call_timeout=900"
 
 
 def _apply_rdzv_workarounds(command: str) -> str:
@@ -298,13 +319,27 @@ def _apply_rdzv_workarounds(command: str) -> str:
        works against the same etcd Pod. Operator-side equivalent:
        ``RendezvousBackend::EtcdV2 -> "etcd"`` in operator distributed.rs.
 
-    2. inject ``--rdzv-conf=timeout=1500`` if no ``--rdzv-conf=`` is
-       already present (refs basilica-backend#419). The torchelastic
-       default ~600 s closes rendezvous before rank-N joins when one
-       node is warm and another is freshly provisioned (image pull
-       ~10-20 min). Same knob the operator injects on the auto-path.
+    2. inject ``--rdzv-conf=timeout=1500,last_call_timeout=900`` if no
+       ``--rdzv-conf=`` is already present (refs basilica-backend#419).
+       Two distinct knobs in one flag (torchrun's ``--rdzv-conf`` is a
+       single arg, comma-separated keys):
+
+       - ``timeout=1500``: total ``next_rendezvous()`` budget. Default
+         ~600 s is too short for image-pull skew between a warm node
+         and a freshly-provisioned node (~10-20 min).
+       - ``last_call_timeout=900``: extra wait after MIN workers have
+         joined, before rendezvous is finalised (status=closed). The
+         torchelastic default of 30 s
+         (etcd_rendezvous._DEFAULT_LAST_CALL_TIMEOUT) is shorter than
+         the autoscaler's node-provisioning window. ex20 take 6 caught
+         this: ranks 0/1 came up on a warm verda node, formed
+         rendezvous, and the 30 s window expired before the autoscaler
+         finished bringing up the second verda node for ranks 2/3.
+         Rendezvous closed with participants=[0, 1] and ranks 2/3 hit
+         RendezvousClosedError on arrival.
+
        Preserves a user-supplied ``--rdzv-conf=`` verbatim so users
-       can opt into a different timeout / extra knobs.
+       can opt into different timeouts / extra knobs.
 
     Non-torchrun commands pass through verbatim -- the workarounds are
     only meaningful for the torchrun rendezvous handler.
@@ -1504,14 +1539,21 @@ class BasilicaClient:
                 if rendezvous_backend == "etcd-v2"
                 else rendezvous_backend
             )
-            # refs basilica-backend#419: torchelastic's rendezvous handlers
-            # default to ~600 s join timeout. Image-pull skew between a
-            # warm node and a freshly-provisioned node easily exceeds that,
-            # closing rendezvous before rank-N joins (RendezvousClosedError
-            # on rank-0). Bump to 1500 s (25 min) so cold-start pulls
-            # finish before the rendezvous window closes. Same knob the
-            # operator's auto-path injects; SDK is on the BYO path so the
-            # operator workaround does not reach this command.
+            # refs basilica-backend#419: two rendezvous knobs, both too
+            # short by default for autoscaler-driven distributed UDs.
+            #   - `timeout=1500` (25 min) covers image-pull skew between
+            #     a warm node and a freshly-provisioned node (default
+            #     ~600 s closes rendezvous before rank-N joins).
+            #   - `last_call_timeout=900` (15 min) covers the autoscaler's
+            #     node-provisioning window. Default 30 s
+            #     (etcd_rendezvous._DEFAULT_LAST_CALL_TIMEOUT) finalises
+            #     the rendezvous as soon as MIN ranks join — ex20 take 6
+            #     surfaced this when ranks 0/1 came up on the warm verda
+            #     node and the autoscaler was still bringing up the
+            #     second verda node for ranks 2/3 (minutes).
+            # `--rdzv-conf` is a single torchrun arg (last one wins);
+            # both keys go in one comma-separated value (see
+            # _RDZV_TIMEOUT_INJECT).
             # /tmp/ used because /workspace/ in pytorch base images is
             # root-owned and pods run as uid=1000 (operator
             # distributed.rs build_security_contexts: runAsUser=1000,
@@ -1524,7 +1566,7 @@ class BasilicaClient:
                 f"--rdzv-backend={backend_token} "
                 f"--rdzv-endpoint=\"$BASILICA_RDZV_ENDPOINT\" "
                 f"--rdzv-id=\"$BASILICA_RDZV_ID\" "
-                f"--rdzv-conf=timeout=1500 "
+                f"--rdzv-conf=timeout=1500,last_call_timeout=900 "
                 f"--nnodes=\"$BASILICA_WORLD_MIN\":\"$BASILICA_WORLD_MAX\" "
                 f"--nproc-per-node=\"$BASILICA_GPUS_PER_POD\" "
                 f"--max-restarts=10 "
@@ -1540,8 +1582,11 @@ class BasilicaClient:
             # user-supplied torchrun invocation gets the same
             # cold-start-safe defaults.
             #   1. etcd-v2 -> etcd (torch DynamicRendezvousHandler bug, #368)
-            #   2. inject --rdzv-conf=timeout=1500 if absent (long-enough
-            #      window for warm/cold node image-pull skew, #419)
+            #   2. inject --rdzv-conf=timeout=1500,last_call_timeout=900
+            #      if absent: 1500 s total budget for warm/cold image-pull
+            #      skew + 900 s last-call so the rendezvous does not
+            #      finalise before late ranks arrive from the autoscaler
+            #      (default last_call_timeout=30 s, #419)
             distributed_command = _apply_rdzv_workarounds(distributed_command)
         else:
             raise ValidationError(

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -1155,6 +1155,187 @@ class TestBuildDistributedRequest:
             f"(refs basilica-backend#419). command: {cmd!r}"
         )
 
+    # -------------------------------------------------------------------------
+    # refs basilica-backend#419: last_call_timeout coverage for autoscaler
+    # provisioning windows.
+    #
+    # PR #492 set `--rdzv-conf=timeout=1500` (total rendezvous budget) but
+    # left `last_call_timeout` at the torchelastic default of 30 s
+    # (etcd_rendezvous._DEFAULT_LAST_CALL_TIMEOUT). ex20 take 6 surfaced
+    # the gap: ranks 0/1 came up on the warm verda node, formed
+    # rendezvous, and the 30 s last-call window expired while the
+    # autoscaler was still provisioning the second verda node for ranks
+    # 2/3. The rendezvous finalised with `participants=[0, 1]`, ranks 2/3
+    # raised RendezvousClosedError on arrival.
+    #
+    # Fix: pack both knobs into the single `--rdzv-conf=` value (torchrun
+    # parses it via `,`-split; multiple `--rdzv-conf=` flags do NOT stack,
+    # the last one wins).
+    # -------------------------------------------------------------------------
+
+    def test_distributed_launcher_injects_last_call_timeout(self) -> None:
+        # Load-bearing: any BYO torchrun launcher without an explicit
+        # `--rdzv-conf=` MUST have `last_call_timeout=900` injected
+        # alongside the existing `timeout=1500`. Without it, the default
+        # 30 s last-call window closes the rendezvous before late ranks
+        # arrive from the autoscaler.
+        client = self._client()
+        req = self._build_with_command(
+            client,
+            [
+                "torchrun",
+                "--rdzv-backend=etcd",
+                "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+                "--rdzv-id=$BASILICA_RDZV_ID",
+                "--nnodes=$BASILICA_WORLD_MIN:$BASILICA_WORLD_MAX",
+                "--nproc-per-node=$BASILICA_GPUS_PER_POD",
+                "--max-restarts=10",
+                "/workspace/train.py",
+            ],
+        )
+        cmd = req["distributed"]["command"]
+        assert "last_call_timeout=900" in cmd, (
+            f"BYO launcher must have last_call_timeout=900 injected to "
+            f"survive autoscaler scale-up windows. Without it, the "
+            f"torchelastic default 30 s closes the rendezvous as soon "
+            f"as MIN ranks join (refs basilica-backend#419). "
+            f"command: {cmd!r}"
+        )
+        # The two knobs must live in a SINGLE --rdzv-conf= flag because
+        # torchrun's argparse does not stack (--rdzv-conf is not
+        # action="append"; see torch/distributed/run.py:443-450). Lock
+        # this in: there must be exactly one --rdzv-conf= occurrence
+        # and it must contain both keys.
+        assert cmd.count("--rdzv-conf=") == 1, (
+            f"multiple --rdzv-conf= flags would cause torchrun to "
+            f"keep only the last one. command: {cmd!r}"
+        )
+        assert "--rdzv-conf=timeout=1500,last_call_timeout=900" in cmd, (
+            f"both knobs must live in one comma-separated --rdzv-conf= "
+            f"value. command: {cmd!r}"
+        )
+
+    def test_distributed_launcher_preserves_existing_last_call_timeout(
+        self,
+    ) -> None:
+        # If the user already passed `--rdzv-conf=...` (any value, with
+        # or without last_call_timeout), the injection MUST NOT clobber
+        # it. Same preservation contract as the `timeout=` knob.
+        client = self._client()
+        req = self._build_with_command(
+            client,
+            [
+                "torchrun",
+                "--rdzv-backend=etcd",
+                "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+                "--rdzv-id=$BASILICA_RDZV_ID",
+                "--rdzv-conf=timeout=600,last_call_timeout=120",
+                "--nnodes=$BASILICA_WORLD_MIN:$BASILICA_WORLD_MAX",
+                "/workspace/train.py",
+            ],
+        )
+        cmd = req["distributed"]["command"]
+        # Positive: user-supplied value stays.
+        assert "--rdzv-conf=timeout=600,last_call_timeout=120" in cmd
+        # Negative: default 900 was NOT additionally appended.
+        assert "last_call_timeout=900" not in cmd, (
+            f"user-supplied last_call_timeout must not be overwritten by "
+            f"the default 900. command: {cmd!r}"
+        )
+        # And no second --rdzv-conf= was appended either.
+        assert cmd.count("--rdzv-conf=") == 1, (
+            f"a second --rdzv-conf= flag was appended; torchrun would "
+            f"discard the user's value. command: {cmd!r}"
+        )
+
+    def test_rdzv_conf_combined_format_parses(self) -> None:
+        # The combined `--rdzv-conf=key1=v1,key2=v2` form must split
+        # back into the expected key/value map.
+        #
+        # Parsing semantics replicated from
+        # torch.distributed.elastic.rendezvous.utils._parse_rendezvous_config
+        # (`,`-separated, then `=`-split with key.strip()/value.strip()).
+        # Replicated inline instead of importing torch so this test
+        # works in the SDK's CI venv (torch is not a basilica-sdk dep).
+        # This guards against accidentally regressing to two
+        # `--rdzv-conf=` flags or a malformed combined value.
+        def _parse_rdzv_conf(value: str) -> Dict[str, str]:
+            out: Dict[str, str] = {}
+            for kv in value.split(","):
+                k, _, v = kv.partition("=")
+                out[k.strip()] = v.strip()
+            return out
+
+        client = self._client()
+        req = self._build_with_command(
+            client,
+            [
+                "torchrun",
+                "--rdzv-backend=etcd",
+                "--rdzv-endpoint=$BASILICA_RDZV_ENDPOINT",
+                "--rdzv-id=$BASILICA_RDZV_ID",
+                "--nnodes=$BASILICA_WORLD_MIN:$BASILICA_WORLD_MAX",
+                "/workspace/train.py",
+            ],
+        )
+        cmd = req["distributed"]["command"]
+        # Pull the value after `--rdzv-conf=` up to the next whitespace.
+        marker = "--rdzv-conf="
+        idx = cmd.index(marker) + len(marker)
+        end = cmd.find(" ", idx)
+        rdzv_conf_value = cmd[idx:] if end == -1 else cmd[idx:end]
+        parsed = _parse_rdzv_conf(rdzv_conf_value)
+        assert parsed == {"timeout": "1500", "last_call_timeout": "900"}, (
+            f"combined --rdzv-conf= value did not split to both keys. "
+            f"value={rdzv_conf_value!r} parsed={parsed!r}"
+        )
+
+    def test_distributed_source_path_injects_last_call_timeout(self) -> None:
+        # Source-shipping path must also inject `last_call_timeout=900`
+        # alongside `timeout=1500` -- ex20 take 6 reproduces on the
+        # decorated-function path too (the launcher is built in
+        # `_build_distributed_request` source branch, not via
+        # `_apply_rdzv_workarounds`).
+        client = self._client()
+
+        def _train() -> None:
+            print("rank-up")
+
+        req = client._build_distributed_request(
+            name="dlc-419-last-call",
+            source=_train,
+            image="pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime",
+            port=18789,
+            env=None,
+            cpu="1",
+            memory="1Gi",
+            gpu_count=1,
+            gpu_models=None,
+            min_gpu_memory_gb=None,
+            world_size=WorldSize(min=2, target=4, max=4),
+            provider_filter=None,
+            topology_spread="provider-aware",
+            nccl_env=None,
+            bench="off",
+            rendezvous_backend="etcd-v2",
+            command=None,
+            args=None,
+            pip_packages=None,
+            ttl_seconds=None,
+            enable_billing=True,
+        )
+        cmd = req["distributed"]["command"]
+        assert "--rdzv-conf=timeout=1500,last_call_timeout=900" in cmd, (
+            f"source-path launcher must pack both rdzv timeouts into "
+            f"one --rdzv-conf= value (refs basilica-backend#419). "
+            f"command: {cmd!r}"
+        )
+        # Single occurrence: source-shipping path emits the flag once.
+        assert cmd.count("--rdzv-conf=") == 1, (
+            f"source-path launcher emitted multiple --rdzv-conf= flags; "
+            f"torchrun would keep only the last one. command: {cmd!r}"
+        )
+
     def test_distributed_launcher_non_torchrun_command_passthrough(self) -> None:
         # Non-torchrun BYO commands (e.g. a custom launcher script,
         # plain `python ...`) must not have torchrun-specific flags


### PR DESCRIPTION
## Why

PR #492 set `--rdzv-conf=timeout=1500` to cover the total rendezvous window against warm/cold image-pull skew. ex20 take 6 surfaced a **separate** torchelastic knob that was still at its 30 s default: `last_call_timeout`.

`last_call_timeout` is the additional wait AFTER min-workers have joined, before the rendezvous is finalised and `status` flips to `closed` (`torch.distributed.elastic.rendezvous.etcd_rendezvous._DEFAULT_LAST_CALL_TIMEOUT = 30`).

With autoscaler-driven scale-up, workers 0/1 came up in ~30 s on a warm verda node while workers 2/3 were still pending provisioning of a second verda node (minutes). The 30 s last-call window expired with `participants=[0, 1]`, the rendezvous transitioned to `status: closed`, and ranks 2/3 hit `RendezvousClosedError` on arrival.

Evidence (private repo): `data/evidence/final-ex20-take6-20260522T0023Z/worker-logs/worker-{0,1}.log` — both workers log:

```
Observed existing rendezvous state: {'status': 'closed', 'version': '1', 'participants': [0, 1], ... 'num_workers_waiting': 0}
Rendezvous for run_id=... was observed to be closed
torch.distributed.elastic.rendezvous.api.RendezvousClosedError
```

## What

Pack both knobs into a SINGLE `--rdzv-conf=` value. torchrun's `--rdzv-conf` is a non-`append` argparse arg (see `torch/distributed/run.py:443-450`) — multiple `--rdzv-conf=` flags do NOT stack, the last one wins. So both keys must go in one comma-separated value, which `_parse_rendezvous_config` (`torch/distributed/elastic/rendezvous/utils.py:22-57`) splits on `,` then `=`.

New injection: `--rdzv-conf=timeout=1500,last_call_timeout=900`.

`last_call_timeout=900` (15 min) gives plenty of headroom for typical autoscaler scale-up windows (~1-5 min observed) while staying well under the `timeout=1500` total budget.

Changes (~50 LoC source + ~180 LoC tests):
- `crates/basilica-sdk-python/python/basilica/__init__.py`
  - `_RDZV_TIMEOUT_INJECT` constant: extend to combined form
  - source-shipping path (Callable `source`): bake combined `--rdzv-conf=timeout=1500,last_call_timeout=900` into the torchrun command
  - `_apply_rdzv_workarounds` (BYO path): existing preserve-user-supplied-`--rdzv-conf=` contract unchanged
- `crates/basilica-sdk-python/tests/test_distributed.py`
  - 4 new tests under `TestBuildDistributedRequest`

## Test plan

- [x] `cargo` not applicable (Python-only crate). `pytest tests/test_distributed.py -q` -> 95 passed (91 existing + 4 new).
- [x] `pytest tests/ --ignore=tests/test_dns_propagation_e2e.py -q` -> 178 passed.
- [x] Load-bearing test: `test_distributed_launcher_injects_last_call_timeout` asserts BYO launcher contains `last_call_timeout=900` AND exactly one `--rdzv-conf=` flag AND the combined value `--rdzv-conf=timeout=1500,last_call_timeout=900`.
- [x] Preservation test: `test_distributed_launcher_preserves_existing_last_call_timeout` confirms user-supplied `--rdzv-conf=` not clobbered.
- [x] Format test: `test_rdzv_conf_combined_format_parses` replicates torchelastic's parser semantics inline (avoids torch as SDK test dep) and asserts both keys deserialise correctly.
- [x] Source path test: `test_distributed_source_path_injects_last_call_timeout` asserts the decorator-driven launcher also injects the combined form.

## Out of scope

- Operator's auto-path (`basilica-private` `crates/basilica-operator/src/controllers/distributed.rs` `build_worker_command`) carries the same `--rdzv-conf=timeout=1500` literal without `last_call_timeout=` — same bug class, separate repo, separate PR. Tracked verbally; not fixed here because Option A in the task plan is SDK-only.
- Issue 13 (bench Pod provider pin) — separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded distributed torchrun rendezvous timeout configuration to include `last_call_timeout` settings alongside `timeout`, improving distributed training stability across both bring-your-own and source-shipping execution paths.

* **Tests**
  * Added comprehensive test coverage for rendezvous timeout configuration behavior across distributed training scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->