### PR TITLE
fix(sdk-python): surface containerStatuses + phase_progress (v0.31.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.31.0"
+version = "0.31.1"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -179,7 +179,7 @@ except ImportError:
 from .decorators import DeployedFunction, DistributedFunction, deployment, distributed
 
 # Import new modules
-from ._deployment import Deployment, DeploymentStatus, ProgressInfo
+from ._deployment import ContainerStatusInfo, Deployment, DeploymentStatus, ProgressInfo
 from .distributed import (
     BENCH_PHASE_FAILED,
     BENCH_PHASE_PENDING,
@@ -421,6 +421,7 @@ __all__ = [
     # High-level types
     "Deployment",
     "DeploymentStatus",
+    "ContainerStatusInfo",
     "ProgressInfo",
     "SourcePackager",
     # Exceptions

--- a/crates/basilica-sdk-python/python/basilica/_basilica.pyi
+++ b/crates/basilica-sdk-python/python/basilica/_basilica.pyi
@@ -27,6 +27,56 @@ class BasilicaClient:
     """
     ...
 
+class ContainerStatusSnapshot:
+    r"""
+    Per-pod per-container state snapshot (Phase 4, ADR §7.2).
+    
+    Mirrors the operator's `UserDeployment.status.containerStatuses[]` entry
+    and is exposed end-to-end (operator -> basilica-api -> SDK -> Python).
+    Surfaces real container state (CrashLoopBackOff, ImagePullBackOff, exit
+    code) so callers can tell apart infrastructure failures from
+    user-program failures instead of seeing only a blank "starting".
+    
+    Issue follow-up to basilica-backend#783 / #497 — the original PR
+    added these fields to the Rust SDK and CLI but missed the PyO3
+    binding (same regression class as #449).
+    """
+    @property
+    def pod_name(self) -> builtins.str:
+        r"""
+        Name of the pod owning the container.
+        """
+    @property
+    def container_name(self) -> builtins.str:
+        r"""
+        Container name within the pod.
+        """
+    @property
+    def state(self) -> builtins.str:
+        r"""
+        One of `"running"`, `"waiting"`, `"terminated"`. Empty string for
+        the unobserved-state edge case (a container whose kubelet has not
+        yet written any state). Consumers should treat empty the same as
+        waiting for display purposes.
+        """
+    @property
+    def reason(self) -> typing.Optional[builtins.str]:
+        r"""
+        K8s waiting / terminated reason verbatim
+        (e.g. `"CrashLoopBackOff"`, `"ImagePullBackOff"`, `"OOMKilled"`,
+        `"Completed"`). `None` for running containers.
+        """
+    @property
+    def message(self) -> typing.Optional[builtins.str]:
+        r"""
+        Kubelet human-readable detail. `None` when absent.
+        """
+    @property
+    def restart_count(self) -> builtins.int:
+        r"""
+        Kubelet monotonic restart count for this container.
+        """
+
 class CpuOffering:
     r"""
     CPU-only offering from secure cloud providers (no GPU)
@@ -54,6 +104,8 @@ class CpuRentalListItem:
     r"""
     CPU rental list item
     """
+    @property
+    def name(self) -> builtins.str: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property
@@ -95,6 +147,8 @@ class CpuRentalResponse:
     r"""
     Response from starting a CPU rental
     """
+    @property
+    def name(self) -> builtins.str: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property
@@ -233,7 +287,7 @@ class DeploymentProgress:
 class DeploymentResponse:
     r"""
     Deployment response
-
+    
     Issue #449: previously the PyO3 binding was missing `image` and
     `distributed`. The Python facade `_coerce_to_dict` consequently saw
     only 4 attributes (`namespace`, `state`, `url`, `userId`) so every
@@ -287,13 +341,33 @@ class DeploymentResponse:
     @property
     def public_metadata(self) -> builtins.bool: ...
     @property
-    def distributed(self) -> typing.Optional[typing.Dict[builtins.str, typing.Any]]:
+    def container_statuses(self) -> builtins.list[ContainerStatusSnapshot]:
         r"""
-        Read-only mirror of `status.distributed` from the operator. Returns
-        a Python dict with camelCase keys (`worldSize`, `ranks`, `bench`,
-        ...) or `None` for non-distributed UDs (issue #449). Consumed by
-        the `DistributedTraining` facade in
-        `crates/basilica-sdk-python/python/basilica/distributed.py`.
+        Phase 4 (ADR §7.2): per-pod per-container state snapshot exposing
+        real container state (e.g. `CrashLoopBackOff`, `ImagePullBackOff`,
+        exit code) instead of a blank `"starting"`. Empty when the
+        operator has not yet observed pods (first reconcile) or when the
+        workload is scaled to zero. Same regression class as #449 —
+        missed by the v0.31.0 release.
+        """
+    @property
+    def phase_progress(self) -> builtins.int:
+        r"""
+        Phase 4 (ADR §7.2): sum of container `restartCount` across every
+        pod. `0` when no restarts have occurred or no pods exist. Used by
+        the CLI's recovery-suffix renderer; available here for SDK
+        consumers to apply the same logic.
+        """
+    @property
+    def distributed(self) -> typing.Optional[typing.Any]:
+        r"""
+        Convert the cached `status.distributed` JSON into a Python dict
+        (or `None` for non-distributed UDs).
+        
+        `pythonize` is only available with a `Python<'_>` token, so this
+        must be a `#[pymethods]` getter rather than a `#[pyo3(get)]`
+        auto-getter on the field. Python access pattern is identical
+        (`response.distributed`).
         """
 
 class DeploymentSummary:
@@ -721,6 +795,8 @@ class RentalResponse:
     Response from starting a rental
     """
     @property
+    def name(self) -> typing.Optional[builtins.str]: ...
+    @property
     def rental_id(self) -> builtins.str: ...
     @property
     def ssh_credentials(self) -> typing.Optional[builtins.str]: ...
@@ -744,6 +820,8 @@ class RentalStatusWithSshResponse:
     r"""
     Full rental status response with SSH credentials (matches API response)
     """
+    @property
+    def name(self) -> builtins.str: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property
@@ -823,6 +901,8 @@ class SecureCloudRentalListItem:
     Secure cloud GPU rental list item
     """
     @property
+    def name(self) -> builtins.str: ...
+    @property
     def rental_id(self) -> builtins.str: ...
     @property
     def provider(self) -> builtins.str: ...
@@ -863,6 +943,8 @@ class SecureCloudRentalResponse:
     r"""
     Response from starting a secure cloud GPU rental
     """
+    @property
+    def name(self) -> builtins.str: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property
@@ -923,19 +1005,25 @@ class StartCpuRentalRequest:
     Request to start a CPU rental
     """
     @property
+    def name(self) -> typing.Optional[builtins.str]: ...
+    @property
     def offering_id(self) -> builtins.str: ...
     @property
     def ssh_public_key_id(self) -> builtins.str: ...
+    @name.setter
+    def name(self, value: typing.Optional[builtins.str]) -> None: ...
     @offering_id.setter
     def offering_id(self, value: builtins.str) -> None: ...
     @ssh_public_key_id.setter
     def ssh_public_key_id(self, value: builtins.str) -> None: ...
-    def __new__(cls, offering_id:builtins.str, ssh_public_key_id:builtins.str) -> StartCpuRentalRequest: ...
+    def __new__(cls, offering_id:builtins.str, ssh_public_key_id:builtins.str, name:typing.Optional[builtins.str]=None) -> StartCpuRentalRequest: ...
 
 class StartRentalApiRequest:
     r"""
     Start rental API request with GPU-based selection
     """
+    @property
+    def name(self) -> typing.Optional[builtins.str]: ...
     @property
     def gpu_category(self) -> builtins.str: ...
     @property
@@ -958,6 +1046,8 @@ class StartRentalApiRequest:
     def command(self) -> builtins.list[builtins.str]: ...
     @property
     def volumes(self) -> builtins.list[VolumeMountRequest]: ...
+    @name.setter
+    def name(self, value: typing.Optional[builtins.str]) -> None: ...
     @gpu_category.setter
     def gpu_category(self, value: builtins.str) -> None: ...
     @gpu_count.setter
@@ -980,26 +1070,32 @@ class StartRentalApiRequest:
     def command(self, value: builtins.list[builtins.str]) -> None: ...
     @volumes.setter
     def volumes(self, value: builtins.list[VolumeMountRequest]) -> None: ...
-    def __new__(cls, gpu_category:builtins.str, container_image:builtins.str, ssh_public_key:builtins.str, max_hourly_rate:builtins.float, gpu_count:builtins.int=1, min_memory_gb:typing.Optional[builtins.int]=None, environment:typing.Optional[typing.Mapping[builtins.str, builtins.str]]=None, ports:typing.Optional[typing.Sequence[PortMappingRequest]]=None, resources:typing.Optional[ResourceRequirementsRequest]=None, command:typing.Optional[typing.Sequence[builtins.str]]=None, volumes:typing.Optional[typing.Sequence[VolumeMountRequest]]=None) -> StartRentalApiRequest: ...
+    def __new__(cls, gpu_category:builtins.str, container_image:builtins.str, ssh_public_key:builtins.str, max_hourly_rate:builtins.float, gpu_count:builtins.int=1, min_memory_gb:typing.Optional[builtins.int]=None, environment:typing.Optional[typing.Mapping[builtins.str, builtins.str]]=None, ports:typing.Optional[typing.Sequence[PortMappingRequest]]=None, resources:typing.Optional[ResourceRequirementsRequest]=None, command:typing.Optional[typing.Sequence[builtins.str]]=None, volumes:typing.Optional[typing.Sequence[VolumeMountRequest]]=None, name:typing.Optional[builtins.str]=None) -> StartRentalApiRequest: ...
 
 class StartSecureCloudRentalRequest:
     r"""
     Request to start a secure cloud GPU rental
     """
     @property
+    def name(self) -> typing.Optional[builtins.str]: ...
+    @property
     def offering_id(self) -> builtins.str: ...
     @property
     def ssh_public_key_id(self) -> builtins.str: ...
+    @name.setter
+    def name(self, value: typing.Optional[builtins.str]) -> None: ...
     @offering_id.setter
     def offering_id(self, value: builtins.str) -> None: ...
     @ssh_public_key_id.setter
     def ssh_public_key_id(self, value: builtins.str) -> None: ...
-    def __new__(cls, offering_id:builtins.str, ssh_public_key_id:builtins.str) -> StartSecureCloudRentalRequest: ...
+    def __new__(cls, offering_id:builtins.str, ssh_public_key_id:builtins.str, name:typing.Optional[builtins.str]=None) -> StartSecureCloudRentalRequest: ...
 
 class StopCpuRentalResponse:
     r"""
     Response from stopping a CPU rental
     """
+    @property
+    def name(self) -> typing.Optional[builtins.str]: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property
@@ -1013,6 +1109,8 @@ class StopSecureCloudRentalResponse:
     r"""
     Response from stopping a secure cloud GPU rental
     """
+    @property
+    def name(self) -> typing.Optional[builtins.str]: ...
     @property
     def rental_id(self) -> builtins.str: ...
     @property

--- a/crates/basilica-sdk-python/python/basilica/_deployment.py
+++ b/crates/basilica-sdk-python/python/basilica/_deployment.py
@@ -23,8 +23,8 @@ import ssl
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from urllib.parse import urlparse
 
 from basilica.exceptions import DeploymentFailed, DeploymentTimeout
@@ -79,6 +79,28 @@ class ProgressInfo:
 
 
 @dataclass
+class ContainerStatusInfo:
+    """
+    Per-container runtime snapshot surfaced from the operator (Phase 4: UD Status Honesty).
+
+    Attributes:
+        pod_name: Pod hosting the container
+        container_name: Container name within the pod
+        state: Lifecycle state (waiting, running, terminated)
+        reason: Optional reason string from kubelet (e.g. ImagePullBackOff)
+        message: Optional human-readable diagnostic message
+        restart_count: Number of restarts observed for this container
+    """
+
+    pod_name: str
+    container_name: str
+    state: str
+    restart_count: int = 0
+    reason: Optional[str] = None
+    message: Optional[str] = None
+
+
+@dataclass
 class DeploymentStatus:
     """
     Represents the current status of a deployment.
@@ -90,6 +112,8 @@ class DeploymentStatus:
         message: Optional status message or error description
         phase: Granular deployment phase (scheduling, pulling, starting, ready, etc.)
         progress: Progress information for long-running operations like storage sync
+        container_statuses: Per-container snapshots from the operator (Phase 4)
+        phase_progress: Sum of container `restartCount` across every pod (Phase 4)
     """
 
     state: str
@@ -98,6 +122,8 @@ class DeploymentStatus:
     message: Optional[str] = None
     phase: Optional[str] = None
     progress: Optional[ProgressInfo] = None
+    container_statuses: List[ContainerStatusInfo] = field(default_factory=list)
+    phase_progress: int = 0
 
     @property
     def is_ready(self) -> bool:
@@ -342,6 +368,18 @@ class Deployment:
                 elapsed_seconds=getattr(response.progress, "elapsed_seconds", 0),
             )
 
+        container_statuses = [
+            ContainerStatusInfo(
+                pod_name=getattr(snap, "pod_name", ""),
+                container_name=getattr(snap, "container_name", ""),
+                state=getattr(snap, "state", ""),
+                restart_count=getattr(snap, "restart_count", 0),
+                reason=getattr(snap, "reason", None),
+                message=getattr(snap, "message", None),
+            )
+            for snap in getattr(response, "container_statuses", []) or []
+        ]
+
         return DeploymentStatus(
             state=response.state,
             replicas_ready=response.replicas.ready,
@@ -349,6 +387,8 @@ class Deployment:
             message=None,
             phase=getattr(response, "phase", None),
             progress=progress,
+            container_statuses=container_statuses,
+            phase_progress=getattr(response, "phase_progress", 0),
         )
 
     def status(self) -> DeploymentStatus:

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -859,6 +859,7 @@ fn _basilica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<types::ResourceRequirements>()?;
     m.add_class::<types::ReplicaStatus>()?;
     m.add_class::<types::PodInfo>()?;
+    m.add_class::<types::ContainerStatusSnapshot>()?;
     m.add_class::<types::SpreadMode>()?;
     m.add_class::<types::TopologySpreadConfig>()?;
     m.add_class::<types::StorageBackend>()?;

--- a/crates/basilica-sdk-python/src/types.rs
+++ b/crates/basilica-sdk-python/src/types.rs
@@ -680,6 +680,7 @@ impl From<ListRentalsQuery> for SdkListRentalsQuery {
 // Deployment types
 
 use basilica_sdk::types::{
+    ContainerStatusSnapshot as SdkContainerStatusSnapshot,
     CreateDeploymentRequest as SdkCreateDeploymentRequest,
     DeleteDeploymentResponse as SdkDeleteDeploymentResponse,
     DeploymentListResponse as SdkDeploymentListResponse,
@@ -915,6 +916,59 @@ impl From<SdkPodInfo> for PodInfo {
             name: pod.name,
             status: pod.status,
             node: pod.node,
+        }
+    }
+}
+
+/// Per-pod per-container state snapshot (Phase 4, ADR §7.2).
+///
+/// Mirrors the operator's `UserDeployment.status.containerStatuses[]` entry
+/// and is exposed end-to-end (operator -> basilica-api -> SDK -> Python).
+/// Surfaces real container state (CrashLoopBackOff, ImagePullBackOff, exit
+/// code) so callers can tell apart infrastructure failures from
+/// user-program failures instead of seeing only a blank "starting".
+///
+/// Issue follow-up to basilica-backend#783 / #497 — the original PR
+/// added these fields to the Rust SDK and CLI but missed the PyO3
+/// binding (same regression class as #449).
+#[cfg_attr(feature = "stub-gen", gen_stub_pyclass)]
+#[pyclass]
+#[derive(Clone)]
+pub struct ContainerStatusSnapshot {
+    /// Name of the pod owning the container.
+    #[pyo3(get)]
+    pub pod_name: String,
+    /// Container name within the pod.
+    #[pyo3(get)]
+    pub container_name: String,
+    /// One of `"running"`, `"waiting"`, `"terminated"`. Empty string for
+    /// the unobserved-state edge case (a container whose kubelet has not
+    /// yet written any state). Consumers should treat empty the same as
+    /// waiting for display purposes.
+    #[pyo3(get)]
+    pub state: String,
+    /// K8s waiting / terminated reason verbatim
+    /// (e.g. `"CrashLoopBackOff"`, `"ImagePullBackOff"`, `"OOMKilled"`,
+    /// `"Completed"`). `None` for running containers.
+    #[pyo3(get)]
+    pub reason: Option<String>,
+    /// Kubelet human-readable detail. `None` when absent.
+    #[pyo3(get)]
+    pub message: Option<String>,
+    /// Kubelet monotonic restart count for this container.
+    #[pyo3(get)]
+    pub restart_count: i32,
+}
+
+impl From<SdkContainerStatusSnapshot> for ContainerStatusSnapshot {
+    fn from(snap: SdkContainerStatusSnapshot) -> Self {
+        Self {
+            pod_name: snap.pod_name,
+            container_name: snap.container_name,
+            state: snap.state,
+            reason: snap.reason,
+            message: snap.message,
+            restart_count: snap.restart_count,
         }
     }
 }
@@ -1501,6 +1555,20 @@ pub struct DeploymentResponse {
     /// Not annotated `#[pyo3(get)]` because `serde_json::Value` is not
     /// `IntoPyObject`; see the `distributed` method on the impl block.
     pub distributed: Option<serde_json::Value>,
+    /// Phase 4 (ADR §7.2): per-pod per-container state snapshot exposing
+    /// real container state (e.g. `CrashLoopBackOff`, `ImagePullBackOff`,
+    /// exit code) instead of a blank `"starting"`. Empty when the
+    /// operator has not yet observed pods (first reconcile) or when the
+    /// workload is scaled to zero. Same regression class as #449 —
+    /// missed by the v0.31.0 release.
+    #[pyo3(get)]
+    pub container_statuses: Vec<ContainerStatusSnapshot>,
+    /// Phase 4 (ADR §7.2): sum of container `restartCount` across every
+    /// pod. `0` when no restarts have occurred or no pods exist. Used by
+    /// the CLI's recovery-suffix renderer; available here for SDK
+    /// consumers to apply the same logic.
+    #[pyo3(get)]
+    pub phase_progress: i32,
 }
 
 #[cfg_attr(feature = "stub-gen", gen_stub_pymethods)]
@@ -1558,6 +1626,12 @@ impl From<SdkDeploymentResponse> for DeploymentResponse {
             websocket: response.websocket.map(Into::into),
             public_metadata: response.public_metadata,
             distributed,
+            container_statuses: response
+                .container_statuses
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            phase_progress: response.phase_progress,
         }
     }
 }

--- a/crates/basilica-sdk-python/tests/test_phase4_status_fields.py
+++ b/crates/basilica-sdk-python/tests/test_phase4_status_fields.py
@@ -1,0 +1,87 @@
+"""
+Phase 4 (UD Status Honesty) regression tests for the Python SDK.
+
+PR #497 added `container_statuses` and `phase_progress` to the API
+DeploymentResponse but the change never reached the Python bindings.
+v0.31.0 shipped without them, so SDK consumers could not read either
+field. This test guards the PyO3 binding + Python facade together.
+"""
+
+from unittest.mock import MagicMock
+
+from basilica import ContainerStatusInfo, Deployment, DeploymentStatus
+
+
+def _make_deployment() -> Deployment:
+    return Deployment(
+        client=MagicMock(),
+        instance_name="phase4-test",
+        url="https://phase4.deployments.basilica.ai",
+        namespace="u-test",
+        user_id="test-user",
+        state="Active",
+        created_at="2026-05-27T00:00:00Z",
+        replicas_ready=1,
+        replicas_desired=1,
+    )
+
+
+def test_parse_status_response_surfaces_container_statuses() -> None:
+    deployment = _make_deployment()
+
+    snap = MagicMock()
+    snap.pod_name = "pod-0"
+    snap.container_name = "main"
+    snap.state = "running"
+    snap.reason = None
+    snap.message = None
+    snap.restart_count = 0
+
+    response = MagicMock()
+    response.state = "Active"
+    response.replicas.ready = 1
+    response.replicas.desired = 1
+    response.phase = "ready"
+    response.progress = None
+    response.container_statuses = [snap]
+    response.phase_progress = 7
+
+    status = deployment._parse_status_response(response)
+
+    assert isinstance(status, DeploymentStatus)
+    assert status.phase_progress == 7
+    assert len(status.container_statuses) == 1
+    cs = status.container_statuses[0]
+    assert isinstance(cs, ContainerStatusInfo)
+    assert cs.pod_name == "pod-0"
+    assert cs.container_name == "main"
+    assert cs.state == "running"
+    assert cs.restart_count == 0
+    assert cs.reason is None
+
+
+def test_parse_status_response_handles_missing_phase4_fields() -> None:
+    deployment = _make_deployment()
+
+    response = MagicMock(spec=["state", "replicas", "phase", "progress"])
+    response.state = "Pending"
+    response.replicas.ready = 0
+    response.replicas.desired = 1
+    response.phase = "pending"
+    response.progress = None
+
+    status = deployment._parse_status_response(response)
+
+    assert status.phase_progress == 0
+    assert status.container_statuses == []
+
+
+def test_pyo3_deployment_response_exposes_phase4_fields() -> None:
+    """The compiled PyO3 module must expose the new fields on DeploymentResponse."""
+    from basilica import _basilica
+
+    assert hasattr(_basilica, "ContainerStatusSnapshot")
+    cls = _basilica.DeploymentResponse
+    sig = cls.__doc__ or ""
+    assert "container_statuses" in sig or hasattr(cls, "container_statuses")
+    assert "phase_progress" in sig or hasattr(cls, "phase_progress")


### PR DESCRIPTION
## Summary

PR #497 (Phase 4 — UD Status Honesty) added two new fields to the Rust SDK `DeploymentResponse`:
- `container_statuses: Vec<ContainerStatusSnapshot>` — real per-container state (`CrashLoopBackOff`, `ImagePullBackOff`, `OOMKilled`, exit codes)
- `phase_progress: i32` — sum of `restartCount` across every pod

…but the PyO3 binding in `crates/basilica-sdk-python` was missed. v0.31.0 therefore shipped without these fields visible to Python consumers:
- `deployment.status().container_statuses` raised `AttributeError` on the binding
- the high-level `Deployment` facade had no notion of either field

This is the same regression class as #449 (the original distributed status drop).

## Changes

- `src/types.rs` — adds the `ContainerStatusSnapshot` PyO3 class and wires `container_statuses` + `phase_progress` onto the existing `DeploymentResponse` binding (plus the `From<SdkDeploymentResponse>` conversion).
- `src/lib.rs` — registers `ContainerStatusSnapshot` on the module.
- `python/basilica/_deployment.py` — adds a `ContainerStatusInfo` dataclass, the two corresponding fields on the `DeploymentStatus` dataclass, and updates `_parse_status_response` to populate them from the binding.
- `python/basilica/__init__.py` — exports `ContainerStatusInfo`.
- `python/basilica/_basilica.pyi` — regenerated stub.
- `tests/test_phase4_status_fields.py` — three regression tests covering the facade parsing path, the missing-field tolerance, and the raw PyO3 binding shape.
- `Cargo.toml` + `pyproject.toml` — bump v0.31.0 → v0.31.1 (additive, backwards-compatible).

## Test plan

- [x] `cargo build -p basilica-sdk-python --features stub-gen` clean (existing `gen_stub_pyfunction` warning is pre-existing, not introduced here).
- [x] `maturin develop --release` builds wheel and installs `basilica-sdk-0.31.1` in a clean venv.
- [x] `python -m pytest tests/` → 181/181 passing (3 new + 178 existing).
- [x] Python smoke confirms `basilica.ContainerStatusInfo`, `basilica.DeploymentStatus.container_statuses`, `basilica.DeploymentStatus.phase_progress`, and `basilica._basilica.ContainerStatusSnapshot` are all reachable.

## Follow-up

After merge:
- Tag the merge commit `basilica-sdk-python-v0.31.1` to trigger the release workflow.
- Approve PyPI publish gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now expose per-container runtime status information, including pod names, container states, and restart counts.
  * Added phase progress tracking to deployment status responses.
  * Added optional name field to rental operations and responses for improved resource identification.

* **Chores**
  * Updated package version to 0.31.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/one-covenant/basilica/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->