### PR TITLE
fix(sdk): migrate secure cloud endpoints to v2

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Secure-cloud GPU, CPU, and volume commands now use SDK calls backed by the
+  V2 API paths under `/v2/secure-cloud/*`.
+- `basilica volumes create --provider <legacy-provider>` prints a temporary
+  stderr warning for legacy secure-cloud provider tags such as `hyperstack` or
+  `verda`; V2 volume creation should use public availability-zone names such as
+  `cyan` with regions such as `us-texas-1`.
+
 ## [0.31.2] - 2026-06-09
 
 ### Added

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -9,21 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Secure-cloud GPU, CPU, and volume commands now use SDK calls backed by the
-  V2 API paths under `/v2/secure-cloud/*`.
-- `basilica volumes create --provider <legacy-provider>` prints a temporary
-  stderr warning for legacy secure-cloud provider tags such as `hyperstack` or
-  `verda`; V2 volume creation should use public availability-zone names such as
-  `cyan` with regions such as `us-texas-1`.
+  V2 API paths under `/v2/secure-cloud/*`, where provider fields carry Basilica
+  public availability zone root names such as `cyan`, `plum`, or `opal`.
+- In human output mode, `basilica volumes create --provider <legacy-provider>`
+  prints a temporary stderr warning for legacy secure-cloud provider tags such
+  as `hyperstack` or `verda`; V2 volume creation should use a public
+  availability zone root plus region, for example `cyan` and `us-texas-1`.
 
 ## [0.31.2] - 2026-06-09
 
 ### Added
-- Support for any provider/availability-zone value the API emits (e.g. AZ-root
-  codenames `cyan`, `plum`, `opal`) in `basilica ls` and other commands, with
-  the region shown in the separate `REGION` column. The provider value is no
-  longer constrained to a fixed client-side list, so new providers/AZs work
-  without a CLI release; previously `basilica ls` failed against a newer API
-  with `unknown variant ...`.
+- Support for any provider/availability zone value the API emits (e.g.
+  availability zone root codenames `cyan`, `plum`, `opal`) in `basilica ls`
+  and other commands, with the region shown in the separate `REGION` column.
+  The provider value is no longer constrained to a fixed client-side list, so
+  new providers/availability zones work without a CLI release; previously
+  `basilica ls` failed against a newer API with `unknown variant ...`.
 - `basilica skills` command group for installing, uninstalling, and listing
   Basilica agent skills across supported coding tools, with `--agent` targeting
   and `-y` automation support.

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -8,9 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Secure-cloud GPU, CPU, and volume commands now use SDK calls backed by the
-  V2 API paths under `/v2/secure-cloud/*`, where provider fields carry Basilica
-  public availability zone root names such as `cyan`, `plum`, or `opal`.
+- Secure-cloud GPU, CPU, rental, and volume commands now use SDK calls backed
+  by the V2 API paths under `/v2/secure-cloud/*`.
 - In human output mode, `basilica volumes create --provider <legacy-provider>`
   prints a temporary stderr warning for legacy secure-cloud provider tags such
   as `hyperstack` or `verda`; V2 volume creation should use a public
@@ -19,12 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.31.2] - 2026-06-09
 
 ### Added
-- Support for any provider/availability zone value the API emits (e.g.
-  availability zone root codenames `cyan`, `plum`, `opal`) in `basilica ls`
-  and other commands, with the region shown in the separate `REGION` column.
-  The provider value is no longer constrained to a fixed client-side list, so
-  new providers/availability zones work without a CLI release; previously
-  `basilica ls` failed against a newer API with `unknown variant ...`.
+- Support for any provider/availability-zone value the API emits (e.g. AZ-root
+  codenames `cyan`, `plum`, `opal`) in `basilica ls` and other commands, with
+  the region shown in the separate `REGION` column. The provider value is no
+  longer constrained to a fixed client-side list, so new providers/AZs work
+  without a CLI release; previously `basilica ls` failed against a newer API
+  with `unknown variant ...`.
 - `basilica skills` command group for installing, uninstalling, and listing
   Basilica agent skills across supported coding tools, with `--agent` targeting
   and `-y` automation support.

