### PR TITLE
fix(skills): update default skills archive owner

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `basilica skills` command group for installing, uninstalling, and listing
+  Basilica agent skills across supported coding tools, with `--agent` targeting
+  and `-y` automation support.
+
 ### Fixed
 - Suppressed OpenSSH's known-host informational warning from `basilica exec`
   and `basilica cp` error output, so failed remote commands surface the

--- a/crates/basilica-cli/src/cli/handlers/skills.rs
+++ b/crates/basilica-cli/src/cli/handlers/skills.rs
@@ -14,7 +14,7 @@ use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 
 const DEFAULT_TARBALL_URL: &str =
-    "https://github.com/itzlambda/basilica-skills/archive/refs/heads/main.tar.gz";
+    "https://github.com/one-covenant/basilica-skills/archive/refs/heads/main.tar.gz";
 const TARBALL_URL_ENV: &str = "BASILICA_SKILLS_TARBALL_URL";
 const SKILLS_DIR: &str = "skills";
 const CURATED_SKILLS: &[&str] = &["use-basilica"];


### PR DESCRIPTION
Updates the default skills archive URL to fetch from the one-covenant/basilica-skills repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `basilica skills` command group to manage agent skills with install, uninstall, and list operations
  * Includes `--agent` option for targeting and `-y` flag for non-interactive automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->