### PR TITLE
fix(ssh): suppress known-host warning in commands

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Suppressed OpenSSH's known-host informational warning from `basilica exec`
+  and `basilica cp` error output, so failed remote commands surface the
+  actual remote stderr without the extra host-key noise.
+
 ## [0.30.1] - 2026-05-22
 
 ### Added

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -132,6 +132,36 @@ impl StandardSshClient {
         &self.config
     }
 
+    fn host_key_options(&self) -> Vec<String> {
+        let mut options = Vec::new();
+
+        if self.config.strict_host_key_checking {
+            options.push("StrictHostKeyChecking=yes".to_string());
+            if let Some(ref known_hosts) = self.config.known_hosts_file {
+                options.push(format!("UserKnownHostsFile={}", known_hosts.display()));
+            }
+        } else {
+            options.push("StrictHostKeyChecking=no".to_string());
+            options.push("UserKnownHostsFile=/dev/null".to_string());
+        }
+
+        options
+    }
+
+    fn connection_options(&self, include_batch_mode: bool) -> Vec<String> {
+        let mut options = self.host_key_options();
+        options.push("LogLevel=ERROR".to_string());
+        options.push("IdentitiesOnly=yes".to_string());
+        if include_batch_mode {
+            options.push("BatchMode=yes".to_string());
+        }
+        options.push(format!(
+            "ConnectTimeout={}",
+            self.config.connection_timeout.as_secs()
+        ));
+        options
+    }
+
     /// Validate SSH connection details
     fn validate_connection_details(&self, details: &SshConnectionDetails) -> Result<()> {
         if details.host.is_empty() {
@@ -528,27 +558,11 @@ impl StandardSshClient {
             .arg("-p")
             .arg(details.port.to_string());
 
-        if self.config.strict_host_key_checking {
-            cmd.arg("-o").arg("StrictHostKeyChecking=yes");
-            if let Some(ref known_hosts) = self.config.known_hosts_file {
-                cmd.arg("-o")
-                    .arg(format!("UserKnownHostsFile={}", known_hosts.display()));
-            }
-        } else {
-            cmd.arg("-o").arg("StrictHostKeyChecking=no");
-            cmd.arg("-o").arg("UserKnownHostsFile=/dev/null");
+        for option in self.connection_options(true) {
+            cmd.arg("-o").arg(option);
         }
 
-        cmd.arg("-o")
-            .arg("IdentitiesOnly=yes")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg("-o")
-            .arg(format!(
-                "ConnectTimeout={}",
-                self.config.connection_timeout.as_secs()
-            ))
-            .arg(format!("{}@{}", details.username, details.host))
+        cmd.arg(format!("{}@{}", details.username, details.host))
             .arg(command);
 
         cmd.stdout(Stdio::piped());
@@ -573,28 +587,11 @@ impl StandardSshClient {
             .arg("-p")
             .arg(details.port.to_string());
 
-        // Configure host key checking based on settings
-        if self.config.strict_host_key_checking {
-            cmd.arg("-o").arg("StrictHostKeyChecking=yes");
-            if let Some(ref known_hosts) = self.config.known_hosts_file {
-                cmd.arg("-o")
-                    .arg(format!("UserKnownHostsFile={}", known_hosts.display()));
-            }
-        } else {
-            cmd.arg("-o").arg("StrictHostKeyChecking=no");
-            cmd.arg("-o").arg("UserKnownHostsFile=/dev/null");
+        for option in self.connection_options(true) {
+            cmd.arg("-o").arg(option);
         }
 
-        cmd.arg("-o")
-            .arg("IdentitiesOnly=yes")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg("-o")
-            .arg(format!(
-                "ConnectTimeout={}",
-                self.config.connection_timeout.as_secs()
-            ))
-            .arg(format!("{}@{}", details.username, details.host))
+        cmd.arg(format!("{}@{}", details.username, details.host))
             .arg(command);
 
         if !capture_output {
@@ -757,30 +754,14 @@ impl SshFileTransferManager for StandardSshClient {
             .arg("-P")
             .arg(details.port.to_string());
 
-        // Configure host key checking based on settings
-        if self.config.strict_host_key_checking {
-            cmd.arg("-o").arg("StrictHostKeyChecking=yes");
-            if let Some(ref known_hosts) = self.config.known_hosts_file {
-                cmd.arg("-o")
-                    .arg(format!("UserKnownHostsFile={}", known_hosts.display()));
-            }
-        } else {
-            cmd.arg("-o").arg("StrictHostKeyChecking=no");
-            cmd.arg("-o").arg("UserKnownHostsFile=/dev/null");
+        for option in self.connection_options(false) {
+            cmd.arg("-o").arg(option);
         }
 
-        cmd.arg("-o")
-            .arg("IdentitiesOnly=yes")
-            .arg("-o")
-            .arg(format!(
-                "ConnectTimeout={}",
-                self.config.connection_timeout.as_secs()
-            ))
-            .arg(local_path)
-            .arg(format!(
-                "{}@{}:{}",
-                details.username, details.host, remote_path
-            ));
+        cmd.arg(local_path).arg(format!(
+            "{}@{}:{}",
+            details.username, details.host, remote_path
+        ));
 
         debug!("Executing SCP command: {:?}", cmd);
 
@@ -833,30 +814,15 @@ impl SshFileTransferManager for StandardSshClient {
             .arg("-P")
             .arg(details.port.to_string());
 
-        // Configure host key checking based on settings
-        if self.config.strict_host_key_checking {
-            cmd.arg("-o").arg("StrictHostKeyChecking=yes");
-            if let Some(ref known_hosts) = self.config.known_hosts_file {
-                cmd.arg("-o")
-                    .arg(format!("UserKnownHostsFile={}", known_hosts.display()));
-            }
-        } else {
-            cmd.arg("-o").arg("StrictHostKeyChecking=no");
-            cmd.arg("-o").arg("UserKnownHostsFile=/dev/null");
+        for option in self.connection_options(false) {
+            cmd.arg("-o").arg(option);
         }
 
-        cmd.arg("-o")
-            .arg("IdentitiesOnly=yes")
-            .arg("-o")
-            .arg(format!(
-                "ConnectTimeout={}",
-                self.config.connection_timeout.as_secs()
-            ))
-            .arg(format!(
-                "{}@{}:{}",
-                details.username, details.host, remote_path
-            ))
-            .arg(local_path);
+        cmd.arg(format!(
+            "{}@{}:{}",
+            details.username, details.host, remote_path
+        ))
+        .arg(local_path);
 
         debug!("Executing SCP download command: {:?}", cmd);
 
@@ -957,6 +923,48 @@ mod tests {
         assert!(config.cleanup_remote_files);
         assert!(!config.strict_host_key_checking);
         assert!(config.known_hosts_file.is_none());
+    }
+
+    #[test]
+    fn test_connection_options_non_strict_include_log_level_error() {
+        let client = StandardSshClient::new();
+
+        let options = client.connection_options(true);
+
+        assert_eq!(
+            options,
+            vec![
+                "StrictHostKeyChecking=no".to_string(),
+                "UserKnownHostsFile=/dev/null".to_string(),
+                "LogLevel=ERROR".to_string(),
+                "IdentitiesOnly=yes".to_string(),
+                "BatchMode=yes".to_string(),
+                "ConnectTimeout=30".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_connection_options_strict_include_known_hosts_and_log_level_error() {
+        let client = StandardSshClient::with_config(SshConnectionConfig {
+            strict_host_key_checking: true,
+            known_hosts_file: Some(std::path::PathBuf::from("/tmp/basilica_known_hosts")),
+            connection_timeout: Duration::from_secs(7),
+            ..SshConnectionConfig::default()
+        });
+
+        let options = client.connection_options(false);
+
+        assert_eq!(
+            options,
+            vec![
+                "StrictHostKeyChecking=yes".to_string(),
+                "UserKnownHostsFile=/tmp/basilica_known_hosts".to_string(),
+                "LogLevel=ERROR".to_string(),
+                "IdentitiesOnly=yes".to_string(),
+                "ConnectTimeout=7".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -132,24 +132,23 @@ impl StandardSshClient {
         &self.config
     }
 
-    fn host_key_options(&self) -> Vec<String> {
+    fn host_key_options(&self) -> Result<Vec<String>> {
         let mut options = Vec::new();
 
         if self.config.strict_host_key_checking {
             options.push("StrictHostKeyChecking=yes".to_string());
-            if let Some(ref known_hosts) = self.config.known_hosts_file {
-                options.push(format!("UserKnownHostsFile={}", known_hosts.display()));
-            }
+            let known_hosts = self.get_known_hosts_path()?;
+            options.push(format!("UserKnownHostsFile={}", known_hosts.display()));
         } else {
             options.push("StrictHostKeyChecking=no".to_string());
             options.push("UserKnownHostsFile=/dev/null".to_string());
         }
 
-        options
+        Ok(options)
     }
 
-    fn connection_options(&self, include_batch_mode: bool) -> Vec<String> {
-        let mut options = self.host_key_options();
+    fn connection_options(&self, include_batch_mode: bool) -> Result<Vec<String>> {
+        let mut options = self.host_key_options()?;
         options.push("LogLevel=ERROR".to_string());
         options.push("IdentitiesOnly=yes".to_string());
         if include_batch_mode {
@@ -159,7 +158,7 @@ impl StandardSshClient {
             "ConnectTimeout={}",
             self.config.connection_timeout.as_secs()
         ));
-        options
+        Ok(options)
     }
 
     /// Validate SSH connection details
@@ -558,7 +557,7 @@ impl StandardSshClient {
             .arg("-p")
             .arg(details.port.to_string());
 
-        for option in self.connection_options(true) {
+        for option in self.connection_options(true)? {
             cmd.arg("-o").arg(option);
         }
 
@@ -587,7 +586,7 @@ impl StandardSshClient {
             .arg("-p")
             .arg(details.port.to_string());
 
-        for option in self.connection_options(true) {
+        for option in self.connection_options(true)? {
             cmd.arg("-o").arg(option);
         }
 
@@ -754,7 +753,7 @@ impl SshFileTransferManager for StandardSshClient {
             .arg("-P")
             .arg(details.port.to_string());
 
-        for option in self.connection_options(false) {
+        for option in self.connection_options(false)? {
             cmd.arg("-o").arg(option);
         }
 
@@ -814,7 +813,7 @@ impl SshFileTransferManager for StandardSshClient {
             .arg("-P")
             .arg(details.port.to_string());
 
-        for option in self.connection_options(false) {
+        for option in self.connection_options(false)? {
             cmd.arg("-o").arg(option);
         }
 
@@ -894,6 +893,15 @@ mod tests {
         }
     }
 
+    fn default_known_hosts_path_for_test() -> std::path::PathBuf {
+        match std::env::var("HOME") {
+            Ok(home) => std::path::PathBuf::from(home)
+                .join(".ssh")
+                .join("known_hosts"),
+            Err(_) => std::path::PathBuf::from("/tmp/known_hosts"),
+        }
+    }
+
     #[test]
     fn test_host_spec_formatting_standard_port() {
         let details = create_test_ssh_details();
@@ -929,7 +937,7 @@ mod tests {
     fn test_connection_options_non_strict_include_log_level_error() {
         let client = StandardSshClient::new();
 
-        let options = client.connection_options(true);
+        let options = client.connection_options(true).unwrap();
 
         assert_eq!(
             options,
@@ -953,13 +961,37 @@ mod tests {
             ..SshConnectionConfig::default()
         });
 
-        let options = client.connection_options(false);
+        let options = client.connection_options(false).unwrap();
 
         assert_eq!(
             options,
             vec![
                 "StrictHostKeyChecking=yes".to_string(),
                 "UserKnownHostsFile=/tmp/basilica_known_hosts".to_string(),
+                "LogLevel=ERROR".to_string(),
+                "IdentitiesOnly=yes".to_string(),
+                "ConnectTimeout=7".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_connection_options_strict_use_default_known_hosts_path() {
+        let client = StandardSshClient::with_config(SshConnectionConfig {
+            strict_host_key_checking: true,
+            known_hosts_file: None,
+            connection_timeout: Duration::from_secs(7),
+            ..SshConnectionConfig::default()
+        });
+        let expected_known_hosts = default_known_hosts_path_for_test();
+
+        let options = client.connection_options(false).unwrap();
+
+        assert_eq!(
+            options,
+            vec![
+                "StrictHostKeyChecking=yes".to_string(),
+                format!("UserKnownHostsFile={}", expected_known_hosts.display()),
                 "LogLevel=ERROR".to_string(),
                 "IdentitiesOnly=yes".to_string(),
                 "ConnectTimeout=7".to_string(),


### PR DESCRIPTION
Suppresses OpenSSH's informational known-host warning in Basilica SSH command execution paths by passing `LogLevel=ERROR`.

This keeps failed remote commands focused on the actual remote stderr, while preserving the existing host-key, batch-mode, and SCP behaviors. The SSH option construction is also centralized so command and file-transfer paths stay consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal SSH/SCP option handling to reduce duplication and standardize invocation behavior.

* **Bug Fixes**
  * basilica exec and basilica cp now suppress OpenSSH known-host informational warnings so remote stderr is shown cleanly on failure.

* **Tests**
  * Added unit tests validating SSH connection option generation across different host-key checking configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->