### PR TITLE
fix(cli): show skills update alias in help

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ambiguous `up` commands now point agents to inspect `basilica --json ls` and
   pass `--offering-id`.
 
+### Changed
+- Removed the hidden `add` alias from `basilica skills install`.
+
+### Fixed
+- `basilica skills --help` now shows `update` as an alias for `install`, making
+  the installed-skills update path discoverable.
+
 ## [0.32.0] - 2026-06-29
 
 ### Added

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -250,7 +250,7 @@ pub struct SkillsCommand {
 #[derive(Subcommand, Debug, Clone)]
 pub enum SkillsAction {
     /// Install Basilica agent skills
-    #[command(alias = "add", alias = "update")]
+    #[command(visible_alias = "update")]
     Install,
 
     /// Uninstall Basilica agent skills


### PR DESCRIPTION
Makes `basilica skills update` discoverable by exposing it as a visible alias for `basilica skills install` in CLI help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `skills install` command so the `add` shortcut is no longer available.
  * Made the `update` alias visible in help output, making the installed-skills update flow easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->