### PR TITLE
chore(release): CLI and Python SDK v0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basilica-cli"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "assert_cmd",
  "axum 0.7.9",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-cli"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Unified CLI for Basilica GPU rental and network management"

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.30.1"
+version = "0.31.0"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
Bumps both CLI and Python SDK from v0.30.1 → v0.31.0.

## What's new in v0.31.0

The user-facing additions from #497 (Phase 4 — UD status honesty + recoverable Failed):

- **\`container_statuses\`** field on \`Deployment\` exposes the real per-container status (CrashLoopBackOff reason, ImagePullBackOff, last terminated exit code) instead of a blank "starting".
- **\`phase_history\`** field on \`Deployment\` exposes the phase transitions with timestamps, so callers can see how long a UD spent in each phase and which phases it touched (e.g. \`starting → health_check → ready\` or \`starting → failed → recovering → ready\`).
- **Recovery suffix** on CLI status output marks deployments that have recovered from a previous \`failed\` state so users know their deployment was unhealthy at some point but is now back to ready.

These are **additive** — older callers continue to work unchanged; the new fields are simply ignored if not read.

## Versioning rationale

Minor bump (\`0.30.1 → 0.31.0\`), following the same cadence as the previous v0.27 → v0.28 → v0.29 → v0.30 line. Patch releases (v0.29.1, v0.30.1) are reserved for bug fixes; this adds new fields.

## What ships when this PR merges

After merge, the release pipeline triggers on these tag pushes:
- \`basilica-cli-v0.31.0\` → release-cli.yml builds the cross-platform CLI binaries and creates a GitHub Release. **The workflow gates on the \`cli-release\` environment and requires a reviewer's approval before any binary is built or release is published.**
- \`basilica-sdk-python-v0.31.0\` → release-python-sdk.yml publishes \`basilica-sdk==0.31.0\` to PyPI via trusted publishing.

## Test plan

- [x] \`cargo update -p basilica-cli -p basilica-sdk-python\` succeeded; Cargo.lock updated
- [x] All three version strings (CLI Cargo.toml, SDK-python Cargo.toml, SDK-python pyproject.toml) consistent at 0.31.0
- [ ] CI green (this PR)
- [ ] Post-merge: tags land, SDK publishes to PyPI, CLI binaries build after \`cli-release\` approval
- [ ] Post-publish: separate verification of \`basilica-sdk==0.31.0\` + new CLI against the now-rolled basilica-api on PROD

## Refs

- basilica-backend#783 — incident this work follows from
- basilica-backend#791 — operator + API status-honesty side
- #497 — SDK + CLI side (this version surfaces those fields to users)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.31.0 across CLI and Python SDK components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->