### PR TITLE
fix(cli): avoid duplicate SSH command failure output

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suppressed OpenSSH's known-host informational warning from `basilica exec`
   and `basilica cp` error output, so failed remote commands surface the
   actual remote stderr without the extra host-key noise.
+- Removed duplicate SSH command failure text from `basilica exec` output, so
+  remote command errors render once with the original stderr and CLI guidance.
 
 ## [0.30.1] - 2026-05-22
 

--- a/crates/basilica-cli/src/output/error_render.rs
+++ b/crates/basilica-cli/src/output/error_render.rs
@@ -56,6 +56,7 @@ fn render_human(err: &CliError, w: &mut dyn Write) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use color_eyre::eyre::eyre;
 
     #[test]
     fn json_render_missing_input() {
@@ -96,5 +97,20 @@ mod tests {
         assert!(s.contains("missing input"));
         assert!(s.contains("rental"));
         assert!(s.contains("<rental-name-or-id>"));
+    }
+
+    #[test]
+    fn human_render_internal_report_does_not_need_command_wrapper() {
+        let report =
+            eyre!("SSH command failed: ModuleNotFoundError: No module named 'definitely_missing'");
+        let err = CliError::Internal(report);
+        let mut buf = Vec::new();
+
+        render_error(&err, RenderMode::Human, &mut buf).unwrap();
+
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("SSH command failed"));
+        assert!(s.contains("ModuleNotFoundError"));
+        assert!(!s.contains("Command execution failed"));
     }
 }

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -112,7 +112,7 @@ impl SshClient {
             .execute_command(&details, command, true)
             .await
             .map_err(|e| {
-                eyre!("Command execution failed: {}", e)
+                eyre!(e)
                     .suggestion("Check if the rental is still active and SSH port is exposed")
                     .note("Run 'basilica status <rental-id>' to check rental status")
             })?;

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// SSH connection configuration
 #[derive(Debug, Clone)]
@@ -609,7 +609,7 @@ impl StandardSshClient {
             Ok(stdout)
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            error!("SSH command failed: {}", stderr);
+            debug!("SSH command failed: {}", stderr);
             Err(anyhow::anyhow!("SSH command failed: {}", stderr))
         }
     }
@@ -647,11 +647,11 @@ impl SshConnectionManager for StandardSshClient {
                 }
             }
             Ok(Err(e)) => {
-                error!("SSH connection test failed: {}", e);
+                debug!("SSH connection test failed: {}", e);
                 Err(e)
             }
             Err(_) => {
-                error!("SSH connection test timed out");
+                debug!("SSH connection test timed out");
                 Err(anyhow::anyhow!("Connection test timed out"))
             }
         }
@@ -676,7 +676,7 @@ impl SshConnectionManager for StandardSshClient {
         match result {
             Ok(result) => result,
             Err(_) => {
-                error!("Command execution timed out");
+                debug!("Command execution timed out");
                 Err(anyhow::anyhow!("Command execution timed out"))
             }
         }
@@ -781,11 +781,11 @@ impl SshFileTransferManager for StandardSshClient {
                 Ok(())
             }
             Ok(Err(e)) => {
-                error!("File upload failed: {}", e);
+                debug!("File upload failed: {}", e);
                 Err(e)
             }
             Err(_) => {
-                error!("File upload timed out");
+                debug!("File upload timed out");
                 Err(anyhow::anyhow!("File upload timed out"))
             }
         }
@@ -842,11 +842,11 @@ impl SshFileTransferManager for StandardSshClient {
                 Ok(())
             }
             Ok(Err(e)) => {
-                error!("File download failed: {}", e);
+                debug!("File download failed: {}", e);
                 Err(e)
             }
             Err(_) => {
-                error!("File download timed out");
+                debug!("File download timed out");
                 Err(anyhow::anyhow!("File download timed out"))
             }
         }


### PR DESCRIPTION
Removes duplicated error output from `basilica exec` failures by letting the CLI renderer own user-facing SSH errors.

Returned SSH/SCP failures are now logged at debug level instead of error level, and the CLI exec path no longer wraps SSH failures with an extra `Command execution failed:` prefix. This preserves the remote stderr details while avoiding repeated traceback/error text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified SSH command error messages by removing redundant wrapper text for improved clarity.

* **Tests**
  * Added unit tests for error message rendering in Human mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->