--- a/crates/basilica-cli/src/cli/handlers/volumes.rs
+++ b/crates/basilica-cli/src/cli/handlers/volumes.rs
@@ -135,6 +135,7 @@ fn prompt_region(provider: &str) -> Result<String, CliError> {
 
 fn validate_volume_provider(provider: &str) -> Result<String, CliError> {
     let provider = provider.trim();
+    basilica_sdk::types::warn_if_legacy_secure_cloud_provider(provider);
     if VOLUME_PROVIDERS.iter().any(|(p, _)| *p == provider) {
         Ok(provider.to_string())
     } else {

--- a/crates/basilica-cli/src/cli/handlers/volumes.rs
+++ b/crates/basilica-cli/src/cli/handlers/volumes.rs
@@ -11,9 +11,33 @@ use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 /// Pricing constant: $0.000096774 per GB per hour (~$0.07/GB/month)
 const VOLUME_PRICE_PER_GB_HOUR: f64 = 0.000096774;
 
-/// Volume-capable availability-zone roots and their public Basilica regions.
+/// Volume-capable availability zone roots and their public Basilica regions.
 const VOLUME_PROVIDERS: &[(&str, &[&str])] =
     &[("cyan", &["us-texas-1", "ca-quebec-1", "no-vestland-1"])];
+
+fn is_legacy_volume_provider(provider: &str) -> bool {
+    matches!(
+        provider.trim().to_ascii_lowercase().as_str(),
+        "datacrunch"
+            | "denvr"
+            | "hydrahost"
+            | "hyperstack"
+            | "lambda"
+            | "masscompute"
+            | "shadeform"
+            | "verda"
+    )
+}
+
+fn warn_legacy_volume_provider(provider: &str) {
+    eprintln!(
+        "Warning: '{}' is a legacy secure-cloud provider tag. Basilica secure-cloud \
+         V2 uses public availability zone root names instead; update \
+         provider/region inputs to public availability zone root and region \
+         values.",
+        provider.trim()
+    );
+}
 
 /// Calculate hourly and monthly cost for a given size
 fn calculate_volume_cost(size_gb: u32) -> (f64, f64) {
@@ -117,7 +141,7 @@ fn prompt_region(provider: &str) -> Result<String, CliError> {
     println!(
         "{}",
         style(
-            "Note: Volumes can only be attached to rentals in the same availability-zone root and region.",
+            "Note: Volumes can only be attached to rentals in the same availability zone root and region.",
         )
         .dim()
     );
@@ -135,7 +159,6 @@ fn prompt_region(provider: &str) -> Result<String, CliError> {
 
 fn validate_volume_provider(provider: &str) -> Result<String, CliError> {
     let provider = provider.trim();
-    basilica_sdk::types::warn_if_legacy_secure_cloud_provider(provider);
     if VOLUME_PROVIDERS.iter().any(|(p, _)| *p == provider) {
         Ok(provider.to_string())
     } else {
@@ -269,7 +292,7 @@ async fn select_volume(
     Ok(filtered_volumes[selection].clone())
 }
 
-/// Select a rental compatible with a volume (same availability-zone root and region)
+/// Select a rental compatible with a volume (same availability zone root and region)
 ///
 /// # Arguments
 /// * `client` - Basilica client
@@ -292,7 +315,7 @@ async fn select_rental_for_volume(
         .chain(cpu_rentals.rentals.iter())
         .collect();
 
-    // Filter for active rentals in the same availability-zone root and region
+    // Filter for active rentals in the same availability zone root and region
     let compatible_rentals: Vec<_> = all_rentals
         .into_iter()
         .filter(|r| {
@@ -324,7 +347,7 @@ async fn select_rental_for_volume(
         return Err(CliError::Internal(color_eyre::eyre::eyre!(
             "No compatible rentals found.\n\n\
              Volume '{}' is in availability zone '{}/{}'.\n\
-             You need an active rental in the same availability-zone root and region to attach this volume.\n\n\
+             You need an active rental in the same availability zone root and region to attach this volume.\n\n\
              Start a new rental with: basilica up --compute secure-cloud",
             volume.name,
             volume.provider,
@@ -432,7 +455,12 @@ pub async fn handle_create_volume(
 ) -> Result<(), CliError> {
     // Get provider first (needed for region selection)
     let provider = match provider {
-        Some(p) => validate_volume_provider(&p)?,
+        Some(p) => {
+            if !json && is_legacy_volume_provider(&p) {
+                warn_legacy_volume_provider(&p);
+            }
+            validate_volume_provider(&p)?
+        }
         None => prompt_provider()?,
     };
 
@@ -847,6 +875,9 @@ mod tests {
 
     #[test]
     fn rejects_legacy_volume_provider_and_regions() {
+        assert!(is_legacy_volume_provider("hyperstack"));
+        assert!(is_legacy_volume_provider(" MASSCOMPUTE "));
+        assert!(!is_legacy_volume_provider("cyan"));
         assert!(validate_volume_provider("hyperstack").is_err());
         assert!(validate_volume_region("cyan", "US-1").is_err());
         assert!(validate_volume_region("cyan", "us-east-1").is_err());

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,14 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Distributed provider filters now document and use Basilica public
+  availability zone root names such as `cyan`, `plum`, or `opal`.
+- Distributed deploy calls now emit a native Python `UserWarning` before
+  calling into the Rust extension when `ProviderFilter.include` or
+  `ProviderFilter.exclude` contains a legacy secure-cloud provider tag such as
+  `hyperstack` or `verda`.
+
 ## [0.31.2] - 2026-06-09
 
 ### Changed
-- `GpuOffering.provider` now accepts any provider/availability-zone value the
-  API emits (e.g. AZ-root codenames `cyan`, `plum`, `opal`), with the region in
-  the separate `region` field. It is still surfaced to Python as a string — no
-  Python API change — but the underlying decode no longer goes through a fixed
-  enum, so new providers/AZs work without an SDK release. Previously
+- `GpuOffering.provider` now accepts any provider/availability zone value the
+  API emits (e.g. availability zone root codenames `cyan`, `plum`, `opal`),
+  with the region in the separate `region` field. It is still surfaced to
+  Python as a string — no Python API change — but the underlying decode no
+  longer goes through a fixed enum, so new providers/availability zones work
+  without an SDK release. Previously
   `list_secure_cloud_gpus()` failed against a newer API with
   `unknown variant ...`.
 

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Distributed provider filters now document and use Basilica public
-  availability zone root names such as `cyan`, `plum`, or `opal`.
+- Secure-cloud GPU, CPU, rental, and volume methods now call the V2 API paths
+  under `/v2/secure-cloud/*`.
 - Distributed deploy calls now emit a native Python `UserWarning` before
   calling into the Rust extension when `ProviderFilter.include` or
   `ProviderFilter.exclude` contains a legacy secure-cloud provider tag such as
@@ -19,12 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.31.2] - 2026-06-09
 
 ### Changed
-- `GpuOffering.provider` now accepts any provider/availability zone value the
-  API emits (e.g. availability zone root codenames `cyan`, `plum`, `opal`),
-  with the region in the separate `region` field. It is still surfaced to
-  Python as a string — no Python API change — but the underlying decode no
-  longer goes through a fixed enum, so new providers/availability zones work
-  without an SDK release. Previously
+- `GpuOffering.provider` now accepts any provider/availability-zone value the
+  API emits (e.g. AZ-root codenames `cyan`, `plum`, `opal`), with the region in
+  the separate `region` field. It is still surfaced to Python as a string — no
+  Python API change — but the underlying decode no longer goes through a fixed
+  enum, so new providers/AZs work without an SDK release. Previously
   `list_secure_cloud_gpus()` failed against a newer API with
   `unknown variant ...`.
 

--- a/crates/basilica-sdk-python/README.md
+++ b/crates/basilica-sdk-python/README.md
@@ -519,12 +519,12 @@ Every method has an `_async` counterpart (`training.scale_async(...)`,
 
 ### `bench=True` — the diagnostic for "is my code slow or is the network slow?"
 
-NCCL collective bandwidth varies with AZ root, region, GPU model, and current
+NCCL collective bandwidth varies with availability zone root, region, GPU model, and current
 mesh load. Without a measurement, the user has to guess whether slow training
 is their code or the network.
 
 `bench=True` opts in to a 2-rank `all_reduce_perf` probe that runs alongside
-your workers on the same AZ-root mesh with the same WireGuard transport. The
+your workers on the same availability zone root mesh with the same WireGuard transport. The
 result lands on `training.bench` after the UD reaches a terminal state:
 
 ```python
@@ -728,11 +728,11 @@ class WorldSize:
 
 @dataclass(frozen=True)
 class ProviderFilter:
-    """Inclusive/exclusive public AZ-root filter for worker scheduling.
+    """Inclusive/exclusive public availability zone root filter for worker scheduling.
 
-    Match is against Basilica public AZ-root names (`cyan`, `plum`, `opal`).
-    With `topology_spread="pack"`, the autoscaler picks ONE AZ root from
-    the include-list and all workers pack on it.
+    Match is against Basilica public availability zone root names (`cyan`,
+    `plum`, `opal`). With `topology_spread="pack"`, the autoscaler picks ONE
+    availability zone root from the include-list and all workers pack on it.
     """
     include: List[str] = []
     exclude: List[str] = []

--- a/crates/basilica-sdk-python/README.md
+++ b/crates/basilica-sdk-python/README.md
@@ -415,7 +415,7 @@ from basilica import ProviderFilter, WorldSize
     min_gpu_memory_gb=40,
     cpu="8",
     memory="32Gi",
-    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",
     bench=True,
     nccl_env={"NCCL_DEBUG": "WARN"},
@@ -480,7 +480,7 @@ training = basilica.distributed(
     world_size=WorldSize(min=2, target=2, max=4),
     gpu_count=1,
     gpu_models=["A100"],
-    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",
     ttl_seconds=900,
 )
@@ -519,12 +519,12 @@ Every method has an `_async` counterpart (`training.scale_async(...)`,
 
 ### `bench=True` — the diagnostic for "is my code slow or is the network slow?"
 
-NCCL collective bandwidth varies with provider, region, GPU model, and current
+NCCL collective bandwidth varies with AZ root, region, GPU model, and current
 mesh load. Without a measurement, the user has to guess whether slow training
 is their code or the network.
 
 `bench=True` opts in to a 2-rank `all_reduce_perf` probe that runs alongside
-your workers on the same provider mesh with the same WireGuard transport. The
+your workers on the same AZ-root mesh with the same WireGuard transport. The
 result lands on `training.bench` after the UD reaches a terminal state:
 
 ```python
@@ -538,7 +538,7 @@ from basilica import ProviderFilter, WorldSize
     world_size=WorldSize(min=2, target=2, max=2),
     gpu_count=1,
     gpu_models=["A100"],
-    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",
     bench=True,
 )
@@ -585,7 +585,7 @@ from basilica import ProviderFilter, WorldSize
     world_size=WorldSize(min=2, target=2, max=2),
     gpu_count=1,
     gpu_models=["A100"],
-    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",
 )
 def run_script() -> None:
@@ -728,12 +728,11 @@ class WorldSize:
 
 @dataclass(frozen=True)
 class ProviderFilter:
-    """Inclusive/exclusive cloud-provider filter for worker scheduling.
+    """Inclusive/exclusive public AZ-root filter for worker scheduling.
 
-    Match is against the `basilica.ai/provider` node label
-    (`hyperstack`, `verda`, `masscompute`, `shadeform`). With
-    `topology_spread="pack"`, the autoscaler picks ONE provider from the
-    include-list and all workers pack on it.
+    Match is against Basilica public AZ-root names (`cyan`, `plum`, `opal`).
+    With `topology_spread="pack"`, the autoscaler picks ONE AZ root from
+    the include-list and all workers pack on it.
     """
     include: List[str] = []
     exclude: List[str] = []

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -34,7 +34,7 @@ Distributed training (NCCL collectives -- DDP, DiLoCo, FSDP):
     ...     world_size=WorldSize(min=2, target=2, max=2),
     ...     gpu_count=1,
     ...     gpu_models=["A100"],
-    ...     provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    ...     provider_filter=ProviderFilter(include=["cyan", "plum"]),
     ...     topology_spread="pack",
     ...     bench=True,
     ... )

--- a/crates/basilica-sdk-python/python/basilica/__init__.py
+++ b/crates/basilica-sdk-python/python/basilica/__init__.py
@@ -221,6 +221,48 @@ from .source import SourcePackager
 from .spec import DeploymentSpec
 from .volume import Volume
 
+_LEGACY_SECURE_CLOUD_PROVIDERS = {
+    "datacrunch",
+    "denvr",
+    "hydrahost",
+    "hyperstack",
+    "lambda",
+    "masscompute",
+    "shadeform",
+    "verda",
+}
+
+
+def _legacy_provider_filter_values(
+    provider_filter: Optional[ProviderFilter],
+) -> List[str]:
+    if provider_filter is None:
+        return []
+
+    legacy_values: List[str] = []
+    seen = set()
+    for value in list(provider_filter.include) + list(provider_filter.exclude):
+        normalized = value.strip().lower()
+        if normalized in _LEGACY_SECURE_CLOUD_PROVIDERS and normalized not in seen:
+            legacy_values.append(value.strip())
+            seen.add(normalized)
+    return legacy_values
+
+
+def _warn_legacy_provider_filter(provider_filter: Optional[ProviderFilter]) -> None:
+    legacy_values = _legacy_provider_filter_values(provider_filter)
+    if not legacy_values:
+        return
+
+    warnings.warn(
+        "ProviderFilter contains legacy secure-cloud provider tag(s): "
+        f"{', '.join(legacy_values)}. Basilica secure-cloud V2 uses public "
+        "availability zone root names instead; update provider_filter "
+        "include/exclude values to public availability zone root values.",
+        UserWarning,
+        stacklevel=3,
+    )
+
 # Default command is a list in Python
 DEFAULT_COMMAND = ["/bin/bash"]
 
@@ -1349,6 +1391,7 @@ class BasilicaClient:
             enable_billing=enable_billing,
         )
 
+        _warn_legacy_provider_filter(provider_filter)
         response = self._client.create_distributed_deployment(request_dict)
         training = DistributedTraining(self, response.instance_name)
         training.refresh()
@@ -2448,6 +2491,7 @@ class BasilicaClient:
             enable_billing=enable_billing,
         )
 
+        _warn_legacy_provider_filter(provider_filter)
         loop = asyncio.get_event_loop()
         response = await loop.run_in_executor(
             None, self._client.create_distributed_deployment, request_dict

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -569,16 +569,14 @@ def distributed(
             short-circuits on ``WorldSize(...)``-construction if the
             triple violates ``1 <= min <= target <= max``.
         provider_filter: ``ProviderFilter(include=[...], exclude=[...])``
-            or the dict equivalent. With ``topology_spread="pack"``, the
-            autoscaler picks ONE provider from ``include`` (cheapest
-            available with capacity, or via your platform's
-            ``secureCloud.preferredProvider``) and packs all workers on
-            it; the include-list is a fallback set, not a multi-provider
-            requirement. Mesh-enabled providers today: ``verda``,
-            ``hyperstack``.
+            or the dict equivalent. Values are Basilica public AZ-root
+            names such as ``cyan``, ``plum``, or ``opal``. With
+            ``topology_spread="pack"``, the autoscaler picks ONE AZ root
+            from ``include`` and packs all workers on it; the include-list
+            is a fallback set, not a multi-AZ requirement.
         topology_spread: One of ``pack | provider-aware | region-aware |
             none``. ``"pack"`` is recommended for NCCL-collective
-            workloads -- it forces same-provider direct WireGuard mesh,
+            workloads -- it forces same-AZ-root direct WireGuard mesh,
             which is 5-10x faster than the hub-relay fallback. Default
             ``"provider-aware"``.
         nccl_env: NCCL environment variables merged on top of operator
@@ -586,7 +584,7 @@ def distributed(
             ``{"NCCL_DEBUG": "WARN"}`` to surface NCCL diagnostics
             without flooding logs.
         bench: ``True`` opts in to the per-UD NCCL bench probe -- a
-            2-rank ``all_reduce_perf`` measurement on the same provider
+            2-rank ``all_reduce_perf`` measurement on the same AZ-root
             mesh as your workers. Read back as ``training.bench``
             (``BenchResult | None`` -- ``None`` means "no measurement",
             regardless of why). Use ``training.bench_diagnostics`` for

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -573,12 +573,12 @@ def distributed(
             zone root names such as ``cyan``, ``plum``, or ``opal``. With
             ``topology_spread="pack"``, the autoscaler picks ONE availability
             zone root from ``include`` and packs all workers on it; the
-            include-list is a fallback set, not a multi-availability-zone
+            include-list is a fallback set, not a multi-availability zone root
             requirement.
         topology_spread: One of ``pack | provider-aware | region-aware |
             none``. ``"pack"`` is recommended for NCCL-collective
-            workloads -- it forces same-availability-zone-root direct WireGuard mesh,
-            which is 5-10x faster than the hub-relay fallback. Default
+            workloads -- it forces same availability zone root direct WireGuard
+            mesh, which is 5-10x faster than the hub-relay fallback. Default
             ``"provider-aware"``.
         nccl_env: NCCL environment variables merged on top of operator
             defaults. User values win on collision. Common pattern:

--- a/crates/basilica-sdk-python/python/basilica/decorators.py
+++ b/crates/basilica-sdk-python/python/basilica/decorators.py
@@ -569,14 +569,15 @@ def distributed(
             short-circuits on ``WorldSize(...)``-construction if the
             triple violates ``1 <= min <= target <= max``.
         provider_filter: ``ProviderFilter(include=[...], exclude=[...])``
-            or the dict equivalent. Values are Basilica public AZ-root
-            names such as ``cyan``, ``plum``, or ``opal``. With
-            ``topology_spread="pack"``, the autoscaler picks ONE AZ root
-            from ``include`` and packs all workers on it; the include-list
-            is a fallback set, not a multi-AZ requirement.
+            or the dict equivalent. Values are Basilica public availability
+            zone root names such as ``cyan``, ``plum``, or ``opal``. With
+            ``topology_spread="pack"``, the autoscaler picks ONE availability
+            zone root from ``include`` and packs all workers on it; the
+            include-list is a fallback set, not a multi-availability-zone
+            requirement.
         topology_spread: One of ``pack | provider-aware | region-aware |
             none``. ``"pack"`` is recommended for NCCL-collective
-            workloads -- it forces same-AZ-root direct WireGuard mesh,
+            workloads -- it forces same-availability-zone-root direct WireGuard mesh,
             which is 5-10x faster than the hub-relay fallback. Default
             ``"provider-aware"``.
         nccl_env: NCCL environment variables merged on top of operator
@@ -584,7 +585,7 @@ def distributed(
             ``{"NCCL_DEBUG": "WARN"}`` to surface NCCL diagnostics
             without flooding logs.
         bench: ``True`` opts in to the per-UD NCCL bench probe -- a
-            2-rank ``all_reduce_perf`` measurement on the same AZ-root
+            2-rank ``all_reduce_perf`` measurement on the same availability zone root
             mesh as your workers. Read back as ``training.bench``
             (``BenchResult | None`` -- ``None`` means "no measurement",
             regardless of why). Use ``training.bench_diagnostics`` for

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -138,10 +138,10 @@ class WorldSize:
 @dataclass(frozen=True)
 class ProviderFilter:
     """
-    Public AZ-root include/exclude lists for worker scheduling.
+    Public availability zone root include/exclude lists for worker scheduling.
 
-    Empty `include` = any AZ. Match is on Basilica public AZ-root names
-    (`cyan`, `plum`, `opal`).
+    Empty `include` = any availability zone root. Match is on Basilica public
+    availability zone root names (`cyan`, `plum`, `opal`).
     `exclude` is subtractive after `include`.
     """
 
@@ -171,9 +171,9 @@ class RankStatus:
     """
     Per-rank pod observation. Read-only.
 
-    `provider` is the Basilica public AZ-root name and `region` is the
-    public region segment; both are `None` when the pod has not scheduled
-    or the labels are absent.
+    `provider` is the Basilica public availability zone root name and
+    `region` is the public region segment; both are `None` when the pod has
+    not scheduled or the labels are absent.
     """
 
     rank: int

--- a/crates/basilica-sdk-python/python/basilica/distributed.py
+++ b/crates/basilica-sdk-python/python/basilica/distributed.py
@@ -138,10 +138,10 @@ class WorldSize:
 @dataclass(frozen=True)
 class ProviderFilter:
     """
-    Provider include/exclude lists for worker scheduling.
+    Public AZ-root include/exclude lists for worker scheduling.
 
-    Empty `include` = any provider. Match is on the `basilica.ai/provider`
-    node label (`hyperstack`, `verda`, `masscompute`, `shadeform`).
+    Empty `include` = any AZ. Match is on Basilica public AZ-root names
+    (`cyan`, `plum`, `opal`).
     `exclude` is subtractive after `include`.
     """
 
@@ -171,8 +171,9 @@ class RankStatus:
     """
     Per-rank pod observation. Read-only.
 
-    `provider` and `region` come from node labels; `None` when the pod
-    has not been scheduled or the labels are absent.
+    `provider` is the Basilica public AZ-root name and `region` is the
+    public region segment; both are `None` when the pod has not scheduled
+    or the labels are absent.
     """
 
     rank: int

--- a/crates/basilica-sdk-python/tests/test_decorator_source_extraction.py
+++ b/crates/basilica-sdk-python/tests/test_decorator_source_extraction.py
@@ -32,7 +32,7 @@ from basilica import ProviderFilter, WorldSize
     world_size=WorldSize(min=1, target=1, max=1),
     gpu_count=1,
     gpu_models=["H100"],
-    provider_filter=ProviderFilter(include=["hyperstack"]),
+    provider_filter=ProviderFilter(include=["cyan"]),
 )
 def _train_with_module_imports() -> None:
     """Fixture: references `os` and `time` from module-level scope."""
@@ -47,7 +47,7 @@ def _train_with_module_imports() -> None:
     world_size=WorldSize(min=1, target=1, max=1),
     gpu_count=1,
     gpu_models=["H100"],
-    provider_filter=ProviderFilter(include=["hyperstack"]),
+    provider_filter=ProviderFilter(include=["cyan"]),
 )
 def _train_with_aliased_import() -> None:
     """Fixture: references `Optional` from a `from typing import Optional`."""
@@ -61,7 +61,7 @@ def _train_with_aliased_import() -> None:
     world_size=WorldSize(min=1, target=1, max=1),
     gpu_count=1,
     gpu_models=["H100"],
-    provider_filter=ProviderFilter(include=["hyperstack"]),
+    provider_filter=ProviderFilter(include=["cyan"]),
 )
 def _train_no_module_imports() -> None:
     """Fixture: only references built-ins, no module-level imports."""
@@ -74,7 +74,7 @@ def _train_no_module_imports() -> None:
     world_size=WorldSize(min=1, target=1, max=1),
     gpu_count=1,
     gpu_models=["H100"],
-    provider_filter=ProviderFilter(include=["hyperstack"]),
+    provider_filter=ProviderFilter(include=["cyan"]),
 )
 def _train_uses_os_only() -> None:
     """

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -593,7 +593,7 @@ class TestBuildDistributedRequest:
             gpu_models=["A100"],
             min_gpu_memory_gb=40,
             world_size=WorldSize(min=2, target=4, max=8),
-            provider_filter=ProviderFilter(include=["verda"], exclude=[]),
+            provider_filter=ProviderFilter(include=["cyan"], exclude=[]),
             topology_spread="provider-aware",
             nccl_env={"NCCL_DEBUG": "WARN"},
             bench="on-start",
@@ -610,7 +610,7 @@ class TestBuildDistributedRequest:
         assert d["enabled"] is True
         assert d["worldSize"] == {"min": 2, "target": 4, "max": 8}
         assert d["rendezvous"]["backend"] == "etcd-v2"
-        assert d["providerFilter"]["include"] == ["verda"]
+        assert d["providerFilter"]["include"] == ["cyan"]
         assert d["providerFilter"]["exclude"] == []
         assert d["topologySpread"]["strategy"] == "provider-aware"
         assert d["bench"]["mode"] == "on-start"
@@ -1389,7 +1389,7 @@ class TestDistributedDecorator:
         @distributed(
             name="dlc-pf-dict",
             world_size=WorldSize(min=1, target=1, max=1),
-            provider_filter={"include": ["hyperstack"], "exclude": ["masscompute"]},
+            provider_filter={"include": ["cyan"], "exclude": ["opal"]},
             gpu_count=1,
         )
         def train_fn() -> None:
@@ -1397,8 +1397,8 @@ class TestDistributedDecorator:
 
         pf = train_fn._kwargs["provider_filter"]
         assert isinstance(pf, ProviderFilter)
-        assert pf.include == ["hyperstack"]
-        assert pf.exclude == ["masscompute"]
+        assert pf.include == ["cyan"]
+        assert pf.exclude == ["opal"]
 
     def test_decorator_requires_world_size(self) -> None:
         with pytest.raises(ValueError, match="world_size"):
@@ -1500,8 +1500,8 @@ class TestIssue449DeploymentResponseDistributed:
                         "rank": 0,
                         "podName": "dlc-449-mock-0",
                         "nodeName": "basilica-verda-fin-03",
-                        "provider": "verda",
-                        "region": "FIN-03",
+                        "provider": "cyan",
+                        "region": "us-texas-1",
                         "phase": "Running",
                         "restarts": 0,
                     },
@@ -1509,8 +1509,8 @@ class TestIssue449DeploymentResponseDistributed:
                         "rank": 1,
                         "podName": "dlc-449-mock-1",
                         "nodeName": "basilica-verda-fin-04",
-                        "provider": "verda",
-                        "region": "FIN-04",
+                        "provider": "cyan",
+                        "region": "us-texas-1",
                         "phase": "Running",
                         "restarts": 0,
                     },
@@ -1552,12 +1552,12 @@ class TestIssue449DeploymentResponseDistributed:
         assert ranks[0].rank == 0
         assert ranks[0].pod_name == "dlc-449-mock-0"
         assert ranks[0].node == "basilica-verda-fin-03"
-        assert ranks[0].provider == "verda"
-        assert ranks[0].region == "FIN-03"
+        assert ranks[0].provider == "cyan"
+        assert ranks[0].region == "us-texas-1"
         assert ranks[0].phase == "Running"
         assert ranks[1].rank == 1
         assert ranks[1].pod_name == "dlc-449-mock-1"
-        assert ranks[1].provider == "verda"
+        assert ranks[1].provider == "cyan"
 
     def test_bench_returns_populated_result(self) -> None:
         client = MagicMock()
@@ -1690,8 +1690,8 @@ class TestIssue454DeploymentWrapperCarriesDistributed:
                         "rank": 0,
                         "podName": "dlc-454-mock-0",
                         "nodeName": "basilica-verda-fin-03",
-                        "provider": "verda",
-                        "region": "FIN-03",
+                        "provider": "cyan",
+                        "region": "us-texas-1",
                         "phase": "Running",
                         "restarts": 0,
                     },
@@ -1699,8 +1699,8 @@ class TestIssue454DeploymentWrapperCarriesDistributed:
                         "rank": 1,
                         "podName": "dlc-454-mock-1",
                         "nodeName": "basilica-verda-fin-04",
-                        "provider": "verda",
-                        "region": "FIN-04",
+                        "provider": "cyan",
+                        "region": "us-texas-1",
                         "phase": "Running",
                         "restarts": 0,
                     },

--- a/crates/basilica-sdk-python/tests/test_distributed.py
+++ b/crates/basilica-sdk-python/tests/test_distributed.py
@@ -17,6 +17,7 @@ DNS-1035 fix lands in basilica-api.
 """
 
 import asyncio
+import warnings
 from typing import Any, Dict
 from unittest.mock import MagicMock
 
@@ -2276,6 +2277,86 @@ def _build_minimal_client() -> BasilicaClient:
     client._base_url = "https://api.test.invalid"
     client._client = MagicMock()
     return client
+
+
+class TestDeployDistributedLegacyProviderWarnings:
+    def _wire_ready(self, client: BasilicaClient) -> MagicMock:
+        response = _pyo3_response(
+            "dlc-provider-warning",
+            "u-test",
+            {
+                "worldSize": {
+                    "ready": 2,
+                    "target": 2,
+                    "min": 2,
+                    "max": 2,
+                    "belowMinimum": False,
+                },
+                "ranks": [],
+            },
+        )
+        client._client.create_distributed_deployment.return_value = response
+        client._client.get_deployment.return_value = response
+        return response
+
+    def test_warns_before_sync_pyo3_call_for_legacy_provider_filter(self) -> None:
+        client = _build_minimal_client()
+        self._wire_ready(client)
+
+        with pytest.warns(UserWarning, match="legacy secure-cloud provider"):
+            client._deploy_distributed_impl(
+                name="dlc-provider-warning",
+                source=_noop_train,
+                world_size=WorldSize(min=2, target=2, max=2),
+                provider_filter=ProviderFilter(
+                    include=["hyperstack"],
+                    exclude=["MASSCOMPUTE", "hyperstack"],
+                ),
+                timeout=10,
+            )
+
+        request = client._client.create_distributed_deployment.call_args.args[0]
+        assert request["distributed"]["providerFilter"]["include"] == ["hyperstack"]
+        assert request["distributed"]["providerFilter"]["exclude"] == [
+            "MASSCOMPUTE",
+            "hyperstack",
+        ]
+
+    def test_does_not_warn_for_public_availability_zone_filter(self) -> None:
+        client = _build_minimal_client()
+        self._wire_ready(client)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client._deploy_distributed_impl(
+                name="dlc-az-filter",
+                source=_noop_train,
+                world_size=WorldSize(min=2, target=2, max=2),
+                provider_filter=ProviderFilter(include=["cyan"], exclude=["opal"]),
+                timeout=10,
+            )
+
+        assert not [
+            warning
+            for warning in caught
+            if "legacy secure-cloud provider" in str(warning.message)
+        ]
+
+    def test_warns_before_async_pyo3_call_for_legacy_provider_filter(self) -> None:
+        client = _build_minimal_client()
+        self._wire_ready(client)
+
+        async def run() -> None:
+            await client._deploy_distributed_impl_async(
+                name="dlc-provider-warning",
+                source=_noop_train,
+                world_size=WorldSize(min=2, target=2, max=2),
+                provider_filter=ProviderFilter(include=["shadeform"]),
+                timeout=10,
+            )
+
+        with pytest.warns(UserWarning, match="legacy secure-cloud provider"):
+            asyncio.run(run())
 
 
 class TestDeployDistributedCleanupOnFailure:

--- a/crates/basilica-sdk-python/tests/test_gpu_flavour_preferences.py
+++ b/crates/basilica-sdk-python/tests/test_gpu_flavour_preferences.py
@@ -3,7 +3,7 @@ Functional tests for GPU Flavour Preferences.
 
 Tests the full SDK path: type construction -> API call -> response parsing.
 
-Note: Tests that hit /secure-cloud/gpu-prices require a token with
+Note: Tests that hit /v2/secure-cloud/gpu-prices require a token with
 secure-cloud permissions. They are skipped when the token lacks access.
 """
 import pytest

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -8,20 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Secure-cloud GPU, CPU, and volume methods now call the V2 API paths under
-  `/v2/secure-cloud/*`, where provider fields carry Basilica public
-  availability zone root names such as `cyan`, `plum`, or `opal`.
+- Secure-cloud GPU, CPU, rental, and volume methods now call the V2 API paths
+  under `/v2/secure-cloud/*`.
 
 ## [0.31.2] - 2026-06-09
 
 ### Changed
 - `GpuOffering.provider` is now a free-form `String` instead of the
   `CloudProvider` enum, and the `CloudProvider` enum has been removed. The API
-  wire boundary emits availability zone root codenames (e.g. `cyan`, `plum`,
+  wire boundary emits availability-zone root codenames (e.g. `cyan`, `plum`,
   `opal`) in `provider`, with the region in the separate `region` field. Keeping
-  this a `String` means new providers/availability zones deserialize cleanly
-  without an SDK release; the previous enum rejected unknown values with
-  `unknown variant ...`, breaking every GPU listing call against a newer API.
+  this a `String` means new providers/AZs deserialize cleanly without an SDK
+  release; the previous enum rejected unknown values with `unknown variant ...`,
+  breaking every GPU listing call against a newer API.
 
 ## [0.29.0] - 2026-05-04
 

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/v2/secure-cloud/*`.
 - `create_volume()` prints a temporary stderr warning when callers pass a
   legacy secure-cloud provider tag such as `hyperstack` or `verda`; V2 volume
-  requests should use public availability-zone names such as `cyan` with
-  regions such as `us-texas-1`.
+  requests should use public availability-zone values.
+- `create_distributed_deployment()` prints the same temporary stderr warning
+  when `providerFilter.include` or `providerFilter.exclude` contains legacy
+  secure-cloud provider tags.
 
 ## [0.31.2] - 2026-06-09
 

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Secure-cloud GPU, CPU, and volume methods now call the V2 API paths under
+  `/v2/secure-cloud/*`.
+- `create_volume()` prints a temporary stderr warning when callers pass a
+  legacy secure-cloud provider tag such as `hyperstack` or `verda`; V2 volume
+  requests should use public availability-zone names such as `cyan` with
+  regions such as `us-texas-1`.
+
 ## [0.31.2] - 2026-06-09
 
 ### Changed

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -9,24 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Secure-cloud GPU, CPU, and volume methods now call the V2 API paths under
-  `/v2/secure-cloud/*`.
-- `create_volume()` prints a temporary stderr warning when callers pass a
-  legacy secure-cloud provider tag such as `hyperstack` or `verda`; V2 volume
-  requests should use public availability-zone values.
-- `create_distributed_deployment()` prints the same temporary stderr warning
-  when `providerFilter.include` or `providerFilter.exclude` contains legacy
-  secure-cloud provider tags.
+  `/v2/secure-cloud/*`, where provider fields carry Basilica public
+  availability zone root names such as `cyan`, `plum`, or `opal`.
 
 ## [0.31.2] - 2026-06-09
 
 ### Changed
 - `GpuOffering.provider` is now a free-form `String` instead of the
   `CloudProvider` enum, and the `CloudProvider` enum has been removed. The API
-  wire boundary emits availability-zone root codenames (e.g. `cyan`, `plum`,
+  wire boundary emits availability zone root codenames (e.g. `cyan`, `plum`,
   `opal`) in `provider`, with the region in the separate `region` field. Keeping
-  this a `String` means new providers/AZs deserialize cleanly without an SDK
-  release; the previous enum rejected unknown values with `unknown variant ...`,
-  breaking every GPU listing call against a newer API.
+  this a `String` means new providers/availability zones deserialize cleanly
+  without an SDK release; the previous enum rejected unknown values with
+  `unknown variant ...`, breaking every GPU listing call against a newer API.
 
 ## [0.29.0] - 2026-05-04
 

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -535,12 +535,12 @@ impl BasilicaClient {
     ///
     /// # Arguments
     ///
-    /// * `request` - Volume creation parameters including name, size, AZ root, and region
+    /// * `request` - Volume creation parameters including name, size,
+    ///   availability zone root, and region
     pub async fn create_volume(
         &self,
         request: crate::types::CreateVolumeRequest,
     ) -> Result<crate::types::VolumeResponse> {
-        crate::types::warn_if_legacy_secure_cloud_provider(&request.provider);
         self.post("/v2/secure-cloud/volumes", &request).await
     }
 
@@ -564,7 +564,7 @@ impl BasilicaClient {
     /// Attach a volume to a rental
     ///
     /// Attaches a volume to a running secure cloud rental.
-    /// The volume and rental must be in the same availability-zone root and region.
+    /// The volume and rental must be in the same availability zone root and region.
     ///
     /// # Arguments
     ///
@@ -985,10 +985,6 @@ impl BasilicaClient {
         &self,
         request: CreateDistributedDeploymentRequest,
     ) -> Result<DeploymentResponse> {
-        request
-            .distributed
-            .provider_filter
-            .warn_if_legacy_secure_cloud_providers();
         self.post("/deployments", &request).await
     }
 

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -540,6 +540,7 @@ impl BasilicaClient {
         &self,
         request: crate::types::CreateVolumeRequest,
     ) -> Result<crate::types::VolumeResponse> {
+        crate::types::warn_if_legacy_secure_cloud_provider(&request.provider);
         self.post("/v2/secure-cloud/volumes", &request).await
     }
 

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -470,7 +470,7 @@ impl BasilicaClient {
         &self,
         query: &crate::types::GpuPriceQuery,
     ) -> Result<Vec<crate::types::GpuOffering>> {
-        let mut url = String::from("/secure-cloud/gpu-prices?available_only=true");
+        let mut url = String::from("/v2/secure-cloud/gpu-prices?available_only=true");
         if let Some(ref interconnect) = query.interconnect {
             url.push_str(&format!("&interconnect={}", interconnect));
         }
@@ -494,7 +494,7 @@ impl BasilicaClient {
     pub async fn list_secure_cloud_rentals(
         &self,
     ) -> Result<crate::types::ListSecureCloudRentalsResponse> {
-        self.get("/secure-cloud/rentals").await
+        self.get("/v2/secure-cloud/rentals").await
     }
 
     /// Start a secure cloud rental
@@ -505,7 +505,7 @@ impl BasilicaClient {
         &self,
         request: crate::types::StartSecureCloudRentalRequest,
     ) -> Result<crate::types::SecureCloudRentalResponse> {
-        self.post("/secure-cloud/rentals/start", &request).await
+        self.post("/v2/secure-cloud/rentals/start", &request).await
     }
 
     /// Stop a secure cloud rental
@@ -515,7 +515,7 @@ impl BasilicaClient {
         &self,
         rental_id: &str,
     ) -> Result<crate::types::StopSecureCloudRentalResponse> {
-        let path = format!("/secure-cloud/rentals/{}/stop", rental_id);
+        let path = format!("/v2/secure-cloud/rentals/{}/stop", rental_id);
         self.post(&path, &serde_json::json!({})).await
     }
 
@@ -525,7 +525,7 @@ impl BasilicaClient {
     ///
     /// Returns all volumes including their status, size, and cost information.
     pub async fn list_volumes(&self) -> Result<crate::types::ListVolumesResponse> {
-        self.get("/secure-cloud/volumes").await
+        self.get("/v2/secure-cloud/volumes").await
     }
 
     /// Create a new volume
@@ -540,7 +540,7 @@ impl BasilicaClient {
         &self,
         request: crate::types::CreateVolumeRequest,
     ) -> Result<crate::types::VolumeResponse> {
-        self.post("/secure-cloud/volumes", &request).await
+        self.post("/v2/secure-cloud/volumes", &request).await
     }
 
     /// Delete a volume
@@ -551,7 +551,7 @@ impl BasilicaClient {
     ///
     /// * `volume_id` - The volume ID to delete
     pub async fn delete_volume(&self, volume_id: &str) -> Result<()> {
-        let path = format!("/secure-cloud/volumes/{}", volume_id);
+        let path = format!("/v2/secure-cloud/volumes/{}", volume_id);
         let response = self.delete_empty(&path).await?;
         if response.status().is_success() {
             Ok(())
@@ -574,7 +574,7 @@ impl BasilicaClient {
         volume_id: &str,
         request: crate::types::AttachVolumeRequest,
     ) -> Result<crate::types::VolumeOperationResponse> {
-        let path = format!("/secure-cloud/volumes/{}/attach", volume_id);
+        let path = format!("/v2/secure-cloud/volumes/{}/attach", volume_id);
         self.post(&path, &request).await
     }
 
@@ -589,7 +589,7 @@ impl BasilicaClient {
         &self,
         volume_id: &str,
     ) -> Result<crate::types::VolumeOperationResponse> {
-        let path = format!("/secure-cloud/volumes/{}/detach", volume_id);
+        let path = format!("/v2/secure-cloud/volumes/{}/detach", volume_id);
         self.post(&path, &serde_json::json!({})).await
     }
 
@@ -601,7 +601,7 @@ impl BasilicaClient {
     /// These have flat hourly rates rather than per-GPU pricing.
     pub async fn list_cpu_offerings(&self) -> Result<Vec<crate::types::CpuOffering>> {
         let response: crate::types::ListCpuOfferingsResponse = self
-            .get("/secure-cloud/cpu-prices?available_only=true")
+            .get("/v2/secure-cloud/cpu-prices?available_only=true")
             .await?;
         Ok(response.nodes)
     }
@@ -611,7 +611,7 @@ impl BasilicaClient {
     /// Returns all CPU-only secure cloud rentals including their status,
     /// IP addresses, and cost information.
     pub async fn list_cpu_rentals(&self) -> Result<crate::types::ListSecureCloudRentalsResponse> {
-        self.get("/secure-cloud/cpu-rentals").await
+        self.get("/v2/secure-cloud/cpu-rentals").await
     }
 
     /// Start a CPU-only rental
@@ -622,7 +622,8 @@ impl BasilicaClient {
         &self,
         request: crate::types::StartSecureCloudRentalRequest,
     ) -> Result<crate::types::SecureCloudRentalResponse> {
-        self.post("/secure-cloud/cpu-rentals/start", &request).await
+        self.post("/v2/secure-cloud/cpu-rentals/start", &request)
+            .await
     }
 
     /// Stop a CPU-only rental
@@ -632,7 +633,7 @@ impl BasilicaClient {
         &self,
         rental_id: &str,
     ) -> Result<crate::types::StopSecureCloudRentalResponse> {
-        let path = format!("/secure-cloud/cpu-rentals/{}/stop", rental_id);
+        let path = format!("/v2/secure-cloud/cpu-rentals/{}/stop", rental_id);
         self.post(&path, &serde_json::json!({})).await
     }
 

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -985,6 +985,10 @@ impl BasilicaClient {
         &self,
         request: CreateDistributedDeploymentRequest,
     ) -> Result<DeploymentResponse> {
+        request
+            .distributed
+            .provider_filter
+            .warn_if_legacy_secure_cloud_providers();
         self.post("/deployments", &request).await
     }
 

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1875,6 +1875,34 @@ pub struct CreateVolumeRequest {
     pub region: String,
 }
 
+/// Returns true when `provider` is a legacy secure-cloud provider tag that is
+/// no longer accepted by the V2 secure-cloud volume API.
+pub fn is_legacy_secure_cloud_provider(provider: &str) -> bool {
+    matches!(
+        provider.trim().to_ascii_lowercase().as_str(),
+        "datacrunch"
+            | "denvr"
+            | "hydrahost"
+            | "hyperstack"
+            | "lambda"
+            | "masscompute"
+            | "shadeform"
+            | "verda"
+    )
+}
+
+/// Print the temporary migration warning for explicit legacy provider input.
+pub fn warn_if_legacy_secure_cloud_provider(provider: &str) {
+    if is_legacy_secure_cloud_provider(provider) {
+        eprintln!(
+            "Warning: '{}' is a legacy secure-cloud provider tag. Basilica secure-cloud \
+             V2 uses public availability-zone names instead; update provider/region \
+             inputs to values such as provider='cyan' and region='us-texas-1'.",
+            provider.trim()
+        );
+    }
+}
+
 /// Attach volume request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttachVolumeRequest {

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -636,7 +636,7 @@ pub struct SecureCloudRentalListItem {
     /// Rental ID
     pub rental_id: String,
 
-    /// Provider name (verda, hyperstack, lambda, hydrahost, etc.)
+    /// Public availability-zone root (e.g., "cyan", "plum", "opal")
     pub provider: String,
 
     /// Provider's instance ID
@@ -1247,9 +1247,8 @@ pub struct DistributedRendezvousSpec {
     pub port: Option<u16>,
 }
 
-/// Provider filter for worker scheduling. Empty `include` = any provider.
-/// Match is on the `basilica.ai/provider` node label (e.g. `hyperstack`,
-/// `verda`, `masscompute`, `shadeform`).
+/// Availability-zone filter for worker scheduling. Empty `include` = any AZ.
+/// Match is on Basilica public AZ-root names (e.g. `cyan`, `plum`, `opal`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DistributedProviderFilter {
@@ -1420,7 +1419,7 @@ pub struct DistributedRankStatus {
     pub pod_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_name: Option<String>,
-    /// `basilica.ai/provider` node label value.
+    /// Basilica public AZ-root name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     /// `basilica.ai/region` node label value.
@@ -1744,7 +1743,7 @@ pub struct CpuOffering {
     /// Unique offering identifier
     pub id: String,
 
-    /// Provider name (e.g., "hyperstack")
+    /// Public availability-zone root (e.g., "cyan")
     pub provider: String,
 
     /// Number of vCPU cores
@@ -2535,7 +2534,7 @@ mod tests {
                 port: None,
             },
             provider_filter: DistributedProviderFilter {
-                include: vec!["hyperstack".to_string(), "verda".to_string()],
+                include: vec!["cyan".to_string(), "plum".to_string()],
                 exclude: vec![],
             },
             topology_spread: DistributedTopologySpread {
@@ -2571,7 +2570,7 @@ mod tests {
             v["rendezvous"].get("port").is_none(),
             "port omitted when None"
         );
-        assert_eq!(v["providerFilter"]["include"][0], "hyperstack");
+        assert_eq!(v["providerFilter"]["include"][0], "cyan");
         assert_eq!(v["topologySpread"]["strategy"], "provider-aware");
         assert_eq!(v["nccl"]["env"]["NCCL_DEBUG"], "INFO");
         assert_eq!(v["bench"]["mode"], "on-start");
@@ -2795,8 +2794,8 @@ mod tests {
                 rank: 0,
                 pod_name: "dlc-test-0".to_string(),
                 node_name: Some("basilica-verda-fin-03".to_string()),
-                provider: Some("verda".to_string()),
-                region: Some("FIN-03".to_string()),
+                provider: Some("cyan".to_string()),
+                region: Some("us-texas-1".to_string()),
                 phase: "Running".to_string(),
                 restarts: 0,
             }],
@@ -2852,8 +2851,8 @@ mod tests {
                         rank: 0,
                         pod_name: "dlc-449-0".to_string(),
                         node_name: Some("basilica-verda-fin-03".to_string()),
-                        provider: Some("verda".to_string()),
-                        region: Some("FIN-03".to_string()),
+                        provider: Some("cyan".to_string()),
+                        region: Some("us-texas-1".to_string()),
                         phase: "Running".to_string(),
                         restarts: 0,
                     },
@@ -2861,8 +2860,8 @@ mod tests {
                         rank: 1,
                         pod_name: "dlc-449-1".to_string(),
                         node_name: Some("basilica-verda-fin-04".to_string()),
-                        provider: Some("verda".to_string()),
-                        region: Some("FIN-04".to_string()),
+                        provider: Some("cyan".to_string()),
+                        region: Some("us-texas-1".to_string()),
                         phase: "Running".to_string(),
                         restarts: 0,
                     },
@@ -2918,7 +2917,7 @@ mod tests {
         assert!(!d.world_size.below_minimum);
         assert_eq!(d.ranks.len(), 2);
         assert_eq!(d.ranks[0].pod_name, "dlc-449-0");
-        assert_eq!(d.ranks[1].provider.as_deref(), Some("verda"));
+        assert_eq!(d.ranks[1].provider.as_deref(), Some("cyan"));
         assert_eq!(d.transport, "hub-relay");
         assert_eq!(d.original_max, Some(3));
         let bench = d.bench.expect("bench present");

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -636,7 +636,7 @@ pub struct SecureCloudRentalListItem {
     /// Rental ID
     pub rental_id: String,
 
-    /// Provider name (verda, hyperstack, lambda, hydrahost)
+    /// Provider name (verda, hyperstack, lambda, hydrahost, etc.)
     pub provider: String,
 
     /// Provider's instance ID
@@ -1257,6 +1257,15 @@ pub struct DistributedProviderFilter {
     pub include: Vec<String>,
     #[serde(default)]
     pub exclude: Vec<String>,
+}
+
+impl DistributedProviderFilter {
+    /// Print the temporary migration warning for legacy provider input.
+    pub fn warn_if_legacy_secure_cloud_providers(&self) {
+        for provider in self.include.iter().chain(self.exclude.iter()) {
+            warn_if_legacy_secure_cloud_provider(provider);
+        }
+    }
 }
 
 /// Topology spread strategy for ranks-to-nodes assignment. SDK arch § 4.
@@ -1897,7 +1906,7 @@ pub fn warn_if_legacy_secure_cloud_provider(provider: &str) {
         eprintln!(
             "Warning: '{}' is a legacy secure-cloud provider tag. Basilica secure-cloud \
              V2 uses public availability-zone names instead; update provider/region \
-             inputs to values such as provider='cyan' and region='us-texas-1'.",
+             inputs to public availability-zone values.",
             provider.trim()
         );
     }
@@ -2705,6 +2714,13 @@ mod tests {
         // matches the operator's CRD field defaults.
         assert_eq!(v["providerFilter"]["include"], serde_json::json!([]));
         assert_eq!(v["providerFilter"]["exclude"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_legacy_secure_cloud_provider_detection_covers_provider_filters() {
+        assert!(is_legacy_secure_cloud_provider("hyperstack"));
+        assert!(is_legacy_secure_cloud_provider(" MASSCOMPUTE "));
+        assert!(!is_legacy_secure_cloud_provider("cyan"));
     }
 
     #[test]

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -636,7 +636,7 @@ pub struct SecureCloudRentalListItem {
     /// Rental ID
     pub rental_id: String,
 
-    /// Public availability-zone root (e.g., "cyan", "plum", "opal")
+    /// Public availability zone root (e.g., "cyan", "plum", "opal")
     pub provider: String,
 
     /// Provider's instance ID
@@ -1259,15 +1259,6 @@ pub struct DistributedProviderFilter {
     pub exclude: Vec<String>,
 }
 
-impl DistributedProviderFilter {
-    /// Print the temporary migration warning for legacy provider input.
-    pub fn warn_if_legacy_secure_cloud_providers(&self) {
-        for provider in self.include.iter().chain(self.exclude.iter()) {
-            warn_if_legacy_secure_cloud_provider(provider);
-        }
-    }
-}
-
 /// Topology spread strategy for ranks-to-nodes assignment. SDK arch § 4.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -1744,7 +1735,7 @@ pub struct CpuOffering {
     /// Unique offering identifier
     pub id: String,
 
-    /// Public availability-zone root (e.g., "cyan")
+    /// Public availability zone root (e.g., "cyan")
     pub provider: String,
 
     /// Number of vCPU cores
@@ -1882,34 +1873,6 @@ pub struct CreateVolumeRequest {
 
     /// Basilica region segment (e.g., "us-texas-1", "ca-quebec-1")
     pub region: String,
-}
-
-/// Returns true when `provider` is a legacy secure-cloud provider tag that is
-/// no longer accepted by the V2 secure-cloud volume API.
-pub fn is_legacy_secure_cloud_provider(provider: &str) -> bool {
-    matches!(
-        provider.trim().to_ascii_lowercase().as_str(),
-        "datacrunch"
-            | "denvr"
-            | "hydrahost"
-            | "hyperstack"
-            | "lambda"
-            | "masscompute"
-            | "shadeform"
-            | "verda"
-    )
-}
-
-/// Print the temporary migration warning for explicit legacy provider input.
-pub fn warn_if_legacy_secure_cloud_provider(provider: &str) {
-    if is_legacy_secure_cloud_provider(provider) {
-        eprintln!(
-            "Warning: '{}' is a legacy secure-cloud provider tag. Basilica secure-cloud \
-             V2 uses public availability-zone names instead; update provider/region \
-             inputs to public availability-zone values.",
-            provider.trim()
-        );
-    }
 }
 
 /// Attach volume request
@@ -2714,13 +2677,6 @@ mod tests {
         // matches the operator's CRD field defaults.
         assert_eq!(v["providerFilter"]["include"], serde_json::json!([]));
         assert_eq!(v["providerFilter"]["exclude"], serde_json::json!([]));
-    }
-
-    #[test]
-    fn test_legacy_secure_cloud_provider_detection() {
-        assert!(is_legacy_secure_cloud_provider("hyperstack"));
-        assert!(is_legacy_secure_cloud_provider(" MASSCOMPUTE "));
-        assert!(!is_legacy_secure_cloud_provider("cyan"));
     }
 
     #[test]

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -1247,8 +1247,9 @@ pub struct DistributedRendezvousSpec {
     pub port: Option<u16>,
 }
 
-/// Availability-zone filter for worker scheduling. Empty `include` = any AZ.
-/// Match is on Basilica public AZ-root names (e.g. `cyan`, `plum`, `opal`).
+/// Availability-zone filter for worker scheduling. Empty `include` = any
+/// availability zone root. Match is on Basilica public availability zone root
+/// names (e.g. `cyan`, `plum`, `opal`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DistributedProviderFilter {
@@ -1419,7 +1420,7 @@ pub struct DistributedRankStatus {
     pub pod_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_name: Option<String>,
-    /// Basilica public AZ-root name.
+    /// Basilica public availability zone root name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     /// `basilica.ai/region` node label value.

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -2717,7 +2717,7 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_secure_cloud_provider_detection_covers_provider_filters() {
+    fn test_legacy_secure_cloud_provider_detection() {
         assert!(is_legacy_secure_cloud_provider("hyperstack"));
         assert!(is_legacy_secure_cloud_provider(" MASSCOMPUTE "));
         assert!(!is_legacy_secure_cloud_provider("cyan"));

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -45,7 +45,7 @@ from basilica import ProviderFilter, WorldSize
     cpu="8",
     memory="32Gi",
     # ``provider_filter`` is a fallback set of public availability zone roots,
-    # not a multi-availability-zone requirement; ``topology_spread="pack"``
+    # not a multi-availability zone root requirement; ``topology_spread="pack"``
     # keeps workers on a single availability zone root for direct WG mesh
     # throughput on NCCL collectives. See
     # ``docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md`` for the WHY.

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -17,7 +17,7 @@ train anything useful.
 
 Prereqs:
 - ``BASILICA_API_TOKEN`` set, account with A100/H100 access.
-- ~4 ranks available across the included public AZ roots.
+- ~4 ranks available across the included public availability zone roots.
 
 Cleanup:
 - The ``with`` block calls ``training.delete()`` on exit (success or
@@ -44,9 +44,10 @@ from basilica import ProviderFilter, WorldSize
     min_gpu_memory_gb=40,
     cpu="8",
     memory="32Gi",
-    # ``provider_filter`` is a fallback set of public AZ roots, not a
-    # multi-AZ requirement; ``topology_spread="pack"`` keeps workers on a
-    # single AZ root for direct WG mesh throughput on NCCL collectives. See
+    # ``provider_filter`` is a fallback set of public availability zone roots,
+    # not a multi-availability-zone requirement; ``topology_spread="pack"``
+    # keeps workers on a single availability zone root for direct WG mesh
+    # throughput on NCCL collectives. See
     # ``docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md`` for the WHY.
     provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",

--- a/examples/20_distributed_diloco.py
+++ b/examples/20_distributed_diloco.py
@@ -17,7 +17,7 @@ train anything useful.
 
 Prereqs:
 - ``BASILICA_API_TOKEN`` set, account with A100/H100 access.
-- ~4 ranks available across the included providers.
+- ~4 ranks available across the included public AZ roots.
 
 Cleanup:
 - The ``with`` block calls ``training.delete()`` on exit (success or
@@ -44,11 +44,11 @@ from basilica import ProviderFilter, WorldSize
     min_gpu_memory_gb=40,
     cpu="8",
     memory="32Gi",
-    # ``provider_filter`` is a fallback set, not a multi-provider
-    # requirement; ``topology_spread="pack"`` keeps workers on a single
-    # provider for direct WG mesh throughput on NCCL collectives. See
+    # ``provider_filter`` is a fallback set of public AZ roots, not a
+    # multi-AZ requirement; ``topology_spread="pack"`` keeps workers on a
+    # single AZ root for direct WG mesh throughput on NCCL collectives. See
     # ``docs/runbooks/USER-RUNBOOK-DISTRIBUTED-NCCL.md`` for the WHY.
-    provider_filter=ProviderFilter(include=["hyperstack", "verda"]),
+    provider_filter=ProviderFilter(include=["cyan", "plum"]),
     topology_spread="pack",
     # Opt in to the per-UD NCCL bench probe. ``True`` -> the platform
     # schedules a 2-rank ``all_reduce_perf`` probe alongside the workers

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -87,12 +87,13 @@ def main() -> None:
         min_gpu_memory_gb=40,
         cpu="8",
         memory="32Gi",
-        # Broadened AZ-root include-list: pinning to a single AZ root exposed
+        # Broadened availability zone root include-list: pinning to a single
+        # availability zone root exposed
         # the example to localized capacity or provider-side transients.
-        # Including several public AZ roots lets the autoscaler fall back when
-        # one root is unavailable. ``topology_spread="pack"`` below still keeps
-        # the workers on a single AZ root per UD; this list is a fallback set,
-        # not a spread directive.
+        # Including several public availability zone roots lets the autoscaler
+        # fall back when one root is unavailable. ``topology_spread="pack"``
+        # below still keeps the workers on a single availability zone root per
+        # UD; this list is a fallback set, not a spread directive.
         provider_filter=ProviderFilter(
             include=["cyan", "plum", "opal"]
         ),

--- a/examples/21_distributed_torchrun.py
+++ b/examples/21_distributed_torchrun.py
@@ -87,17 +87,14 @@ def main() -> None:
         min_gpu_memory_gb=40,
         cpu="8",
         memory="32Gi",
-        # Broadened provider include-list (refs basilica-backend#544):
-        # pinning to a single provider exposed the example to provider-
-        # side rental-revoke transients (the autoscaler's "Rental
-        # disappeared from provider" failure mode). Including the four
-        # providers we onboard today lets the autoscaler fall back across
-        # them when one provider's rental API is misbehaving under burst
-        # load. ``topology_spread="pack"`` below still keeps the workers
-        # on a single provider per UD; this list is a fallback set, not
-        # a spread directive.
+        # Broadened AZ-root include-list: pinning to a single AZ root exposed
+        # the example to localized capacity or provider-side transients.
+        # Including several public AZ roots lets the autoscaler fall back when
+        # one root is unavailable. ``topology_spread="pack"`` below still keeps
+        # the workers on a single AZ root per UD; this list is a fallback set,
+        # not a spread directive.
         provider_filter=ProviderFilter(
-            include=["verda", "hyperstack", "masscompute", "shadeform"]
+            include=["cyan", "plum", "opal"]
         ),
         topology_spread="pack",
         nccl_env={"NCCL_DEBUG": "WARN"},

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -25,7 +25,7 @@ debug detail on a ``None`` result, inspect ``training.bench_diagnostics``.
 
 Prereqs:
 - ``BASILICA_API_TOKEN`` set.
-- Account with verda A100 access (or adjust the provider filter).
+- Account with access to the selected public AZ root (or adjust the provider filter).
 - Namespace rank budget >= 4 (worker(2) + bench(2)).
 """
 
@@ -44,7 +44,7 @@ from basilica import ProviderFilter, WorldSize
     min_gpu_memory_gb=40,
     cpu="8",
     memory="32Gi",
-    provider_filter=ProviderFilter(include=["verda"]),
+    provider_filter=ProviderFilter(include=["cyan"]),
     topology_spread="pack",  # Pack for the smallest measured pair.
     bench=True,  # Schedule the 2-rank NCCL probe.
     nccl_env={"NCCL_DEBUG": "WARN"},

--- a/examples/22_distributed_with_bench.py
+++ b/examples/22_distributed_with_bench.py
@@ -25,7 +25,7 @@ debug detail on a ``None`` result, inspect ``training.bench_diagnostics``.
 
 Prereqs:
 - ``BASILICA_API_TOKEN`` set.
-- Account with access to the selected public AZ root (or adjust the provider filter).
+- Account with access to the selected public availability zone root (or adjust the provider filter).
 - Namespace rank budget >= 4 (worker(2) + bench(2)).
 """
 


### PR DESCRIPTION
Updates all secure cloud API paths in the Rust SDK client from `/secure-cloud/...` to `/v2/secure-cloud/...`, covering GPU/CPU pricing, rentals, and volume operations.

Also updates a test comment to reference the correct v2 path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure Cloud GPU, CPU, rental, and volume operations now use versioned API routes under `/v2/secure-cloud/*`.
* **Bug Fixes**
  * Legacy secure-cloud provider tags now trigger warnings during volume creation (CLI `stderr`, non-JSON) and distributed deployment setup (Python `UserWarning`).
* **Documentation**
  * Updated secure-cloud and distributed training docs/examples to use public AZ-root values (e.g., `cyan`, `plum`, `opal`) and region fields.
* **Tests**
  * Updated CLI/SDK and distributed-training test fixtures to match AZ-root semantics and the new `/v2/secure-cloud/*` routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->