### PR TITLE
fix(cli): support non-interactive up by Citadel offering ID

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `basilica up --offering-id <ID>` can now start a specific Citadel GPU or CPU
+  offering without opening the interactive offering selector, and non-interactive
+  ambiguous `up` commands now point agents to inspect `basilica --json ls` and
+  pass `--offering-id`.
+
 ## [0.32.0] - 2026-06-29
 
 ### Added

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -469,6 +469,30 @@ pub struct ListFilters {
 /// Options for provisioning instances
 #[derive(clap::Args, Debug, Clone)]
 pub struct UpOptions {
+    /// Citadel GPU or CPU offering ID from `basilica --json ls`
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "target",
+            "compute",
+            "gpu_count",
+            "max_hourly_rate",
+            "image",
+            "env",
+            "ports",
+            "cpu_cores",
+            "memory_mb",
+            "storage_mb",
+            "command",
+            "country",
+            "interconnect",
+            "region",
+            "spot",
+            "exclude_spot"
+        ]
+    )]
+    pub offering_id: Option<String>,
+
     /// Exact GPU count required
     #[arg(long)]
     pub gpu_count: Option<u32>,
@@ -1542,6 +1566,9 @@ pub enum TrainAction {
 #[cfg(test)]
 mod train_command_tests {
     use super::*;
+    use crate::cli::args::Args;
+    use clap::error::ErrorKind;
+    use clap::Parser;
     use std::str::FromStr;
 
     // -----------------------------------------------------------------
@@ -1602,6 +1629,75 @@ mod train_command_tests {
     fn world_size_triple_rejects_non_numeric() {
         assert!(WorldSizeTriple::from_str("a:b:c").is_err());
         assert!(WorldSizeTriple::from_str("4:eight:16").is_err());
+    }
+
+    #[test]
+    fn up_offering_id_conflicts_with_compute() {
+        let err = Args::try_parse_from([
+            "basilica",
+            "up",
+            "--offering-id",
+            "off_123",
+            "--compute",
+            "bourse",
+            "--name",
+            "test",
+            "--detach",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn up_offering_id_conflicts_with_selection_filters() {
+        let err = Args::try_parse_from([
+            "basilica",
+            "up",
+            "a100",
+            "--offering-id",
+            "off_123",
+            "--gpu-count",
+            "1",
+            "--spot",
+            "--name",
+            "test",
+            "--detach",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn up_offering_id_conflicts_with_bourse_options() {
+        let err = Args::try_parse_from([
+            "basilica",
+            "up",
+            "--offering-id",
+            "off_123",
+            "--image",
+            "ubuntu:22.04",
+            "--ports",
+            "8080:80",
+            "--name",
+            "test",
+            "--detach",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn up_offering_id_allows_name_and_detach() {
+        Args::try_parse_from([
+            "basilica",
+            "up",
+            "--offering-id",
+            "off_123",
+            "--name",
+            "test",
+            "--detach",
+        ])
+        .unwrap();
     }
 
     // -----------------------------------------------------------------

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -12,6 +12,7 @@ use crate::cli::handlers::region_mapping::region_matches_country;
 use crate::cli::handlers::ssh_keys::select_and_read_ssh_key;
 use crate::client::create_authenticated_client;
 use crate::config::CliConfig;
+use crate::interactive::gate::{self, Interactivity};
 use crate::output::{
     compress_path, format_usd, json_output, print_error, print_info, print_success, table_output,
 };
@@ -41,6 +42,13 @@ use tracing::{debug, warn};
 const RENTAL_READY_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn prompt_rental_name() -> Result<String, CliError> {
+    if matches!(gate::current(), Interactivity::NonInteractive) {
+        return Err(CliError::MissingInput {
+            field: "name".to_string(),
+            hint: "Pass --name when running `basilica up` non-interactively.".to_string(),
+        });
+    }
+
     let default_name = basilica_common::rental::generate_random_rental_name();
     let theme = dialoguer::theme::ColorfulTheme::default();
     let name: String = Input::with_theme(&theme)
@@ -1132,6 +1140,87 @@ fn validate_no_community_cloud_options(options: &UpOptions) -> Result<(), CliErr
     Ok(())
 }
 
+fn resolve_rental_name(options: &mut UpOptions) -> Result<String, CliError> {
+    match options.name.take() {
+        Some(n) => {
+            RentalName::new(n.trim()).map_err(|e| CliError::Internal(eyre!(e.to_string())))?;
+            Ok(n.trim().to_string())
+        }
+        None => prompt_rental_name(),
+    }
+}
+
+async fn resolve_citadel_offering_by_id(
+    api_client: &basilica_sdk::BasilicaClient,
+    offering_id: &str,
+) -> Result<RentalOffering, CliError> {
+    let gpu_result = api_client.list_secure_cloud_gpus().await;
+    let cpu_result = api_client.list_cpu_offerings().await;
+
+    match &gpu_result {
+        Ok(gpu_offerings) => {
+            if let Some(offering) = gpu_offerings
+                .iter()
+                .find(|offering| offering.id == offering_id)
+                .cloned()
+            {
+                return Ok(RentalOffering::SecureCloud(offering));
+            }
+        }
+        Err(e) => warn!("Failed to list Citadel GPU offerings: {}", e),
+    }
+
+    match &cpu_result {
+        Ok(cpu_offerings) => {
+            if let Some(offering) = cpu_offerings
+                .iter()
+                .find(|offering| offering.id == offering_id)
+                .cloned()
+            {
+                return Ok(RentalOffering::CpuOnly(offering));
+            }
+        }
+        Err(e) => warn!("Failed to list Citadel CPU offerings: {}", e),
+    }
+
+    if let (Err(gpu_err), Err(cpu_err)) = (&gpu_result, &cpu_result) {
+        return Err(CliError::Internal(eyre!(
+            "Failed to resolve Citadel offering ID '{}': GPU catalog request failed: {}; CPU catalog request failed: {}",
+            offering_id,
+            gpu_err,
+            cpu_err
+        )));
+    }
+
+    if let Err(err) = &gpu_result {
+        return Err(CliError::Internal(eyre!(
+            "Citadel offering ID '{}' was not found in CPU offerings, and the GPU catalog request failed: {}",
+            offering_id,
+            err
+        )
+        .suggestion(
+            "Run `basilica --json ls --compute citadel` and pass an ID from `gpu_offerings[].id` or `cpu_offerings[].id`.",
+        )));
+    }
+
+    if let Err(err) = &cpu_result {
+        return Err(CliError::Internal(eyre!(
+            "Citadel offering ID '{}' was not found in GPU offerings, and the CPU catalog request failed: {}",
+            offering_id,
+            err
+        )
+        .suggestion(
+            "Run `basilica --json ls --compute citadel` and pass an ID from `gpu_offerings[].id` or `cpu_offerings[].id`.",
+        )));
+    }
+
+    Err(CliError::Internal(
+        eyre!("Citadel offering ID '{}' was not found", offering_id).suggestion(
+            "Run `basilica --json ls --compute citadel` and pass an ID from `gpu_offerings[].id` or `cpu_offerings[].id`.",
+        ),
+    ))
+}
+
 /// Handle the `up` command - provision GPU instances
 ///
 /// All paths use the unified offering resolver which presents a consistent
@@ -1146,6 +1235,12 @@ pub async fn handle_up(
 
     // Ensure SSH key is registered before proceeding (needed for both clouds)
     ensure_ssh_key_registered(&api_client).await?;
+
+    if let Some(offering_id) = options.offering_id.take() {
+        let name = resolve_rental_name(&mut options)?;
+        let offering = resolve_citadel_offering_by_id(&api_client, &offering_id).await?;
+        return handle_rental_with_offering(api_client, offering, name, options, config).await;
+    }
 
     // Extract GPU filter from target
     let gpu_filter_owned = target.as_ref().map(|t| t.0.as_str());
@@ -1174,18 +1269,10 @@ pub async fn handle_up(
         cloud_filter,
         &flavour,
     )
-    .await
-    .map_err(CliError::Internal)?;
+    .await?;
 
     // Resolve rental name: use --name arg if provided, otherwise prompt interactively
-    let name = match options.name.take() {
-        Some(n) => {
-            // Validate the name provided via --name
-            RentalName::new(n.trim()).map_err(|e| CliError::Internal(eyre!(e.to_string())))?;
-            n.trim().to_string()
-        }
-        None => prompt_rental_name()?,
-    };
+    let name = resolve_rental_name(&mut options)?;
 
     match selected {
         SelectedOffering::SecureCloud(offering) => {

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental_helpers.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::handlers::region_mapping::{extract_country_code, region_matches_country};
 use crate::error::CliError;
+use crate::interactive::gate::{self, Interactivity};
 use crate::progress::{complete_spinner_and_clear, complete_spinner_error, create_spinner};
 use basilica_common::types::ComputeCategory;
 use basilica_common::types::{GpuCategory, GpuOffering};
@@ -581,7 +582,7 @@ pub async fn resolve_offering_unified(
     min_gpu_memory_filter: Option<u32>,
     cloud_filter: Option<ComputeCategory>,
     flavour: &FlavourFilters,
-) -> Result<SelectedOffering> {
+) -> std::result::Result<SelectedOffering, CliError> {
     let spinner_msg = match cloud_filter {
         Some(ComputeCategory::SecureCloud) => "Fetching available GPUs from The Citadel...",
         Some(ComputeCategory::CommunityCloud) => "Fetching available GPUs from The Bourse...",
@@ -858,9 +859,17 @@ pub async fn resolve_offering_unified(
     }
 
     if unified_items.is_empty() {
-        return Err(eyre!(
+        return Err(CliError::Internal(eyre!(
             "No offerings available. Try different filters or check back later."
-        ));
+        )));
+    }
+
+    if matches!(gate::current(), Interactivity::NonInteractive) {
+        return Err(CliError::MissingInput {
+            field: "offering_id".to_string(),
+            hint: "Run `basilica --json ls --compute citadel` with your filters, pick `gpu_offerings[].id` or `cpu_offerings[].id`, then run `basilica up --offering-id <ID> --name <name> --detach`."
+                .to_string(),
+        });
     }
 
     // Helper to truncate strings to fit column width (unicode-safe)
@@ -912,11 +921,11 @@ pub async fn resolve_offering_unified(
         .items(&items)
         .default(0)
         .interact_opt()
-        .map_err(|e| eyre!("Selection failed: {}", e))?;
+        .map_err(|e| CliError::Internal(eyre!("Selection failed: {}", e)))?;
 
     let selection = match selection {
         Some(s) => s,
-        None => return Err(eyre!("Selection cancelled")),
+        None => return Err(CliError::Internal(eyre!("Selection cancelled"))),
     };
 
     // Clear the header and selection prompt lines
@@ -928,28 +937,25 @@ pub async fn resolve_offering_unified(
     // Return appropriate offering type
     match selected.offering_type {
         OfferingType::SecureGpu => {
-            let offering = selected
-                .secure_offering
-                .clone()
-                .ok_or_else(|| eyre!("Internal error: secure cloud offering data missing"))?;
+            let offering = selected.secure_offering.clone().ok_or_else(|| {
+                CliError::Internal(eyre!("Internal error: secure cloud offering data missing"))
+            })?;
             Ok(SelectedOffering::SecureCloud(offering))
         }
         OfferingType::SecureCpu => {
-            let offering = selected
-                .cpu_offering
-                .clone()
-                .ok_or_else(|| eyre!("Internal error: CPU offering data missing"))?;
+            let offering = selected.cpu_offering.clone().ok_or_else(|| {
+                CliError::Internal(eyre!("Internal error: CPU offering data missing"))
+            })?;
             Ok(SelectedOffering::CpuOnly(offering))
         }
         OfferingType::Community => {
-            let nodes = selected
-                .community_nodes
-                .clone()
-                .ok_or_else(|| eyre!("Internal error: community cloud node data missing"))?;
+            let nodes = selected.community_nodes.clone().ok_or_else(|| {
+                CliError::Internal(eyre!("Internal error: community cloud node data missing"))
+            })?;
 
-            let first_node = nodes
-                .first()
-                .ok_or_else(|| eyre!("Internal error: community cloud group is empty"))?;
+            let first_node = nodes.first().ok_or_else(|| {
+                CliError::Internal(eyre!("Internal error: community cloud group is empty"))
+            })?;
 
             // Extract GPU category and count from the group
             let gpu_category = first_node
@@ -961,7 +967,7 @@ pub async fn resolve_offering_unified(
                         .map(|c| c.to_string())
                         .unwrap_or_else(|_| gpu.name.clone())
                 })
-                .ok_or_else(|| eyre!("Selected group has no GPU specs"))?;
+                .ok_or_else(|| CliError::Internal(eyre!("Selected group has no GPU specs")))?;
 
             let gpu_count = first_node.node.gpu_specs.len() as u32;
             let min_memory_gb = nodes


### PR DESCRIPTION
## Summary

Adds a non-interactive `basilica up --offering-id <ID>` path for Citadel offerings.

Agents can now inspect offerings with:

```bash
basilica --json ls --compute citadel
```

then start a specific GPU or CPU Citadel offering directly with:

```bash
basilica up --offering-id <ID> --name <name> --detach
```

This bypasses the interactive offering selector, while still preserving the normal SSH key registration, rental name validation/prompting, start, detach, and post-start output flow.

Invalid combinations with `--offering-id` are rejected by clap, including `--compute`, positional GPU filters, GPU filter flags, and Bourse-only options.

## Notes

`--offering-id` resolves the ID against current Citadel GPU and CPU offerings, then reuses the existing typed rental path instead of adding a raw ID variant to `RentalOffering`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `basilica up --offering-id <ID>` to start a specific CPU/GPU offering directly, without using the interactive selector.
  * Non-interactive `up` runs now clearly guide users to list offerings and pass an offering ID when multiple choices exist.

* **Bug Fixes**
  * Improved handling for non-interactive runs so missing required inputs now fail fast with clearer messages instead of prompting.
  * Tightened command validation so `--offering-id` can’t be combined with conflicting selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->