### PR TITLE
release: basilica-cli + basilica-sdk + basilica-sdk-python at v0.30.1 (refs basilica-backend#419)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basilica-cli"
-version = "0.29.0"
+version = "0.30.1"
 dependencies = [
  "assert_cmd",
  "axum 0.7.9",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.29.0"
+version = "0.30.1"
 dependencies = [
  "base64 0.21.7",
  "basilica-common",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-05-22
+
 ### Added
 - Non-interactive mode for agent and CI usage. Auto-detected when stdin
   is not a TTY, or forced with `BASILICA_NON_INTERACTIVE=1`. In this

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-cli"
-version = "0.29.0"
+version = "0.30.1"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Unified CLI for Basilica GPU rental and network management"

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-05-22
+
+### Fixed
+
+- **Inject `--rdzv-conf=timeout=1500`** into the BYO launcher command for
+  distributed runs. Earlier versions relied on torchelastic's 600s default
+  rendezvous join timeout, which was too short for cold-start image-pull
+  windows on freshly provisioned nodes. Refs basilica-backend#419 (PR #492).
+- **Rewrite `--rdzv-backend=etcd-v2`→`etcd`** in the BYO launcher command.
+  The `etcd-v2` backend has a known regression in torch 2.5.0a0; the
+  operator's auto-path workaround did not cover BYO commands. Refs
+  basilica-backend#419 (PR #492).
+- **Inject `--rdzv-conf=last_call_timeout=900`** alongside the existing
+  `timeout=1500`. torchelastic's default `last_call_timeout=30s` was
+  insufficient for autoscaler-provisioned late ranks under capacity
+  pressure. Refs basilica-backend#419 (PR #493).
+
 ## [0.30.0] - 2026-05-18
 
 This is the major-equivalent (pre-1.0) bump that REMOVES every surface

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.30.0"
+version = "0.30.1"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk"
-version = "0.29.0"
+version = "0.30.1"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "SDK for interacting with the Basilica GPU rental network"


### PR DESCRIPTION
## Why

Aligns CLI, Rust SDK, and Python SDK versions per directive that the
CLI and SDK should stay at par. Before this PR:

- `basilica-sdk-python`: 0.30.0
- `basilica-sdk` (Rust): 0.29.0
- `basilica-cli`: 0.29.0

After this PR all three are at **0.30.1**. Internal-only workspace
crates (basilica-common, basilica-protocol, basilica-miner,
basilica-validator) remain at 0.1.0 and are not user-facing.

## What

Version bump + CHANGELOG entries. No code changes.

### basilica-sdk-python 0.30.1
Three rendezvous fixes merged on main since 0.30.0:

- **PR #492** -- inject `--rdzv-conf=timeout=1500` into the BYO
  launcher command. Default torchelastic 600s rendezvous join timeout
  was too short for cold-start image-pull windows. Refs
  basilica-backend#419.
- **PR #492** -- rewrite `--rdzv-backend=etcd-v2` to `etcd` in BYO
  launcher commands. Works around a torch 2.5.0a0 regression that the
  operator's auto-path workaround did not cover. Refs
  basilica-backend#419.
- **PR #493** -- inject `--rdzv-conf=last_call_timeout=900` alongside
  the existing `timeout=1500`. Default 30s `last_call_timeout` was
  insufficient for autoscaler-provisioned late ranks under capacity
  pressure. Refs basilica-backend#419.

### basilica-cli 0.30.1
Accumulated CLI changes since 0.29.0 -- see the `## [0.30.1]` block in
`crates/basilica-cli/CHANGELOG.md`. Highlights:
- Non-interactive mode for agent and CI usage (auto-detected on
  non-TTY stdin, or forced via `BASILICA_NON_INTERACTIVE=1`).
- OAuth auto-login skipped in non-interactive mode; commands fail fast
  with a `missing_prerequisite` hint instead of blocking on the
  callback server for 300s.
- `basilica ssh-keys add` no longer silently generates a new key in
  non-interactive mode.
- New dedicated `VRAM` column in `basilica ls` secure-cloud offerings
  so GPU memory is unambiguous vs. system RAM.
- `basilica up` interactive selector labels the Memory column with
  `(VRAM)` or `(RAM)` per offering type.
- Normalised size formatting across CLI to `<N> GB` (space between
  number and unit) for VRAM, RAM, storage, volume size.

### basilica-sdk 0.30.1
Rust SDK bumped to keep PyO3 binding contract aligned with the Python
SDK release; no separate behaviour delta vs. 0.29.0 worth a changelog
section.

## Test plan

- [x] `cargo check --workspace` succeeds with new versions
- [x] `Cargo.lock` regenerated and committed
- [ ] CI green on this branch
- [ ] No behavioural code changes -- pytest / integration tests not
  re-run (no diff that would affect them)

## Note

This PR is intentionally **version-metadata + CHANGELOG only**. No
code changes. The CI gate is build success.

## Post-merge

After CI green and merge, tag both:

- `basilica-sdk-python-v0.30.1` -- triggers maturin PyPI release
- `basilica-cli-v0.30.1` -- triggers CLI release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed launcher argument handling and injection issues affecting distributed run deployments across multiple nodes.
  * Corrected rendezvous backend coordination mechanism to ensure reliable multi-node distributed execution and improved job stability.

* **Chores**
  * Released patch version 0.30.1 for basilica-cli, basilica-sdk, and basilica-sdk-python packages with comprehensive changelog updates documenting all bug fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->