### PR TITLE
feat(cli): add responsive list table output

### DIFF
--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -11,14 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ls`, `ps`, `tokens list`, `fund list`, `volumes list`, and `deploy ls` now
   support `--output auto|compact|wide|json`. The default `auto` mode adapts
   columns to interactive terminal width while non-interactive output remains
-  wide and stable for scripts.
+  wide and terminal-width-independent.
 
 ### Changed
 - CLI tables now prioritize useful columns on narrow terminals, keep truncated
   deployment URLs and funding transaction hashes actionable, and use consistent
   headers and hourly pricing.
+- Human-readable tables now group related hardware details, shorten long GPU and
+  container-image labels, and display active-resource timestamps to the minute.
 - Interactive `basilica ps` output now summarizes the total rentals, combined
   hourly price, and accrued cost.
+- Global `--json` now applies consistently to all `deploy` subcommands.
 
 ### Fixed
 - `basilica ps` now resolves Bourse SSH hosts for human-readable output, so

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wide and stable for scripts.
 
 ### Changed
-- CLI tables now prioritize useful columns on narrow terminals, keep long
-  deployment URLs actionable, and use consistent headers and hourly pricing.
+- CLI tables now prioritize useful columns on narrow terminals, keep truncated
+  deployment URLs and funding transaction hashes actionable, and use consistent
+  headers and hourly pricing.
 - Interactive `basilica ps` output now summarizes the total rentals, combined
   hourly price, and accrued cost.
 

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ls`, `ps`, `tokens list`, `fund list`, `volumes list`, and `deploy ls` now
+  support `--output auto|compact|wide|json`. The default `auto` mode adapts
+  columns to interactive terminal width while non-interactive output remains
+  wide and stable for scripts.
+
+### Changed
+- CLI tables now prioritize useful columns on narrow terminals, keep long
+  deployment URLs actionable, and use consistent headers and hourly pricing.
+- Interactive `basilica ps` output now summarizes the total rentals, combined
+  hourly price, and accrued cost.
+
 ### Fixed
+- `basilica ps` now resolves Bourse SSH hosts for human-readable output, so
+  access addresses are available alongside Citadel rental addresses.
 - `basilica deploy` with `--private` now prints the one-time share token after
   waiting for the deployment to become ready. The token is only returned by
   the create call, so the ready-wait status response dropped it and the CLI

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -162,12 +162,15 @@ impl Args {
                 gpu_type,
                 filters,
                 compute,
+                output,
             } => {
+                let output = crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
+                    .map_err(|message| CliError::Internal(color_eyre::eyre::eyre!(message)))?;
                 handlers::gpu_rental::handle_ls(
                     gpu_type.clone(),
                     filters.clone(),
                     *compute,
-                    self.json,
+                    output,
                     config,
                 )
                 .await?;
@@ -180,9 +183,14 @@ impl Args {
                 handlers::gpu_rental::handle_up(target.clone(), options.clone(), *compute, config)
                     .await?;
             }
-            Commands::Ps { compute, filters } => {
-                handlers::gpu_rental::handle_ps(filters.clone(), *compute, self.json, config)
-                    .await?;
+            Commands::Ps {
+                compute,
+                filters,
+                output,
+            } => {
+                let output = crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
+                    .map_err(|message| CliError::Internal(color_eyre::eyre::eyre!(message)))?;
+                handlers::gpu_rental::handle_ps(filters.clone(), *compute, output, config).await?;
             }
             Commands::Status { target } => {
                 handlers::gpu_rental::handle_status(target.clone(), self.json, config).await?;
@@ -218,6 +226,17 @@ impl Args {
                 use crate::cli::commands::TokenAction;
                 use crate::client::create_client;
 
+                let list_json = match action {
+                    TokenAction::List { output } => Some(
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
+                            .map_err(|message| {
+                                CliError::Internal(color_eyre::eyre::eyre!(message))
+                            })?
+                            .is_json(),
+                    ),
+                    _ => None,
+                };
+
                 // Create client with file-based auth (JWT required for token management)
                 let client = create_client(config).await?;
 
@@ -225,8 +244,9 @@ impl Args {
                     TokenAction::Create { name } => {
                         handlers::tokens::handle_create_token(&client, name.clone()).await?;
                     }
-                    TokenAction::List => {
-                        handlers::tokens::handle_list_tokens(&client, self.json).await?;
+                    TokenAction::List { .. } => {
+                        handlers::tokens::handle_list_tokens(&client, list_json.unwrap_or(false))
+                            .await?;
                     }
                     TokenAction::Revoke { name, yes } => {
                         handlers::tokens::handle_revoke_token(&client, name.clone(), *yes).await?;
@@ -261,6 +281,17 @@ impl Args {
                 use crate::cli::commands::FundAction;
                 use crate::client::create_authenticated_client;
 
+                let list_json = match action {
+                    Some(FundAction::List { output, .. }) => Some(
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
+                            .map_err(|message| {
+                                CliError::Internal(color_eyre::eyre::eyre!(message))
+                            })?
+                            .is_json(),
+                    ),
+                    None => None,
+                };
+
                 // Create authenticated client
                 let client = create_authenticated_client(config).await?;
 
@@ -268,9 +299,16 @@ impl Args {
                     None => {
                         handlers::fund::handle_fund(&client, *usd, *tao, self.json).await?;
                     }
-                    Some(FundAction::List { limit, offset }) => {
+                    Some(FundAction::List {
+                        limit,
+                        offset,
+                        output: _,
+                    }) => {
                         handlers::fund::list::handle_list_payments(
-                            &client, *limit, *offset, self.json,
+                            &client,
+                            *limit,
+                            *offset,
+                            list_json.unwrap_or(false),
                         )
                         .await?;
                     }
@@ -289,7 +327,9 @@ impl Args {
 
             // Deploy command
             Commands::Deploy(cmd) => {
-                handlers::deploy::handle_deploy(*cmd.clone(), config).await?;
+                let mut cmd = *cmd.clone();
+                cmd.json |= self.json;
+                handlers::deploy::handle_deploy(cmd, config).await?;
             }
 
             // Distributed training (`basilica train ...`).
@@ -301,6 +341,17 @@ impl Args {
             Commands::Volumes { action } => {
                 use crate::cli::commands::VolumeAction;
                 use crate::client::create_client;
+
+                let list_json = match action {
+                    VolumeAction::List { output } => Some(
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
+                            .map_err(|message| {
+                                CliError::Internal(color_eyre::eyre::eyre!(message))
+                            })?
+                            .is_json(),
+                    ),
+                    _ => None,
+                };
 
                 // Create client with file-based auth (JWT required for volume management)
                 let client = create_client(config).await?;
@@ -324,8 +375,9 @@ impl Args {
                         )
                         .await?;
                     }
-                    VolumeAction::List => {
-                        handlers::volumes::handle_list_volumes(&client, self.json).await?;
+                    VolumeAction::List { .. } => {
+                        handlers::volumes::handle_list_volumes(&client, list_json.unwrap_or(false))
+                            .await?;
                     }
                     VolumeAction::Delete { volume, yes } => {
                         handlers::volumes::handle_delete_volume(

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -226,13 +226,11 @@ impl Args {
                 use crate::cli::commands::TokenAction;
                 use crate::client::create_client;
 
-                let list_json = match action {
+                let list_output = match action {
                     TokenAction::List { output } => Some(
-                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
-                            .map_err(|message| {
-                                CliError::Internal(color_eyre::eyre::eyre!(message))
-                            })?
-                            .is_json(),
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output).map_err(
+                            |message| CliError::Internal(color_eyre::eyre::eyre!(message)),
+                        )?,
                     ),
                     _ => None,
                 };
@@ -245,8 +243,11 @@ impl Args {
                         handlers::tokens::handle_create_token(&client, name.clone()).await?;
                     }
                     TokenAction::List { .. } => {
-                        handlers::tokens::handle_list_tokens(&client, list_json.unwrap_or(false))
-                            .await?;
+                        handlers::tokens::handle_list_tokens(
+                            &client,
+                            list_output.unwrap_or(crate::cli::commands::ResolvedOutput::Auto),
+                        )
+                        .await?;
                     }
                     TokenAction::Revoke { name, yes } => {
                         handlers::tokens::handle_revoke_token(&client, name.clone(), *yes).await?;

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -282,13 +282,11 @@ impl Args {
                 use crate::cli::commands::FundAction;
                 use crate::client::create_authenticated_client;
 
-                let list_json = match action {
+                let list_output = match action {
                     Some(FundAction::List { output, .. }) => Some(
-                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
-                            .map_err(|message| {
-                                CliError::Internal(color_eyre::eyre::eyre!(message))
-                            })?
-                            .is_json(),
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output).map_err(
+                            |message| CliError::Internal(color_eyre::eyre::eyre!(message)),
+                        )?,
                     ),
                     None => None,
                 };
@@ -309,7 +307,7 @@ impl Args {
                             &client,
                             *limit,
                             *offset,
-                            list_json.unwrap_or(false),
+                            list_output.unwrap_or(crate::cli::commands::ResolvedOutput::Auto),
                         )
                         .await?;
                     }

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -342,13 +342,11 @@ impl Args {
                 use crate::cli::commands::VolumeAction;
                 use crate::client::create_client;
 
-                let list_json = match action {
+                let list_output = match action {
                     VolumeAction::List { output } => Some(
-                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output)
-                            .map_err(|message| {
-                                CliError::Internal(color_eyre::eyre::eyre!(message))
-                            })?
-                            .is_json(),
+                        crate::cli::commands::ResolvedOutput::resolve(self.json, *output).map_err(
+                            |message| CliError::Internal(color_eyre::eyre::eyre!(message)),
+                        )?,
                     ),
                     _ => None,
                 };
@@ -376,8 +374,11 @@ impl Args {
                         .await?;
                     }
                     VolumeAction::List { .. } => {
-                        handlers::volumes::handle_list_volumes(&client, list_json.unwrap_or(false))
-                            .await?;
+                        handlers::volumes::handle_list_volumes(
+                            &client,
+                            list_output.unwrap_or(crate::cli::commands::ResolvedOutput::Auto),
+                        )
+                        .await?;
                     }
                     VolumeAction::Delete { volume, yes } => {
                         handlers::volumes::handle_delete_volume(

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -5,6 +5,43 @@ use std::path::PathBuf;
 
 use crate::handlers::gpu_rental::GpuTarget;
 
+/// Human and machine-readable formats supported by resource list commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Compact,
+    Wide,
+    Json,
+}
+
+/// Fully resolved output mode after combining `--json` and `-o`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedOutput {
+    Auto,
+    Compact,
+    Wide,
+    Json,
+}
+
+impl ResolvedOutput {
+    pub fn resolve(json: bool, output: Option<OutputFormat>) -> Result<Self, String> {
+        match (json, output) {
+            (true, Some(OutputFormat::Compact | OutputFormat::Wide)) => Err(
+                "--json conflicts with -o compact and -o wide; use --json or -o json".to_string(),
+            ),
+            (true, None | Some(OutputFormat::Json)) | (false, Some(OutputFormat::Json)) => {
+                Ok(Self::Json)
+            }
+            (false, Some(OutputFormat::Compact)) => Ok(Self::Compact),
+            (false, Some(OutputFormat::Wide)) => Ok(Self::Wide),
+            (false, None) => Ok(Self::Auto),
+        }
+    }
+
+    pub const fn is_json(self) -> bool {
+        matches!(self, Self::Json)
+    }
+}
+
 /// CLI wrapper for ComputeCategory to implement ValueEnum
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ComputeCategoryArg {
@@ -52,6 +89,10 @@ pub enum Commands {
 
         #[command(flatten)]
         filters: ListFilters,
+
+        /// Output format (auto-selects compact or wide when omitted)
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
     },
 
     /// Provision and start GPU instances
@@ -76,6 +117,10 @@ pub enum Commands {
 
         #[command(flatten)]
         filters: PsFilters,
+
+        /// Output format (auto-selects compact or wide when omitted)
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
     },
 
     /// Check instance status
@@ -273,6 +318,10 @@ pub enum FundAction {
         /// Offset for pagination, applied to both sources (default: 0)
         #[arg(long, default_value = "0")]
         offset: u32,
+
+        /// Output format
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
     },
 }
 
@@ -286,7 +335,11 @@ pub enum TokenAction {
     },
 
     /// List all API keys
-    List,
+    List {
+        /// Output format
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
+    },
 
     /// Revoke an API key
     Revoke {
@@ -352,7 +405,11 @@ pub enum VolumeAction {
 
     /// List all volumes
     #[command(alias = "ls")]
-    List,
+    List {
+        /// Output format
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
+    },
 
     /// Delete a volume (must be detached first)
     #[command(alias = "rm")]
@@ -988,7 +1045,11 @@ impl Default for LifecycleOptions {
 pub enum DeployAction {
     /// List all deployments
     #[command(name = "ls", visible_alias = "list")]
-    List,
+    List {
+        /// Output format (auto-selects compact or wide when omitted)
+        #[arg(short = 'o', long = "output", value_enum)]
+        output: Option<OutputFormat>,
+    },
 
     /// Get deployment status
     #[command(name = "status", visible_alias = "get")]
@@ -1570,6 +1631,53 @@ mod train_command_tests {
     use clap::error::ErrorKind;
     use clap::Parser;
     use std::str::FromStr;
+
+    #[test]
+    fn list_output_format_resolves_json_alias_and_conflicts() {
+        assert_eq!(
+            ResolvedOutput::resolve(false, Some(OutputFormat::Json)),
+            Ok(ResolvedOutput::Json)
+        );
+        assert_eq!(
+            ResolvedOutput::resolve(true, Some(OutputFormat::Json)),
+            Ok(ResolvedOutput::Json)
+        );
+        assert!(ResolvedOutput::resolve(true, Some(OutputFormat::Compact)).is_err());
+        assert!(ResolvedOutput::resolve(true, Some(OutputFormat::Wide)).is_err());
+    }
+
+    #[test]
+    fn list_commands_parse_all_output_formats() {
+        for value in ["compact", "wide", "json"] {
+            Args::try_parse_from(["basilica", "ls", "-o", value]).unwrap();
+            Args::try_parse_from(["basilica", "ps", "--output", value]).unwrap();
+            Args::try_parse_from(["basilica", "tokens", "list", "-o", value]).unwrap();
+            Args::try_parse_from(["basilica", "fund", "list", "-o", value]).unwrap();
+            Args::try_parse_from(["basilica", "volumes", "list", "-o", value]).unwrap();
+            Args::try_parse_from(["basilica", "summon", "ls", "-o", value]).unwrap();
+        }
+    }
+
+    #[test]
+    fn output_flag_is_rejected_on_non_list_commands() {
+        let error =
+            Args::try_parse_from(["basilica", "status", "rental", "-o", "wide"]).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn global_json_conflicts_with_disagreeing_summon_output() {
+        let args =
+            Args::try_parse_from(["basilica", "--json", "summon", "ls", "--output", "compact"])
+                .unwrap();
+        let Commands::Deploy(command) = args.command else {
+            panic!("expected deploy command");
+        };
+        let Some(DeployAction::List { output }) = command.action else {
+            panic!("expected deploy list action");
+        };
+        assert!(ResolvedOutput::resolve(args.json || command.json, output).is_err());
+    }
 
     // -----------------------------------------------------------------
     // WorldSizeTriple parser.

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -90,7 +90,7 @@ pub enum Commands {
         #[command(flatten)]
         filters: ListFilters,
 
-        /// Output format (auto-selects compact or wide when omitted)
+        /// Output format (automatically adapts columns to terminal width when omitted)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -118,7 +118,7 @@ pub enum Commands {
         #[command(flatten)]
         filters: PsFilters,
 
-        /// Output format (auto-selects compact or wide when omitted)
+        /// Output format (automatically adapts columns to terminal width when omitted)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -8,8 +8,13 @@ use crate::handlers::gpu_rental::GpuTarget;
 /// Human and machine-readable formats supported by resource list commands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
+    /// Choose the human-readable layout automatically
+    Auto,
+    /// Show only the required columns
     Compact,
+    /// Show every column, even when the table exceeds the terminal width
     Wide,
+    /// Emit machine-readable JSON
     Json,
 }
 
@@ -25,12 +30,14 @@ pub enum ResolvedOutput {
 impl ResolvedOutput {
     pub fn resolve(json: bool, output: Option<OutputFormat>) -> Result<Self, String> {
         match (json, output) {
-            (true, Some(OutputFormat::Compact | OutputFormat::Wide)) => Err(
-                "--json conflicts with -o compact and -o wide; use --json or -o json".to_string(),
+            (true, Some(OutputFormat::Auto | OutputFormat::Compact | OutputFormat::Wide)) => Err(
+                "--json conflicts with -o auto, -o compact, and -o wide; use --json or -o json"
+                    .to_string(),
             ),
             (true, None | Some(OutputFormat::Json)) | (false, Some(OutputFormat::Json)) => {
                 Ok(Self::Json)
             }
+            (false, Some(OutputFormat::Auto)) => Ok(Self::Auto),
             (false, Some(OutputFormat::Compact)) => Ok(Self::Compact),
             (false, Some(OutputFormat::Wide)) => Ok(Self::Wide),
             (false, None) => Ok(Self::Auto),
@@ -90,7 +97,7 @@ pub enum Commands {
         #[command(flatten)]
         filters: ListFilters,
 
-        /// Output format (automatically adapts columns to terminal width when omitted)
+        /// Output format (default: auto; adapts columns to terminal width)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -118,7 +125,7 @@ pub enum Commands {
         #[command(flatten)]
         filters: PsFilters,
 
-        /// Output format (automatically adapts columns to terminal width when omitted)
+        /// Output format (default: auto; adapts columns to terminal width)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -319,7 +326,7 @@ pub enum FundAction {
         #[arg(long, default_value = "0")]
         offset: u32,
 
-        /// Output format
+        /// Output format (default: auto)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -336,7 +343,7 @@ pub enum TokenAction {
 
     /// List all API keys
     List {
-        /// Output format
+        /// Output format (default: auto)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -406,7 +413,7 @@ pub enum VolumeAction {
     /// List all volumes
     #[command(alias = "ls")]
     List {
-        /// Output format
+        /// Output format (default: auto)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -1046,7 +1053,7 @@ pub enum DeployAction {
     /// List all deployments
     #[command(name = "ls", visible_alias = "list")]
     List {
-        /// Output format (auto-selects compact or wide when omitted)
+        /// Output format (default: auto)
         #[arg(short = 'o', long = "output", value_enum)]
         output: Option<OutputFormat>,
     },
@@ -1635,6 +1642,14 @@ mod train_command_tests {
     #[test]
     fn list_output_format_resolves_json_alias_and_conflicts() {
         assert_eq!(
+            ResolvedOutput::resolve(false, None),
+            Ok(ResolvedOutput::Auto)
+        );
+        assert_eq!(
+            ResolvedOutput::resolve(false, Some(OutputFormat::Auto)),
+            Ok(ResolvedOutput::Auto)
+        );
+        assert_eq!(
             ResolvedOutput::resolve(false, Some(OutputFormat::Json)),
             Ok(ResolvedOutput::Json)
         );
@@ -1642,13 +1657,14 @@ mod train_command_tests {
             ResolvedOutput::resolve(true, Some(OutputFormat::Json)),
             Ok(ResolvedOutput::Json)
         );
+        assert!(ResolvedOutput::resolve(true, Some(OutputFormat::Auto)).is_err());
         assert!(ResolvedOutput::resolve(true, Some(OutputFormat::Compact)).is_err());
         assert!(ResolvedOutput::resolve(true, Some(OutputFormat::Wide)).is_err());
     }
 
     #[test]
     fn list_commands_parse_all_output_formats() {
-        for value in ["compact", "wide", "json"] {
+        for value in ["auto", "compact", "wide", "json"] {
             Args::try_parse_from(["basilica", "ls", "-o", value]).unwrap();
             Args::try_parse_from(["basilica", "ps", "--output", value]).unwrap();
             Args::try_parse_from(["basilica", "tokens", "list", "-o", value]).unwrap();
@@ -1677,6 +1693,24 @@ mod train_command_tests {
             panic!("expected deploy list action");
         };
         assert!(ResolvedOutput::resolve(args.json || command.json, output).is_err());
+    }
+
+    #[test]
+    fn global_json_accepts_implicit_auto_but_conflicts_with_explicit_auto() {
+        let args = Args::try_parse_from(["basilica", "--json", "ls"]).unwrap();
+        let Commands::Ls { output, .. } = args.command else {
+            panic!("expected ls command");
+        };
+        assert_eq!(
+            ResolvedOutput::resolve(args.json, output),
+            Ok(ResolvedOutput::Json)
+        );
+
+        let args = Args::try_parse_from(["basilica", "--json", "ls", "-o", "auto"]).unwrap();
+        let Commands::Ls { output, .. } = args.command else {
+            panic!("expected ls command");
+        };
+        assert!(ResolvedOutput::resolve(args.json, output).is_err());
     }
 
     // -----------------------------------------------------------------

--- a/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
@@ -867,7 +867,7 @@ mod tests {
             width: Some(80),
             now: chrono::DateTime::UNIX_EPOCH,
         };
-        assert_eq!(compact_url_budget(context, 120, Some(40), 60), Some(48));
+        assert_eq!(compact_url_budget(context, 120, Some(40), 60), Some(52));
     }
 
     #[test]

--- a/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
@@ -233,16 +233,19 @@ pub fn print_share_token_info(token: &str, share_url: &str) {
 }
 
 /// Print summons table
-pub fn print_deployments_table(deployments: &[DeploymentSummary]) {
+pub fn print_deployments_table(
+    deployments: &[DeploymentSummary],
+    output: crate::cli::commands::ResolvedOutput,
+) {
     if deployments.is_empty() {
         print_info("No summons found");
         return;
     }
 
-    use tabled::{settings::Style, Table, Tabled};
+    use tabled::{Table, Tabled};
 
     #[derive(Tabled)]
-    struct Row {
+    struct WideRow {
         #[tabled(rename = "Name")]
         name: String,
         #[tabled(rename = "State")]
@@ -259,9 +262,9 @@ pub fn print_deployments_table(deployments: &[DeploymentSummary]) {
         created: String,
     }
 
-    let rows: Vec<Row> = deployments
+    let wide_rows: Vec<WideRow> = deployments
         .iter()
-        .map(|d| Row {
+        .map(|d| WideRow {
             name: display_name(&d.friendly_name, &d.instance_name).to_string(),
             state: d.state.clone(),
             access: if d.public {
@@ -276,13 +279,73 @@ pub fn print_deployments_table(deployments: &[DeploymentSummary]) {
             },
             replicas: format!("{}/{}", d.replicas.ready, d.replicas.desired),
             url: d.url.clone(),
-            created: crate::output::table_output::format_timestamp(&d.created_at),
+            created: crate::output::table_output::format_created_str(&d.created_at),
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{table}");
+    #[derive(Tabled)]
+    struct CompactRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "State")]
+        state: String,
+        #[tabled(rename = "URL")]
+        url: String,
+        #[tabled(rename = "Replicas")]
+        replicas: String,
+        #[tabled(rename = "Age")]
+        age: String,
+    }
+
+    let context = crate::output::table_output::RenderContext::stdout();
+    let compact_rows = deployments.iter().map(|deployment| CompactRow {
+        name: display_name(&deployment.friendly_name, &deployment.instance_name).to_string(),
+        state: deployment.state.clone(),
+        url: compact_deployment_url(&deployment.url),
+        replicas: format!(
+            "{}/{}",
+            deployment.replicas.ready, deployment.replicas.desired
+        ),
+        age: crate::output::table_output::format_age_str(&deployment.created_at, context.now),
+    });
+    let name_width = deployments
+        .iter()
+        .map(|deployment| {
+            console::measure_text_width(display_name(
+                &deployment.friendly_name,
+                &deployment.instance_name,
+            ))
+        })
+        .max();
+    let rendered = crate::output::table_output::render_table_with_context(
+        Table::new(wide_rows),
+        Some(Table::new(compact_rows)),
+        output,
+        context,
+        name_width,
+    );
+    println!("{rendered}");
+}
+
+fn compact_deployment_url(value: &str) -> String {
+    const MAX_VISIBLE: usize = 36;
+    let compact = url::Url::parse(value)
+        .ok()
+        .and_then(|url| {
+            url.host_str()
+                .map(|host| format!("{}://{host}/…", url.scheme()))
+        })
+        .unwrap_or_else(|| value.to_string());
+
+    if console::measure_text_width(value) <= MAX_VISIBLE {
+        value.to_string()
+    } else if console::measure_text_width(&compact) <= MAX_VISIBLE {
+        compact
+    } else {
+        let mut shortened: String = compact.chars().take(MAX_VISIBLE - 1).collect();
+        shortened.push('…');
+        shortened
+    }
 }
 
 /// Print summons details
@@ -677,6 +740,25 @@ mod tests {
     #[test]
     fn test_display_name_falls_back_to_instance_when_friendly_empty() {
         assert_eq!(display_name("", "uuid-1234"), "uuid-1234");
+    }
+
+    #[test]
+    fn compact_url_keeps_host_visible_and_respects_cap() {
+        let compact = compact_deployment_url(
+            "https://my-service.deployments.basilica.ai/a/very/long/path?token=value",
+        );
+        assert!(compact.starts_with("https://my-service"));
+        assert!(compact.ends_with('…'));
+        assert!(console::measure_text_width(&compact) <= 36);
+    }
+
+    #[test]
+    fn compact_url_caps_pathological_long_hosts() {
+        let compact = compact_deployment_url(
+            "https://this-is-an-unusually-long-subdomain-for-a-deployment.basilica.ai/path",
+        );
+        assert!(console::measure_text_width(&compact) <= 36);
+        assert!(compact.ends_with('…'));
     }
 
     #[test]

--- a/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/helpers.rs
@@ -298,10 +298,10 @@ pub fn print_deployments_table(
     }
 
     let context = crate::output::table_output::RenderContext::stdout();
-    let compact_rows = deployments.iter().map(|deployment| CompactRow {
+    let full_compact_rows = deployments.iter().map(|deployment| CompactRow {
         name: display_name(&deployment.friendly_name, &deployment.instance_name).to_string(),
         state: deployment.state.clone(),
-        url: compact_deployment_url(&deployment.url),
+        url: deployment.url.clone(),
         replicas: format!(
             "{}/{}",
             deployment.replicas.ready, deployment.replicas.desired
@@ -317,9 +317,42 @@ pub fn print_deployments_table(
             ))
         })
         .max();
+    let natural_url_width = deployments
+        .iter()
+        .map(|deployment| console::measure_text_width(&deployment.url))
+        .max()
+        .unwrap_or(3);
+    let mut compact_table = Table::new(full_compact_rows);
+    compact_table.with(tabled::settings::Style::modern());
+    let url_budget = matches!(
+        output,
+        crate::cli::commands::ResolvedOutput::Auto | crate::cli::commands::ResolvedOutput::Compact
+    )
+    .then(|| {
+        compact_url_budget(
+            context,
+            compact_table.total_width(),
+            name_width,
+            natural_url_width,
+        )
+    })
+    .flatten();
+    if let Some(max_visible) = url_budget {
+        let linked_rows = deployments.iter().map(|deployment| CompactRow {
+            name: display_name(&deployment.friendly_name, &deployment.instance_name).to_string(),
+            state: deployment.state.clone(),
+            url: compact_deployment_url(&deployment.url, Some(max_visible)),
+            replicas: format!(
+                "{}/{}",
+                deployment.replicas.ready, deployment.replicas.desired
+            ),
+            age: crate::output::table_output::format_age_str(&deployment.created_at, context.now),
+        });
+        compact_table = Table::new(linked_rows);
+    }
     let rendered = crate::output::table_output::render_table_with_context(
         Table::new(wide_rows),
-        Some(Table::new(compact_rows)),
+        Some(compact_table),
         output,
         context,
         name_width,
@@ -327,25 +360,59 @@ pub fn print_deployments_table(
     println!("{rendered}");
 }
 
-fn compact_deployment_url(value: &str) -> String {
-    const MAX_VISIBLE: usize = 36;
-    let compact = url::Url::parse(value)
-        .ok()
-        .and_then(|url| {
-            url.host_str()
-                .map(|host| format!("{}://{host}/…", url.scheme()))
-        })
-        .unwrap_or_else(|| value.to_string());
+const MIN_COMPACT_URL_WIDTH: usize = 12;
 
-    if console::measure_text_width(value) <= MAX_VISIBLE {
-        value.to_string()
-    } else if console::measure_text_width(&compact) <= MAX_VISIBLE {
+fn compact_url_budget(
+    context: crate::output::table_output::RenderContext,
+    compact_table_width: usize,
+    natural_name_width: Option<usize>,
+    natural_url_width: usize,
+) -> Option<usize> {
+    if !context.is_tty {
+        return None;
+    }
+    let terminal_width = context.width?;
+    let reducible_name_width = natural_name_width
+        .unwrap_or_default()
+        .saturating_sub(crate::output::table_output::MIN_NAME_WIDTH);
+    let minimum_table_width = compact_table_width.saturating_sub(reducible_name_width);
+    let overflow = minimum_table_width.saturating_sub(terminal_width);
+
+    (overflow > 0).then(|| {
+        natural_url_width
+            .saturating_sub(overflow)
+            .max(MIN_COMPACT_URL_WIDTH)
+    })
+}
+
+fn compact_deployment_url(value: &str, max_visible: Option<usize>) -> String {
+    let Some(max_visible) = max_visible else {
+        return value.to_string();
+    };
+    if console::measure_text_width(value) <= max_visible {
+        return value.to_string();
+    }
+
+    let Ok(url) = url::Url::parse(value) else {
+        return value.to_string();
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return value.to_string();
+    }
+    let Some(host) = url.host_str() else {
+        return value.to_string();
+    };
+
+    let compact = format!("{}://{host}/…", url.scheme());
+    let label = if console::measure_text_width(&compact) <= max_visible {
         compact
     } else {
-        let mut shortened: String = compact.chars().take(MAX_VISIBLE - 1).collect();
+        let mut shortened: String = compact.chars().take(max_visible - 1).collect();
         shortened.push('…');
         shortened
-    }
+    };
+
+    crate::output::table_output::link_cell(&label, url.as_str())
 }
 
 /// Print summons details
@@ -744,21 +811,63 @@ mod tests {
 
     #[test]
     fn compact_url_keeps_host_visible_and_respects_cap() {
-        let compact = compact_deployment_url(
-            "https://my-service.deployments.basilica.ai/a/very/long/path?token=value",
-        );
-        assert!(compact.starts_with("https://my-service"));
-        assert!(compact.ends_with('…'));
-        assert!(console::measure_text_width(&compact) <= 36);
+        let url = "https://my-service.deployments.basilica.ai/a/very/long/path?mode=stream";
+        let compact = compact_deployment_url(url, Some(36));
+        assert!(compact.contains(&format!("\x1b]8;;{url}\x1b\\")));
+        assert!(compact.contains('…'));
+        assert!(tabled::grid::util::string::get_line_width(&compact) <= 36);
+        assert!(compact.ends_with("\x1b]8;;\x1b\\"));
     }
 
     #[test]
     fn compact_url_caps_pathological_long_hosts() {
-        let compact = compact_deployment_url(
-            "https://this-is-an-unusually-long-subdomain-for-a-deployment.basilica.ai/path",
-        );
-        assert!(console::measure_text_width(&compact) <= 36);
-        assert!(compact.ends_with('…'));
+        let url = "https://this-is-an-unusually-long-subdomain-for-a-deployment.basilica.ai/path";
+        let compact = compact_deployment_url(url, Some(36));
+        assert!(compact.contains(&format!("\x1b]8;;{url}\x1b\\")));
+        assert!(tabled::grid::util::string::get_line_width(&compact) <= 36);
+        assert!(compact.contains('…'));
+    }
+
+    #[test]
+    fn compact_url_keeps_short_urls_plain() {
+        let url = "https://app.basilica.ai";
+        assert_eq!(compact_deployment_url(url, Some(36)), url);
+    }
+
+    #[test]
+    fn compact_url_keeps_non_tty_output_complete_and_plain() {
+        let url = "https://my-service.deployments.basilica.ai/a/very/long/path?mode=stream";
+        let compact = compact_deployment_url(url, None);
+        assert_eq!(compact, url);
+        assert!(!compact.contains('\x1b'));
+    }
+
+    #[test]
+    fn compact_url_does_not_link_non_http_targets() {
+        let url = "ftp://downloads.example.test/a/very/long/archive/location/file.tar.zst";
+        let compact = compact_deployment_url(url, Some(36));
+        assert_eq!(compact, url);
+        assert!(!compact.contains('\x1b'));
+    }
+
+    #[test]
+    fn compact_url_budget_preserves_url_when_name_can_absorb_overflow() {
+        let context = crate::output::table_output::RenderContext {
+            is_tty: true,
+            width: Some(110),
+            now: chrono::DateTime::UNIX_EPOCH,
+        };
+        assert_eq!(compact_url_budget(context, 120, Some(40), 60), None);
+    }
+
+    #[test]
+    fn compact_url_budget_uses_only_the_unavoidable_overflow() {
+        let context = crate::output::table_output::RenderContext {
+            is_tty: true,
+            width: Some(80),
+            now: chrono::DateTime::UNIX_EPOCH,
+        };
+        assert_eq!(compact_url_budget(context, 120, Some(40), 60), Some(48));
     }
 
     #[test]

--- a/crates/basilica-cli/src/cli/handlers/deploy/mod.rs
+++ b/crates/basilica-cli/src/cli/handlers/deploy/mod.rs
@@ -1,6 +1,6 @@
 //! Deploy command handlers
 
-use crate::cli::commands::{DeployAction, DeployCommand};
+use crate::cli::commands::{DeployAction, DeployCommand, ResolvedOutput};
 use crate::client::create_authenticated_client;
 use crate::config::CliConfig;
 use crate::error::{CliError, DeployError};
@@ -28,6 +28,15 @@ pub async fn handle_deploy(cmd: DeployCommand, config: &CliConfig) -> Result<(),
         validation::validate_deployment_request(&cmd)?;
     }
 
+    // Validate output flags before authentication or network activity.
+    let list_output = match &cmd.action {
+        Some(DeployAction::List { output }) => Some(
+            ResolvedOutput::resolve(cmd.json, *output)
+                .map_err(|message| CliError::Internal(color_eyre::eyre::eyre!(message)))?,
+        ),
+        _ => None,
+    };
+
     // Create authenticated client
     let client = create_authenticated_client(config).await?;
 
@@ -36,7 +45,14 @@ pub async fn handle_deploy(cmd: DeployCommand, config: &CliConfig) -> Result<(),
     let show_phases = cmd.show_phases;
 
     match cmd.action {
-        Some(DeployAction::List) => handle_list(&client, json).await,
+        Some(DeployAction::List { .. }) => {
+            let output = list_output.ok_or_else(|| {
+                CliError::Internal(color_eyre::eyre::eyre!(
+                    "deployment list output was not resolved"
+                ))
+            })?;
+            handle_list(&client, output).await
+        }
         Some(DeployAction::Status { name, show_token }) => {
             let resolved = helpers::resolve_deployment_name(name, &client).await?;
             handle_status(&client, &resolved, json, show_phases, show_token).await
@@ -101,16 +117,19 @@ pub async fn handle_deploy(cmd: DeployCommand, config: &CliConfig) -> Result<(),
 }
 
 /// List all deployments
-async fn handle_list(client: &basilica_sdk::BasilicaClient, json: bool) -> Result<(), CliError> {
+async fn handle_list(
+    client: &basilica_sdk::BasilicaClient,
+    output: ResolvedOutput,
+) -> Result<(), CliError> {
     let spinner = create_spinner("Fetching summons...");
     let result = client.list_deployments().await;
     complete_spinner_and_clear(spinner);
     let response = result.map_err(CliError::Api)?;
 
-    if json {
+    if output.is_json() {
         json_output(&response)?;
     } else {
-        helpers::print_deployments_table(&response.deployments);
+        helpers::print_deployments_table(&response.deployments, output);
     }
 
     Ok(())

--- a/crates/basilica-cli/src/cli/handlers/fund/list.rs
+++ b/crates/basilica-cli/src/cli/handlers/fund/list.rs
@@ -20,7 +20,7 @@ pub async fn handle_list_payments(
     client: &BasilicaClient,
     limit: u32,
     offset: u32,
-    json: bool,
+    output: crate::cli::commands::ResolvedOutput,
 ) -> EyreResult<(), CliError> {
     let spinner = create_spinner("Loading payment history...");
 
@@ -36,16 +36,17 @@ pub async fn handle_list_payments(
     let tao = tao_result.map_err(|e| e.to_string());
     let card = card_result.map_err(|e| e.to_string());
 
-    if json {
+    if output.is_json() {
         render_json(&tao, &card)
     } else {
-        render_text(&tao, &card)
+        render_text(&tao, &card, output)
     }
 }
 
 fn render_text(
     tao: &SourceResult<ListDepositsResponse>,
     card: &SourceResult<ListCardPurchasesResponse>,
+    output: crate::cli::commands::ResolvedOutput,
 ) -> EyreResult<(), CliError> {
     if let (Err(tao_err), Err(card_err)) = (tao, card) {
         return Err(CliError::Internal(
@@ -60,7 +61,7 @@ fn render_text(
     let card_empty = matches!(card, Ok(r) if r.purchases.is_empty());
 
     match tao {
-        Ok(resp) if !resp.deposits.is_empty() => table_output::display_deposits(resp)?,
+        Ok(resp) if !resp.deposits.is_empty() => table_output::display_deposits(resp, output)?,
         Ok(_) => {
             if card.is_err() {
                 print_info("No TAO deposits found yet");

--- a/crates/basilica-cli/src/cli/handlers/fund/list.rs
+++ b/crates/basilica-cli/src/cli/handlers/fund/list.rs
@@ -71,7 +71,9 @@ fn render_text(
     }
 
     match card {
-        Ok(resp) if !resp.purchases.is_empty() => table_output::display_card_purchases(resp)?,
+        Ok(resp) if !resp.purchases.is_empty() => {
+            table_output::display_card_purchases(resp, output)?
+        }
         Ok(_) => {
             if tao.is_err() {
                 print_info("No card payments found yet");

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -1,6 +1,8 @@
 //! GPU rental command handlers
 
-use crate::cli::commands::{ComputeCategoryArg, ListFilters, LogsOptions, PsFilters, UpOptions};
+use crate::cli::commands::{
+    ComputeCategoryArg, ListFilters, LogsOptions, PsFilters, ResolvedOutput, UpOptions,
+};
 use crate::cli::handlers::deploy::helpers::stream_logs_to_stdout;
 use crate::cli::handlers::gpu_rental_helpers::{
     active_rentals_query, get_ssh_private_key_path, print_cloud_section_header,
@@ -33,6 +35,7 @@ use console::style;
 use dialoguer::Input;
 use reqwest::StatusCode;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -328,13 +331,14 @@ async fn fetch_and_filter_community_cloud(
 /// Helper function to display secure cloud GPUs
 fn display_secure_cloud_table(
     gpus: &[basilica_common::types::GpuOffering],
+    output: ResolvedOutput,
 ) -> Result<(), CliError> {
     if gpus.is_empty() {
         print_info("No GPUs available matching your criteria");
         return Ok(());
     }
 
-    table_output::display_secure_cloud_offerings_detailed(gpus)?;
+    table_output::display_secure_cloud_offerings_detailed(gpus, output)?;
 
     Ok(())
 }
@@ -402,18 +406,34 @@ fn total_hourly_cost(hourly_costs: impl IntoIterator<Item = f64>) -> f64 {
 }
 
 fn format_total_hourly_cost(hourly_cost: f64) -> String {
-    // Normalize signed zero so Rust does not format it as "$-0.00/hr".
+    // Normalize signed zero so Rust does not format it as "$-0.00/h".
     let display_cost = if hourly_cost == 0.0 { 0.0 } else { hourly_cost };
-    format!("${:.2}/hr", display_cost)
+    format!("${:.2}/h", display_cost)
 }
 
-fn display_total_hourly_cost(hourly_cost: f64) {
-    println!();
-    println!(
-        "{}: {}",
-        style("Total hourly cost").cyan(),
-        style(format_total_hourly_cost(hourly_cost)).green().bold()
-    );
+fn accrued_cost<'a>(costs: impl IntoIterator<Item = Option<&'a str>>) -> rust_decimal::Decimal {
+    costs
+        .into_iter()
+        .flatten()
+        .filter_map(|cost| cost.parse::<rust_decimal::Decimal>().ok())
+        .sum()
+}
+
+fn format_ps_footer(count: usize, hourly_cost: f64, accrued: rust_decimal::Decimal) -> String {
+    format!(
+        "{} rental{} · {} · {} accrued",
+        count,
+        if count == 1 { "" } else { "s" },
+        format_total_hourly_cost(hourly_cost),
+        format_usd(&accrued.to_string())
+    )
+}
+
+fn display_ps_footer(count: usize, hourly_cost: f64, accrued: rust_decimal::Decimal) {
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("{}", format_ps_footer(count, hourly_cost, accrued));
+    }
 }
 
 fn is_secure_cpu_history_item(rental: &HistoricalRentalItem) -> bool {
@@ -467,7 +487,7 @@ pub async fn handle_ls(
     gpu_category: Option<GpuCategory>,
     filters: ListFilters,
     compute: Option<ComputeCategoryArg>,
-    json: bool,
+    output: ResolvedOutput,
     config: &CliConfig,
 ) -> Result<(), CliError> {
     let api_client = create_authenticated_client(config).await?;
@@ -505,7 +525,7 @@ pub async fn handle_ls(
                 vec![]
             };
 
-            if json {
+            if output.is_json() {
                 #[derive(serde::Serialize)]
                 struct CombinedSecureCloudOfferings<'a> {
                     gpu_offerings: &'a [basilica_common::types::GpuOffering],
@@ -520,13 +540,13 @@ pub async fn handle_ls(
             } else {
                 // Display GPU offerings section
                 println!("{}", style("GPU Offerings").bold().cyan());
-                display_secure_cloud_table(&filtered_gpus)?;
+                display_secure_cloud_table(&filtered_gpus, output)?;
 
                 // Only display CPU offerings section if no GPU type filter
                 if show_cpu {
                     println!();
                     println!("{}", style("The Citadel (CPU)").bold().cyan());
-                    table_output::display_cpu_offerings_detailed(&filtered_cpu)?;
+                    table_output::display_cpu_offerings_detailed(&filtered_cpu, output)?;
                 }
             }
         }
@@ -538,7 +558,7 @@ pub async fn handle_ls(
             complete_spinner_and_clear(spinner);
             let (nodes, _pricing_map) = result?;
 
-            if json {
+            if output.is_json() {
                 // Create a simple response structure for JSON output
                 #[derive(serde::Serialize)]
                 struct NodesResponse<'a> {
@@ -618,7 +638,7 @@ pub async fn handle_ls(
                 vec![]
             };
 
-            if json {
+            if output.is_json() {
                 #[derive(serde::Serialize)]
                 struct CombinedResponse<'a> {
                     secure_cloud: &'a [basilica_common::types::GpuOffering],
@@ -639,14 +659,14 @@ pub async fn handle_ls(
                 println!();
 
                 print_cloud_section_header("The Citadel (GPU)", false);
-                display_secure_cloud_table(&secure_gpus)?;
+                display_secure_cloud_table(&secure_gpus, output)?;
 
                 // Only display CPU offerings section if no GPU type filter
                 if show_cpu {
                     println!();
 
                     print_cloud_section_header("The Citadel (CPU)", false);
-                    table_output::display_cpu_offerings_detailed(&filtered_cpu)?;
+                    table_output::display_cpu_offerings_detailed(&filtered_cpu, output)?;
                 }
             }
         }
@@ -1310,7 +1330,7 @@ pub async fn handle_up(
 pub async fn handle_ps(
     filters: PsFilters,
     compute: Option<ComputeCategoryArg>,
-    json: bool,
+    output: ResolvedOutput,
     config: &CliConfig,
 ) -> Result<(), CliError> {
     use basilica_common::types::ComputeCategory;
@@ -1335,7 +1355,7 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     json_output(&history)?;
                 } else {
                     // Filter to only community cloud rentals and sort by start time (most recent first)
@@ -1384,13 +1404,20 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     json_output(&rentals_list)?;
                 } else {
-                    table_output::display_rental_items(&rentals_list.rentals[..])?;
-
-                    println!("\nTotal: {} active rentals", rentals_list.rentals.len());
-                    display_total_hourly_cost(bourse_total_hourly_cost(&rentals_list.rentals));
+                    table_output::display_rental_items(&rentals_list.rentals[..], output)?;
+                    display_ps_footer(
+                        rentals_list.rentals.len(),
+                        bourse_total_hourly_cost(&rentals_list.rentals),
+                        accrued_cost(
+                            rentals_list
+                                .rentals
+                                .iter()
+                                .map(|rental| rental.accumulated_cost.as_deref()),
+                        ),
+                    );
 
                     display_ps_quick_start_commands();
                 }
@@ -1409,7 +1436,7 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     use serde_json::json;
                     let mut secure_gpu_history: Vec<_> = history
                         .rentals
@@ -1516,7 +1543,7 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     use serde_json::json;
                     let output = json!({
                         "gpu_rentals": gpu_rentals_list,
@@ -1531,12 +1558,7 @@ pub async fn handle_ps(
                             .collect();
 
                     println!("{}", style("The Citadel (GPU)").bold().cyan());
-                    table_output::display_secure_cloud_rentals(&gpu_rentals_to_display)?;
-
-                    println!(
-                        "\nTotal: {} Citadel (GPU) rentals",
-                        gpu_rentals_to_display.len()
-                    );
+                    table_output::display_secure_cloud_rentals(&gpu_rentals_to_display, output)?;
 
                     println!();
 
@@ -1548,12 +1570,7 @@ pub async fn handle_ps(
                         .collect();
 
                     println!("{}", style("The Citadel (CPU)").bold().cyan());
-                    table_output::display_cpu_rentals(&cpu_rentals_to_display)?;
-
-                    println!(
-                        "\nTotal: {} Citadel (CPU) rentals",
-                        cpu_rentals_to_display.len()
-                    );
+                    table_output::display_cpu_rentals(&cpu_rentals_to_display, output)?;
 
                     let total_hourly_cost = citadel_total_hourly_cost(
                         gpu_rentals_to_display
@@ -1561,7 +1578,17 @@ pub async fn handle_ps(
                             .chain(cpu_rentals_to_display.iter())
                             .copied(),
                     );
-                    display_total_hourly_cost(total_hourly_cost);
+                    let accrued = accrued_cost(
+                        gpu_rentals_to_display
+                            .iter()
+                            .chain(cpu_rentals_to_display.iter())
+                            .map(|rental| rental.accumulated_cost.as_deref()),
+                    );
+                    display_ps_footer(
+                        gpu_rentals_to_display.len() + cpu_rentals_to_display.len(),
+                        total_hourly_cost,
+                        accrued,
+                    );
 
                     display_ps_quick_start_commands();
                 }
@@ -1594,7 +1621,7 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     use serde_json::json;
                     // Split history by cloud type and sort by start time (most recent first)
                     let mut community_history: Vec<_> = history
@@ -1757,7 +1784,7 @@ pub async fn handle_ps(
 
                 complete_spinner_and_clear(spinner);
 
-                if json {
+                if output.is_json() {
                     use serde_json::json;
                     let output = json!({
                         "community_cloud": community_rentals_list,
@@ -1769,12 +1796,10 @@ pub async fn handle_ps(
                     // Section 1: Community Cloud
                     print_cloud_section_header("The Bourse", true);
 
-                    table_output::display_rental_items(&community_rentals_list.rentals[..])?;
-
-                    println!(
-                        "\nTotal: {} Bourse rentals",
-                        community_rentals_list.rentals.len()
-                    );
+                    table_output::display_rental_items(
+                        &community_rentals_list.rentals[..],
+                        output,
+                    )?;
 
                     println!();
 
@@ -1786,12 +1811,7 @@ pub async fn handle_ps(
                             .into_iter()
                             .collect();
 
-                    table_output::display_secure_cloud_rentals(&secure_rentals_to_display)?;
-
-                    println!(
-                        "\nTotal: {} Citadel (GPU) rentals",
-                        secure_rentals_to_display.len()
-                    );
+                    table_output::display_secure_cloud_rentals(&secure_rentals_to_display, output)?;
 
                     println!();
 
@@ -1804,12 +1824,7 @@ pub async fn handle_ps(
                         .filter(|r| r.stopped_at.is_none() && r.gpu_count == 0)
                         .collect();
 
-                    table_output::display_cpu_rentals(&cpu_rentals_to_display)?;
-
-                    println!(
-                        "\nTotal: {} Citadel (CPU) rentals",
-                        cpu_rentals_to_display.len()
-                    );
+                    table_output::display_cpu_rentals(&cpu_rentals_to_display, output)?;
 
                     let total_hourly_cost =
                         bourse_total_hourly_cost(&community_rentals_list.rentals)
@@ -1819,7 +1834,25 @@ pub async fn handle_ps(
                                     .chain(cpu_rentals_to_display.iter())
                                     .copied(),
                             );
-                    display_total_hourly_cost(total_hourly_cost);
+                    let accrued = accrued_cost(
+                        community_rentals_list
+                            .rentals
+                            .iter()
+                            .map(|rental| rental.accumulated_cost.as_deref())
+                            .chain(
+                                secure_rentals_to_display
+                                    .iter()
+                                    .chain(cpu_rentals_to_display.iter())
+                                    .map(|rental| rental.accumulated_cost.as_deref()),
+                            ),
+                    );
+                    display_ps_footer(
+                        community_rentals_list.rentals.len()
+                            + secure_rentals_to_display.len()
+                            + cpu_rentals_to_display.len(),
+                        total_hourly_cost,
+                        accrued,
+                    );
 
                     display_ps_quick_start_commands();
                 }
@@ -3174,17 +3207,18 @@ fn display_ps_quick_start_commands() {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_total_hourly_cost, total_hourly_cost};
+    use super::{format_ps_footer, format_total_hourly_cost, total_hourly_cost};
+    use rust_decimal::Decimal;
 
     #[test]
     fn format_total_hourly_cost_uses_two_decimal_places() {
-        assert_eq!(format_total_hourly_cost(12.345), "$12.35/hr");
-        assert_eq!(format_total_hourly_cost(0.0), "$0.00/hr");
+        assert_eq!(format_total_hourly_cost(12.345), "$12.35/h");
+        assert_eq!(format_total_hourly_cost(0.0), "$0.00/h");
     }
 
     #[test]
     fn format_total_hourly_cost_does_not_show_negative_zero() {
-        assert_eq!(format_total_hourly_cost(-0.0), "$0.00/hr");
+        assert_eq!(format_total_hourly_cost(-0.0), "$0.00/h");
     }
 
     #[test]
@@ -3194,6 +3228,14 @@ mod tests {
 
         let total = total_hourly_cost(bourse_rates.into_iter().flatten().chain(citadel_rates));
 
-        assert_eq!(format_total_hourly_cost(total), "$7.50/hr");
+        assert_eq!(format_total_hourly_cost(total), "$7.50/h");
+    }
+
+    #[test]
+    fn ps_footer_matches_the_human_output_contract() {
+        assert_eq!(
+            format_ps_footer(3, 4.05, Decimal::new(2310, 2)),
+            "3 rentals · $4.05/h · $23.10 accrued"
+        );
     }
 }

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -454,7 +454,7 @@ fn accrued_cost<'a>(costs: impl IntoIterator<Item = Option<&'a str>>) -> rust_de
 
 fn format_ps_footer(count: usize, hourly_cost: f64, accrued: rust_decimal::Decimal) -> String {
     format!(
-        "Rentals shown: {}\nCombined hourly price: {}\nAccrued cost: {}",
+        "Total rentals: {}\nCombined hourly price: {}\nAccrued cost: {}",
         count,
         format_total_hourly_cost(hourly_cost),
         format_usd(&accrued.to_string())
@@ -3284,7 +3284,7 @@ mod tests {
     fn ps_footer_matches_the_human_output_contract() {
         assert_eq!(
             format_ps_footer(3, 4.05, Decimal::new(2310, 2)),
-            "Rentals shown: 3\nCombined hourly price: $4.05/h\nAccrued cost: $23.10"
+            "Total rentals: 3\nCombined hourly price: $4.05/h\nAccrued cost: $23.10"
         );
     }
 }

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -1398,7 +1398,7 @@ pub async fn handle_ps(
                         .collect();
                     community_history.sort_by_key(|r| std::cmp::Reverse(r.started_at));
 
-                    table_output::display_rental_history(&community_history)?;
+                    table_output::display_rental_history(&community_history, output)?;
 
                     // Calculate total cost for community cloud only
                     let total_cost: rust_decimal::Decimal = community_history
@@ -1518,7 +1518,7 @@ pub async fn handle_ps(
                     secure_cpu_history.sort_by_key(|r| std::cmp::Reverse(r.started_at));
 
                     print_cloud_section_header("The Citadel (GPU) Rental History", true);
-                    table_output::display_rental_history(&secure_gpu_history)?;
+                    table_output::display_rental_history(&secure_gpu_history, output)?;
 
                     let secure_gpu_total_cost: rust_decimal::Decimal = secure_gpu_history
                         .iter()
@@ -1541,7 +1541,7 @@ pub async fn handle_ps(
                     println!();
 
                     print_cloud_section_header("The Citadel (CPU) History", false);
-                    table_output::display_cpu_rental_history(&secure_cpu_history)?;
+                    table_output::display_cpu_rental_history(&secure_cpu_history, output)?;
 
                     let secure_cpu_total_cost: rust_decimal::Decimal = secure_cpu_history
                         .iter()
@@ -1718,7 +1718,7 @@ pub async fn handle_ps(
 
                     // Display community cloud history
                     print_cloud_section_header("The Bourse History", true);
-                    table_output::display_rental_history(&community_history)?;
+                    table_output::display_rental_history(&community_history, output)?;
 
                     let community_total_cost: rust_decimal::Decimal = community_history
                         .iter()
@@ -1742,7 +1742,7 @@ pub async fn handle_ps(
 
                     // Display secure cloud GPU history
                     print_cloud_section_header("The Citadel (GPU) History", false);
-                    table_output::display_rental_history(&secure_gpu_history)?;
+                    table_output::display_rental_history(&secure_gpu_history, output)?;
 
                     let secure_gpu_total_cost: rust_decimal::Decimal = secure_gpu_history
                         .iter()
@@ -1766,7 +1766,7 @@ pub async fn handle_ps(
 
                     // Display secure cloud CPU history
                     print_cloud_section_header("The Citadel (CPU) History", false);
-                    table_output::display_cpu_rental_history(&secure_cpu_history)?;
+                    table_output::display_cpu_rental_history(&secure_cpu_history, output)?;
 
                     let secure_cpu_total_cost: rust_decimal::Decimal = secure_cpu_history
                         .iter()

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -345,7 +345,10 @@ fn display_secure_cloud_table(
 }
 
 /// Helper function to display community cloud nodes (aggregated by GPU category)
-fn display_community_cloud_table(nodes: &[basilica_sdk::AvailableNode]) -> Result<(), CliError> {
+fn display_community_cloud_table(
+    nodes: &[basilica_sdk::AvailableNode],
+    output: ResolvedOutput,
+) -> Result<(), CliError> {
     if nodes.is_empty() {
         print_info("No GPUs available matching your criteria");
         return Ok(());
@@ -353,7 +356,7 @@ fn display_community_cloud_table(nodes: &[basilica_sdk::AvailableNode]) -> Resul
 
     use crate::cli::handlers::gpu_rental_helpers::aggregate_nodes_by_gpu_category;
     let aggregations = aggregate_nodes_by_gpu_category(nodes);
-    table_output::display_community_cloud_categories(&aggregations)?;
+    table_output::display_community_cloud_categories(&aggregations, output)?;
 
     Ok(())
 }
@@ -599,7 +602,7 @@ pub async fn handle_ls(
                 };
                 json_output(&response)?;
             } else {
-                display_community_cloud_table(&nodes)?;
+                display_community_cloud_table(&nodes, output)?;
             }
         }
         None => {
@@ -684,7 +687,7 @@ pub async fn handle_ls(
                 json_output(&response)?;
             } else {
                 print_cloud_section_header("The Bourse (GPU)", true);
-                display_community_cloud_table(&community_nodes)?;
+                display_community_cloud_table(&community_nodes, output)?;
 
                 println!();
 

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -454,9 +454,8 @@ fn accrued_cost<'a>(costs: impl IntoIterator<Item = Option<&'a str>>) -> rust_de
 
 fn format_ps_footer(count: usize, hourly_cost: f64, accrued: rust_decimal::Decimal) -> String {
     format!(
-        "{} rental{} · {} · {} accrued",
+        "Rentals shown: {}\nCombined hourly price: {}\nAccrued cost: {}",
         count,
-        if count == 1 { "" } else { "s" },
         format_total_hourly_cost(hourly_cost),
         format_usd(&accrued.to_string())
     )
@@ -3285,7 +3284,7 @@ mod tests {
     fn ps_footer_matches_the_human_output_contract() {
         assert_eq!(
             format_ps_footer(3, 4.05, Decimal::new(2310, 2)),
-            "3 rentals · $4.05/h · $23.10 accrued"
+            "Rentals shown: 3\nCombined hourly price: $4.05/h\nAccrued cost: $23.10"
         );
     }
 }

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -33,6 +33,7 @@ use color_eyre::eyre::eyre;
 use color_eyre::Section;
 use console::style;
 use dialoguer::Input;
+use futures::{stream, StreamExt};
 use reqwest::StatusCode;
 use std::collections::HashMap;
 use std::io::IsTerminal;
@@ -403,6 +404,35 @@ fn citadel_total_hourly_cost<'a>(
 
 fn total_hourly_cost(hourly_costs: impl IntoIterator<Item = f64>) -> f64 {
     hourly_costs.into_iter().sum()
+}
+
+async fn bourse_access_hosts(
+    client: &basilica_sdk::BasilicaClient,
+    rentals: &[basilica_sdk::types::ApiRentalListItem],
+) -> HashMap<String, String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    stream::iter(
+        rentals
+            .iter()
+            .filter(|rental| rental.has_ssh)
+            .map(|rental| {
+                let rental_id = rental.rental_id.clone();
+                async move {
+                    let status =
+                        tokio::time::timeout_at(deadline, client.get_rental_status(&rental_id))
+                            .await
+                            .ok()?
+                            .ok()?;
+                    let credentials = status.ssh_credentials?;
+                    let (host, _, _) = parse_ssh_credentials(&credentials).ok()?;
+                    Some((rental_id, host))
+                }
+            }),
+    )
+    .buffer_unordered(8)
+    .filter_map(|entry| async move { entry })
+    .collect()
+    .await
 }
 
 fn format_total_hourly_cost(hourly_cost: f64) -> String {
@@ -1402,12 +1432,22 @@ pub async fn handle_ps(
                     complete_spinner_error(spinner.clone(), "Failed to load rentals")
                 })?;
 
+                let access_hosts = if output.is_json() {
+                    HashMap::new()
+                } else {
+                    bourse_access_hosts(&api_client, &rentals_list.rentals).await
+                };
+
                 complete_spinner_and_clear(spinner);
 
                 if output.is_json() {
                     json_output(&rentals_list)?;
                 } else {
-                    table_output::display_rental_items(&rentals_list.rentals[..], output)?;
+                    table_output::display_rental_items(
+                        &rentals_list.rentals,
+                        &access_hosts,
+                        output,
+                    )?;
                     display_ps_footer(
                         rentals_list.rentals.len(),
                         bourse_total_hourly_cost(&rentals_list.rentals),
@@ -1782,6 +1822,12 @@ pub async fn handle_ps(
                     }
                 });
 
+                let access_hosts = if output.is_json() {
+                    HashMap::new()
+                } else {
+                    bourse_access_hosts(&api_client, &community_rentals_list.rentals).await
+                };
+
                 complete_spinner_and_clear(spinner);
 
                 if output.is_json() {
@@ -1797,7 +1843,8 @@ pub async fn handle_ps(
                     print_cloud_section_header("The Bourse", true);
 
                     table_output::display_rental_items(
-                        &community_rentals_list.rentals[..],
+                        &community_rentals_list.rentals,
+                        &access_hosts,
                         output,
                     )?;
 

--- a/crates/basilica-cli/src/cli/handlers/tokens.rs
+++ b/crates/basilica-cli/src/cli/handlers/tokens.rs
@@ -94,10 +94,13 @@ pub async fn handle_create_token(
 }
 
 /// Handle listing all tokens
-pub async fn handle_list_tokens(client: &BasilicaClient, json: bool) -> Result<(), CliError> {
+pub async fn handle_list_tokens(
+    client: &BasilicaClient,
+    output: crate::cli::commands::ResolvedOutput,
+) -> Result<(), CliError> {
     let keys = client.list_api_keys().await.map_err(CliError::Api)?;
 
-    if json {
+    if output.is_json() {
         json_output(&keys)?;
         return Ok(());
     }
@@ -109,7 +112,7 @@ pub async fn handle_list_tokens(client: &BasilicaClient, json: bool) -> Result<(
             style("basilica").cyan()
         );
     } else {
-        table_output::display_api_keys(&keys).map_err(|e| {
+        table_output::display_api_keys(&keys, output).map_err(|e| {
             CliError::Internal(color_eyre::eyre::eyre!("Failed to display API keys: {}", e))
         })?;
     }

--- a/crates/basilica-cli/src/cli/handlers/volumes.rs
+++ b/crates/basilica-cli/src/cli/handlers/volumes.rs
@@ -550,10 +550,13 @@ pub async fn handle_create_volume(
 }
 
 /// Handle listing volumes
-pub async fn handle_list_volumes(client: &BasilicaClient, json: bool) -> Result<(), CliError> {
+pub async fn handle_list_volumes(
+    client: &BasilicaClient,
+    output: crate::cli::commands::ResolvedOutput,
+) -> Result<(), CliError> {
     let response = client.list_volumes().await.map_err(CliError::Api)?;
 
-    if json {
+    if output.is_json() {
         json_output(&response)?;
         return Ok(());
     }
@@ -568,7 +571,7 @@ pub async fn handle_list_volumes(client: &BasilicaClient, json: bool) -> Result<
         return Ok(());
     }
 
-    table_output::display_volumes(&response.volumes)?;
+    table_output::display_volumes(&response.volumes, output)?;
 
     println!();
     println!("Total volumes: {}", response.total_count);

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -437,7 +437,9 @@ fn compact_image_name(image: &str) -> String {
     let without_digest = image.split('@').next().unwrap_or(image);
     let last_slash = without_digest.rfind('/');
     let without_tag = match without_digest.rfind(':') {
-        Some(colon) if last_slash.is_none_or(|slash| colon > slash) => &without_digest[..colon],
+        Some(colon) if !matches!(last_slash, Some(slash) if colon <= slash) => {
+            &without_digest[..colon]
+        }
         _ => without_digest,
     };
     let mut parts = without_tag.split('/');

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -191,6 +191,15 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("Age"),
 ];
 
+const FUND_DEPOSIT_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("Date"),
+    AdaptiveColumn::required("TAO"),
+    AdaptiveColumn::required("Tx Hash"),
+    AdaptiveColumn::optional("Conf", 2),
+    AdaptiveColumn::optional("Block", 1),
+    AdaptiveColumn::required("Status"),
+];
+
 const TOKEN_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
     AdaptiveColumn::required("Created"),
@@ -471,6 +480,38 @@ pub fn format_timestamp(timestamp: &str) -> String {
 
 fn format_utc_date(timestamp: &DateTime<Utc>) -> String {
     timestamp.format("%Y-%m-%d").to_string()
+}
+
+fn compact_tx_hash(hash: &str) -> String {
+    const PREFIX_LENGTH: usize = 6;
+    const SUFFIX_LENGTH: usize = 3;
+    const COMPACT_LENGTH: usize = PREFIX_LENGTH + 1 + SUFFIX_LENGTH;
+
+    let length = hash.chars().count();
+    if length <= COMPACT_LENGTH {
+        return hash.to_string();
+    }
+
+    let prefix: String = hash.chars().take(PREFIX_LENGTH).collect();
+    let suffix: String = hash.chars().skip(length - SUFFIX_LENGTH).collect();
+    format!("{prefix}…{suffix}")
+}
+
+fn taostats_extrinsic_url(hash: &str) -> Option<String> {
+    let mut url = url::Url::parse("https://taostats.io").ok()?;
+    url.path_segments_mut().ok()?.extend(["extrinsic", hash]);
+    Some(url.to_string())
+}
+
+fn deposit_tx_hash_cell(hash: &str, is_tty: bool) -> String {
+    let label = compact_tx_hash(hash);
+    if !is_tty {
+        return label;
+    }
+
+    taostats_extrinsic_url(hash)
+        .map(|url| link_cell(&label, &url))
+        .unwrap_or(label)
 }
 
 fn format_duration(seconds: i64) -> String {
@@ -997,63 +1038,74 @@ pub fn display_secure_cloud_offerings_detailed(
 }
 
 /// Display deposits history in table format
-pub fn display_deposits(response: &ListDepositsResponse) -> Result<()> {
+pub fn display_deposits(response: &ListDepositsResponse, output: ResolvedOutput) -> Result<()> {
     println!();
     println!("{}", style("Deposit History").bold());
     println!();
 
-    let mut builder = Builder::default();
-
-    // Add header
-    builder.push_record(["Date", "TAO", "Tx Hash", "Conf", "Block", "Status"]);
-
-    let mut total_tao = 0.0;
-
-    for deposit in &response.deposits {
-        let amount_tao: f64 = deposit.amount_tao.parse().unwrap_or(0.0);
-        total_tao += amount_tao;
-
-        // Format date
-        let date = format_utc_date(&deposit.observed_at);
-
-        // Format tx hash (truncate to first 8 and last 3 chars)
-        let tx_hash = if deposit.tx_hash.len() > 11 {
-            format!(
-                "{}...{}",
-                &deposit.tx_hash[..8],
-                &deposit.tx_hash[deposit.tx_hash.len() - 3..]
-            )
-        } else {
-            deposit.tx_hash.clone()
-        };
-
-        // Format confirmations (12+ means finalized)
-        let confirmations = if deposit.finalized_at.is_some() {
-            "12+".to_string()
-        } else {
-            "-".to_string()
-        };
-
-        // Format status
-        let status = if deposit.credited_at.is_some() {
-            "Credited"
-        } else if deposit.finalized_at.is_some() {
-            "Finalized"
-        } else {
-            "Pending"
-        };
-
-        builder.push_record([
-            date.as_str(),
-            &format!("{:.3}", amount_tao),
-            tx_hash.as_str(),
-            confirmations.as_str(),
-            &deposit.block_number.to_string(),
-            status,
-        ]);
+    #[derive(Clone, Tabled)]
+    struct DepositRow {
+        #[tabled(rename = "Date")]
+        date: String,
+        #[tabled(rename = "TAO")]
+        amount: String,
+        #[tabled(rename = "Tx Hash")]
+        tx_hash: String,
+        #[tabled(rename = "Conf")]
+        confirmations: String,
+        #[tabled(rename = "Block")]
+        block: String,
+        #[tabled(rename = "Status")]
+        status: String,
     }
 
-    print_standard_table(builder.build());
+    let mut total_tao = 0.0;
+    let context = RenderContext::stdout();
+    let rows: Vec<DepositRow> = response
+        .deposits
+        .iter()
+        .map(|deposit| {
+            let amount_tao: f64 = deposit.amount_tao.parse().unwrap_or(0.0);
+            total_tao += amount_tao;
+
+            DepositRow {
+                date: format_utc_date(&deposit.observed_at),
+                amount: format!("{amount_tao:.3}"),
+                tx_hash: deposit_tx_hash_cell(&deposit.tx_hash, context.is_tty),
+                confirmations: if deposit.finalized_at.is_some() {
+                    "12+".to_string()
+                } else {
+                    "-".to_string()
+                },
+                block: deposit.block_number.to_string(),
+                status: if deposit.credited_at.is_some() {
+                    "Credited".to_string()
+                } else if deposit.finalized_at.is_some() {
+                    "Finalized".to_string()
+                } else {
+                    "Pending".to_string()
+                },
+            }
+        })
+        .collect();
+
+    let adaptive = AdaptiveTable::new(
+        FUND_DEPOSIT_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.date.clone(),
+                    row.amount.clone(),
+                    row.tx_hash.clone(),
+                    row.confirmations.clone(),
+                    row.block.clone(),
+                    row.status.clone(),
+                ]
+            })
+            .collect(),
+    );
+    let rendered = render_adaptive_table_with_context(Table::new(rows), adaptive, output, context);
+    println!("{rendered}");
 
     // Display totals
     println!();
@@ -2420,6 +2472,88 @@ mod tests {
     #[test]
     fn funding_history_dates_do_not_include_times() {
         assert_eq!(format_utc_date(&DateTime::UNIX_EPOCH), "1970-01-01");
+    }
+
+    #[test]
+    fn deposit_columns_drop_block_then_confirmations() {
+        assert_eq!(
+            schema(FUND_DEPOSIT_COLUMNS),
+            vec![
+                ("Date", None),
+                ("TAO", None),
+                ("Tx Hash", None),
+                ("Conf", Some(2)),
+                ("Block", Some(1)),
+                ("Status", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn deposit_hash_uses_short_link_to_taostats() {
+        let hash = "0x1234567890abcdef1234567890abcdef";
+        let cell = deposit_tx_hash_cell(hash, true);
+
+        assert_eq!(get_text_width(&cell), 10);
+        assert!(cell.contains("0x1234…def"));
+        assert!(cell.contains(&format!(
+            "\x1b]8;;https://taostats.io/extrinsic/{hash}\x1b\\"
+        )));
+        assert!(cell.ends_with("\x1b]8;;\x1b\\"));
+    }
+
+    #[test]
+    fn deposit_hash_stays_plain_outside_a_terminal() {
+        let hash = "0x1234567890abcdef1234567890abcdef";
+        assert_eq!(deposit_tx_hash_cell(hash, false), "0x1234…def");
+    }
+
+    #[test]
+    fn deposit_compact_omits_block_and_confirmations() {
+        #[derive(Tabled)]
+        struct DepositTestRow {
+            date: String,
+            amount: String,
+            tx_hash: String,
+            confirmations: String,
+            block: String,
+            status: String,
+        }
+
+        let values = vec![
+            "2026-07-13".to_string(),
+            "1.250".to_string(),
+            deposit_tx_hash_cell("0x1234567890abcdef1234567890abcdef", true),
+            "12+".to_string(),
+            "123456".to_string(),
+            "Credited".to_string(),
+        ];
+        let rendered = render_adaptive_table_with_context(
+            Table::new([DepositTestRow {
+                date: values[0].clone(),
+                amount: values[1].clone(),
+                tx_hash: values[2].clone(),
+                confirmations: values[3].clone(),
+                block: values[4].clone(),
+                status: values[5].clone(),
+            }]),
+            AdaptiveTable::new(FUND_DEPOSIT_COLUMNS.to_vec(), vec![values]),
+            ResolvedOutput::Compact,
+            RenderContext {
+                is_tty: true,
+                width: Some(60),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        let header = rendered.lines().nth(1).expect("header row");
+        assert!(header.contains("Date"));
+        assert!(header.contains("TAO"));
+        assert!(header.contains("Tx Hash"));
+        assert!(header.contains("Status"));
+        assert!(!header.contains("Conf"));
+        assert!(!header.contains("Block"));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 60));
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -1453,12 +1453,10 @@ pub fn display_usage_history(history: &UsageHistoryResponse) -> Result<()> {
 }
 
 fn historical_rental_name(rental: &HistoricalRentalItem) -> String {
-    rental.name.clone().unwrap_or_else(|| {
-        format!(
-            "id:{}",
-            rental.rental_id.chars().take(8).collect::<String>()
-        )
-    })
+    rental
+        .name
+        .clone()
+        .unwrap_or_else(|| rental.rental_id.clone())
 }
 
 fn render_rental_history_with_context(
@@ -2598,11 +2596,25 @@ mod tests {
     }
 
     #[test]
-    fn history_name_falls_back_to_locally_shortened_api_rental_id() {
+    fn history_name_falls_back_to_full_api_rental_id() {
         let mut rental = historical_rental_fixture();
         rental.name = None;
 
-        assert_eq!(historical_rental_name(&rental), "id:rental-c");
+        assert_eq!(historical_rental_name(&rental), "rental-c1234567890");
+
+        let context = RenderContext {
+            is_tty: true,
+            width: Some(25),
+            now: DateTime::UNIX_EPOCH,
+        };
+        let wide = render_rental_history_with_context(&[&rental], ResolvedOutput::Wide, context);
+        let compact =
+            render_rental_history_with_context(&[&rental], ResolvedOutput::Compact, context);
+
+        assert!(wide.contains("rental-c1234567890"));
+        assert!(!compact.contains("rental-c1234567890"));
+        assert!(compact.contains("rental-…"));
+        assert!(compact.lines().all(|line| get_text_width(line) <= 25));
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -23,7 +23,7 @@ use tabled::{
     Table, Tabled,
 };
 
-pub(crate) const MIN_NAME_WIDTH: usize = 12;
+pub(crate) const MIN_NAME_WIDTH: usize = 8;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RenderContext {
@@ -1689,11 +1689,11 @@ mod tests {
         let rendered = render_test_table(ResolvedOutput::Compact, true, 20);
         assert_eq!(
             rendered,
-            "┌──────────────┬──────────────┐\n\
-             │ Name         │ State        │\n\
-             ├──────────────┼──────────────┤\n\
-             │ training-re… │ provisioning │\n\
-             └──────────────┴──────────────┘"
+            "┌──────────┬──────────────┐\n\
+             │ Name     │ State        │\n\
+             ├──────────┼──────────────┤\n\
+             │ trainin… │ provisioning │\n\
+             └──────────┴──────────────┘"
         );
     }
 

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -161,7 +161,7 @@ const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("Image", 3),
     AdaptiveColumn::optional("CPU/RAM", 2),
     AdaptiveColumn::optional("Location", 4),
-    AdaptiveColumn::optional("Cost/Hr", 6),
+    AdaptiveColumn::optional("Price/Hr", 6),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -174,7 +174,7 @@ const PS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("CPU/RAM", 2),
     AdaptiveColumn::optional("Region", 3),
-    AdaptiveColumn::optional("Cost/Hr", 5),
+    AdaptiveColumn::optional("Price/Hr", 5),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -186,7 +186,7 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("State", 5),
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("Region", 2),
-    AdaptiveColumn::optional("Cost/Hr", 4),
+    AdaptiveColumn::optional("Price/Hr", 4),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -510,7 +510,7 @@ pub fn display_rental_items(
         cpu_ram: String,
         #[tabled(rename = "Location")]
         location: String,
-        #[tabled(rename = "Cost/Hr")]
+        #[tabled(rename = "Price/Hr")]
         rate_per_hour: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -1498,7 +1498,7 @@ pub fn display_secure_cloud_rentals(
         cpu_ram: String,
         #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "Cost/Hr")]
+        #[tabled(rename = "Price/Hr")]
         hourly_cost: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -1673,7 +1673,7 @@ pub fn display_cpu_rentals(
         ip: String,
         #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "Cost/Hr")]
+        #[tabled(rename = "Price/Hr")]
         hourly_cost: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -2174,7 +2174,7 @@ mod tests {
                 ("Image", Some(3)),
                 ("CPU/RAM", Some(2)),
                 ("Location", Some(4)),
-                ("Cost/Hr", Some(6)),
+                ("Price/Hr", Some(6)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]
@@ -2189,7 +2189,7 @@ mod tests {
                 ("IP", None),
                 ("CPU/RAM", Some(2)),
                 ("Region", Some(3)),
-                ("Cost/Hr", Some(5)),
+                ("Price/Hr", Some(5)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]
@@ -2203,7 +2203,7 @@ mod tests {
                 ("State", Some(5)),
                 ("IP", None),
                 ("Region", Some(2)),
-                ("Cost/Hr", Some(4)),
+                ("Price/Hr", Some(4)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -130,26 +130,26 @@ impl AdaptiveColumn {
 const LS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required_truncatable("GPU", 1, MIN_GPU_WIDTH),
     AdaptiveColumn::required("Available"),
-    AdaptiveColumn::required("Price/hr"),
+    AdaptiveColumn::required("Price/Hr"),
 ];
 
 const LS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::optional("PROVIDER", 4),
+    AdaptiveColumn::optional("Provider", 4),
     AdaptiveColumn::required_truncatable("GPU", 1, MIN_GPU_WIDTH),
     AdaptiveColumn::required("VRAM"),
     AdaptiveColumn::optional("CPU/RAM", 1),
-    AdaptiveColumn::optional("STORAGE", 2),
-    AdaptiveColumn::optional("INTERCONNECT", 3),
-    AdaptiveColumn::required("REGION"),
-    AdaptiveColumn::required("PRICE/HR"),
+    AdaptiveColumn::optional("Storage", 2),
+    AdaptiveColumn::optional("Interconnect", 3),
+    AdaptiveColumn::required("Region"),
+    AdaptiveColumn::required("Price/Hr"),
 ];
 
 const LS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::required("PROVIDER"),
-    AdaptiveColumn::required("SIZE"),
-    AdaptiveColumn::optional("STORAGE", 1),
-    AdaptiveColumn::required("REGION"),
-    AdaptiveColumn::required("PRICE/HR"),
+    AdaptiveColumn::required("Provider"),
+    AdaptiveColumn::required("Size"),
+    AdaptiveColumn::optional("Storage", 1),
+    AdaptiveColumn::required("Region"),
+    AdaptiveColumn::required("Price/Hr"),
 ];
 
 const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
@@ -161,7 +161,7 @@ const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("Image", 3),
     AdaptiveColumn::optional("CPU/RAM", 2),
     AdaptiveColumn::optional("Location", 4),
-    AdaptiveColumn::optional("Rate/hr", 6),
+    AdaptiveColumn::optional("Cost/Hr", 6),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -174,7 +174,7 @@ const PS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("CPU/RAM", 2),
     AdaptiveColumn::optional("Region", 3),
-    AdaptiveColumn::optional("Rate/hr", 5),
+    AdaptiveColumn::optional("Cost/Hr", 5),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -186,7 +186,7 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("State", 5),
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("Region", 2),
-    AdaptiveColumn::optional("Rate/hr", 4),
+    AdaptiveColumn::optional("Cost/Hr", 4),
     AdaptiveColumn::optional("Total Cost", 1),
     AdaptiveColumn::required("Age"),
 ];
@@ -510,7 +510,7 @@ pub fn display_rental_items(
         cpu_ram: String,
         #[tabled(rename = "Location")]
         location: String,
-        #[tabled(rename = "Rate/hr")]
+        #[tabled(rename = "Cost/Hr")]
         rate_per_hour: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -802,7 +802,7 @@ pub fn display_community_cloud_categories(
         gpu: String,
         #[tabled(rename = "Available")]
         available: String,
-        #[tabled(rename = "Price/hr")]
+        #[tabled(rename = "Price/Hr")]
         price: String,
     }
 
@@ -871,7 +871,7 @@ pub fn display_secure_cloud_offerings_detailed(
 
     #[derive(Clone, Tabled)]
     struct OfferingRow {
-        #[tabled(rename = "PROVIDER")]
+        #[tabled(rename = "Provider")]
         provider: String,
         #[tabled(rename = "GPU")]
         gpu_info: String,
@@ -879,13 +879,13 @@ pub fn display_secure_cloud_offerings_detailed(
         vram: String,
         #[tabled(rename = "CPU/RAM")]
         cpu_ram: String,
-        #[tabled(rename = "STORAGE")]
+        #[tabled(rename = "Storage")]
         storage: String,
-        #[tabled(rename = "INTERCONNECT")]
+        #[tabled(rename = "Interconnect")]
         interconnect: String,
-        #[tabled(rename = "REGION")]
+        #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "PRICE/HR")]
+        #[tabled(rename = "Price/Hr")]
         price: String,
     }
 
@@ -1498,7 +1498,7 @@ pub fn display_secure_cloud_rentals(
         cpu_ram: String,
         #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "Rate/hr")]
+        #[tabled(rename = "Cost/Hr")]
         hourly_cost: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -1592,15 +1592,15 @@ pub fn display_cpu_offerings_detailed(
 
     #[derive(Clone, Tabled)]
     struct CpuOfferingRow {
-        #[tabled(rename = "PROVIDER")]
+        #[tabled(rename = "Provider")]
         provider: String,
-        #[tabled(rename = "SIZE")]
+        #[tabled(rename = "Size")]
         size: String,
-        #[tabled(rename = "STORAGE")]
+        #[tabled(rename = "Storage")]
         storage: String,
-        #[tabled(rename = "REGION")]
+        #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "PRICE/HR")]
+        #[tabled(rename = "Price/Hr")]
         price: String,
     }
 
@@ -1673,7 +1673,7 @@ pub fn display_cpu_rentals(
         ip: String,
         #[tabled(rename = "Region")]
         region: String,
-        #[tabled(rename = "Rate/hr")]
+        #[tabled(rename = "Cost/Hr")]
         hourly_cost: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -2134,29 +2134,29 @@ mod tests {
     fn ls_adaptive_column_priorities_match_the_cli_contract() {
         assert_eq!(
             schema(LS_BOURSE_COLUMNS),
-            vec![("GPU", None), ("Available", None), ("Price/hr", None)]
+            vec![("GPU", None), ("Available", None), ("Price/Hr", None)]
         );
         assert_eq!(
             schema(LS_CITADEL_GPU_COLUMNS),
             vec![
-                ("PROVIDER", Some(4)),
+                ("Provider", Some(4)),
                 ("GPU", None),
                 ("VRAM", None),
                 ("CPU/RAM", Some(1)),
-                ("STORAGE", Some(2)),
-                ("INTERCONNECT", Some(3)),
-                ("REGION", None),
-                ("PRICE/HR", None),
+                ("Storage", Some(2)),
+                ("Interconnect", Some(3)),
+                ("Region", None),
+                ("Price/Hr", None),
             ]
         );
         assert_eq!(
             schema(LS_CITADEL_CPU_COLUMNS),
             vec![
-                ("PROVIDER", None),
-                ("SIZE", None),
-                ("STORAGE", Some(1)),
-                ("REGION", None),
-                ("PRICE/HR", None),
+                ("Provider", None),
+                ("Size", None),
+                ("Storage", Some(1)),
+                ("Region", None),
+                ("Price/Hr", None),
             ]
         );
     }
@@ -2174,7 +2174,7 @@ mod tests {
                 ("Image", Some(3)),
                 ("CPU/RAM", Some(2)),
                 ("Location", Some(4)),
-                ("Rate/hr", Some(6)),
+                ("Cost/Hr", Some(6)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]
@@ -2189,7 +2189,7 @@ mod tests {
                 ("IP", None),
                 ("CPU/RAM", Some(2)),
                 ("Region", Some(3)),
-                ("Rate/hr", Some(5)),
+                ("Cost/Hr", Some(5)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]
@@ -2203,7 +2203,7 @@ mod tests {
                 ("State", Some(5)),
                 ("IP", None),
                 ("Region", Some(2)),
-                ("Rate/hr", Some(4)),
+                ("Cost/Hr", Some(4)),
                 ("Total Cost", Some(1)),
                 ("Age", None),
             ]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -23,7 +23,7 @@ use tabled::{
     Table, Tabled,
 };
 
-const MIN_NAME_WIDTH: usize = 12;
+pub(crate) const MIN_NAME_WIDTH: usize = 12;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RenderContext {
@@ -874,7 +874,7 @@ fn purchase_primary_link(
 /// Width is calculated correctly because `tabled` is compiled with the
 /// `ansi` feature, which strips both ANSI CSI (color/underline) and OSC
 /// 8 escape bytes before measuring.
-fn link_cell(label: &str, url: &str) -> String {
+pub(crate) fn link_cell(label: &str, url: &str) -> String {
     let styled = style(label).blue().underlined().to_string();
     format!("\x1b]8;;{url}\x1b\\{styled}\x1b]8;;\x1b\\")
 }

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -191,6 +191,18 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("Age"),
 ];
 
+const VOLUME_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+    AdaptiveColumn::required("Size"),
+    AdaptiveColumn::required("Status"),
+    AdaptiveColumn::optional("Provider", 2),
+    AdaptiveColumn::required("Region"),
+    AdaptiveColumn::optional("Rental", 5),
+    AdaptiveColumn::optional("Price/Hr", 4),
+    AdaptiveColumn::optional("Total Cost", 3),
+    AdaptiveColumn::optional("Created", 1),
+];
+
 struct AdaptiveTable {
     columns: Vec<AdaptiveColumn>,
     rows: Vec<Vec<String>>,
@@ -449,6 +461,10 @@ pub fn format_timestamp(timestamp: &str) -> String {
             local_dt.format("%y-%m-%d %H:%M:%S").to_string()
         })
         .unwrap_or_else(|| timestamp.to_string())
+}
+
+fn format_utc_date(timestamp: &DateTime<Utc>) -> String {
+    timestamp.format("%Y-%m-%d").to_string()
 }
 
 fn format_duration(seconds: i64) -> String {
@@ -971,7 +987,7 @@ pub fn display_deposits(response: &ListDepositsResponse) -> Result<()> {
     let mut builder = Builder::default();
 
     // Add header
-    builder.push_record(["Date (UTC)", "TAO", "Tx Hash", "Conf", "Block", "Status"]);
+    builder.push_record(["Date", "TAO", "Tx Hash", "Conf", "Block", "Status"]);
 
     let mut total_tao = 0.0;
 
@@ -980,7 +996,7 @@ pub fn display_deposits(response: &ListDepositsResponse) -> Result<()> {
         total_tao += amount_tao;
 
         // Format date
-        let date = deposit.observed_at.format("%Y-%m-%d %H:%M:%S").to_string();
+        let date = format_utc_date(&deposit.observed_at);
 
         // Format tx hash (truncate to first 8 and last 3 chars)
         let tx_hash = if deposit.tx_hash.len() > 11 {
@@ -1036,14 +1052,14 @@ pub fn display_card_purchases(response: &ListCardPurchasesResponse) -> Result<()
     println!();
 
     let mut builder = Builder::default();
-    builder.push_record(["Date (UTC)", "Amount", "Status", "Invoice/Receipt"]);
+    builder.push_record(["Date", "Amount", "Status", "Invoice/Receipt"]);
 
     let mut total_paid_cents: u64 = 0;
 
     for purchase in &response.purchases {
         let date = purchase
             .created_at
-            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
+            .map(|dt| format_utc_date(&dt))
             .unwrap_or_else(|| "-".to_string());
 
         let amount = format_cents(purchase.requested_amount_cents);
@@ -1740,13 +1756,13 @@ pub fn display_cpu_rentals(
 }
 
 /// Display volumes in table format
-pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
+pub fn display_volumes(volumes: &[VolumeResponse], output: ResolvedOutput) -> Result<()> {
     if volumes.is_empty() {
         println!("{}", style("No volumes found").yellow());
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct VolumeRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -1760,7 +1776,7 @@ pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
         region: String,
         #[tabled(rename = "Rental")]
         rental: String,
-        #[tabled(rename = "Rate/hr")]
+        #[tabled(rename = "Price/Hr")]
         hourly_cost: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -1796,7 +1812,7 @@ pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
                 rental: volume.rental_id.clone().unwrap_or_else(|| "-".to_string()),
                 hourly_cost: volume
                     .estimated_hourly_cost
-                    .map(|c| format!("${:.2}/hr", c))
+                    .map(format_hourly_price)
                     .unwrap_or_else(|| "-".to_string()),
                 total_cost,
                 created: format_timestamp(&volume.created_at.to_rfc3339()),
@@ -1804,7 +1820,31 @@ pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
         })
         .collect();
 
-    print_standard_table(Table::new(&rows));
+    let adaptive = AdaptiveTable::new(
+        VOLUME_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.name.clone(),
+                    row.size.clone(),
+                    row.status.clone(),
+                    row.provider.clone(),
+                    row.region.clone(),
+                    row.rental.clone(),
+                    row.hourly_cost.clone(),
+                    row.total_cost.clone(),
+                    row.created.clone(),
+                ]
+            })
+            .collect(),
+    );
+    let rendered = render_adaptive_table_with_context(
+        Table::new(rows),
+        adaptive,
+        output,
+        RenderContext::stdout(),
+    );
+    println!("{rendered}");
 
     Ok(())
 }
@@ -2211,6 +2251,81 @@ mod tests {
     }
 
     #[test]
+    fn volume_adaptive_column_priorities_match_the_cli_contract() {
+        assert_eq!(
+            schema(VOLUME_COLUMNS),
+            vec![
+                ("Name", None),
+                ("Size", None),
+                ("Status", None),
+                ("Provider", Some(2)),
+                ("Region", None),
+                ("Rental", Some(5)),
+                ("Price/Hr", Some(4)),
+                ("Total Cost", Some(3)),
+                ("Created", Some(1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn volume_auto_fits_required_columns_within_sixty_columns() {
+        #[derive(Tabled)]
+        struct VolumeTestRow {
+            name: String,
+            size: String,
+            status: String,
+            provider: String,
+            region: String,
+            rental: String,
+            price: String,
+            total_cost: String,
+            created: String,
+        }
+
+        let values = vec![
+            "training-checkpoints-with-a-long-name".to_string(),
+            "10240 GB".to_string(),
+            "Available".to_string(),
+            "cyan".to_string(),
+            "us-silicon-valley-1".to_string(),
+            "rental-with-a-long-name".to_string(),
+            "$0.12".to_string(),
+            "$18.42".to_string(),
+            "26-07-13 12:00:00".to_string(),
+        ];
+        let rendered = render_adaptive_table_with_context(
+            Table::new([VolumeTestRow {
+                name: values[0].clone(),
+                size: values[1].clone(),
+                status: values[2].clone(),
+                provider: values[3].clone(),
+                region: values[4].clone(),
+                rental: values[5].clone(),
+                price: values[6].clone(),
+                total_cost: values[7].clone(),
+                created: values[8].clone(),
+            }]),
+            AdaptiveTable::new(VOLUME_COLUMNS.to_vec(), vec![values]),
+            ResolvedOutput::Auto,
+            RenderContext {
+                is_tty: true,
+                width: Some(60),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        let header = rendered.lines().nth(1).expect("header row");
+        assert!(header.contains("Name"));
+        assert!(header.contains("Size"));
+        assert!(header.contains("Status"));
+        assert!(header.contains("Region"));
+        assert!(!header.contains("Provider"));
+        assert!(!header.contains("Rental"));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 60));
+    }
+
+    #[test]
     fn adaptive_truncation_rules_preserve_non_truncatable_required_columns() {
         assert_eq!(
             truncation_schema(LS_BOURSE_COLUMNS),
@@ -2233,6 +2348,15 @@ mod tests {
             truncation_schema(PS_CITADEL_CPU_COLUMNS),
             vec![("Name", 1, MIN_NAME_WIDTH)]
         );
+        assert_eq!(
+            truncation_schema(VOLUME_COLUMNS),
+            vec![("Name", 1, MIN_NAME_WIDTH)]
+        );
+    }
+
+    #[test]
+    fn funding_history_dates_do_not_include_times() {
+        assert_eq!(format_utc_date(&DateTime::UNIX_EPOCH), "1970-01-01");
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -19,6 +19,7 @@ use rust_decimal::Decimal;
 use std::{collections::HashMap, io::IsTerminal, str::FromStr};
 use tabled::{
     builder::Builder,
+    grid::util::string::get_text_width,
     settings::{object::Columns, Modify, Style, Width},
     Table, Tabled,
 };
@@ -86,6 +87,249 @@ pub(crate) fn render_table_with_context(
     table.to_string()
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AdaptiveColumn {
+    header: &'static str,
+    drop_order: Option<usize>,
+}
+
+impl AdaptiveColumn {
+    const fn required(header: &'static str) -> Self {
+        Self {
+            header,
+            drop_order: None,
+        }
+    }
+
+    const fn optional(header: &'static str, drop_order: usize) -> Self {
+        Self {
+            header,
+            drop_order: Some(drop_order),
+        }
+    }
+}
+
+const LS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required("Available"),
+    AdaptiveColumn::required("Price/hr"),
+];
+
+const LS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::optional("PROVIDER", 4),
+    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required("VRAM"),
+    AdaptiveColumn::optional("CPU/RAM", 1),
+    AdaptiveColumn::optional("STORAGE", 2),
+    AdaptiveColumn::optional("INTERCONNECT", 3),
+    AdaptiveColumn::required("REGION"),
+    AdaptiveColumn::required("PRICE/HR"),
+];
+
+const LS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("PROVIDER"),
+    AdaptiveColumn::required("SIZE"),
+    AdaptiveColumn::optional("STORAGE", 1),
+    AdaptiveColumn::required("REGION"),
+    AdaptiveColumn::required("PRICE/HR"),
+];
+
+const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("Name"),
+    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::optional("State", 7),
+    AdaptiveColumn::required("IP"),
+    AdaptiveColumn::optional("Ports (Host → Container)", 5),
+    AdaptiveColumn::optional("Image", 3),
+    AdaptiveColumn::optional("CPU/RAM", 2),
+    AdaptiveColumn::optional("Location", 4),
+    AdaptiveColumn::optional("Rate/hr", 6),
+    AdaptiveColumn::optional("Total Cost", 1),
+    AdaptiveColumn::required("Age"),
+];
+
+const PS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("Name"),
+    AdaptiveColumn::optional("Provider", 4),
+    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::optional("State", 6),
+    AdaptiveColumn::required("IP"),
+    AdaptiveColumn::optional("CPU/RAM", 2),
+    AdaptiveColumn::optional("Region", 3),
+    AdaptiveColumn::optional("Rate/hr", 5),
+    AdaptiveColumn::optional("Total Cost", 1),
+    AdaptiveColumn::required("Age"),
+];
+
+const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("Name"),
+    AdaptiveColumn::optional("Provider", 3),
+    AdaptiveColumn::required("Size"),
+    AdaptiveColumn::optional("State", 5),
+    AdaptiveColumn::required("IP"),
+    AdaptiveColumn::optional("Region", 2),
+    AdaptiveColumn::optional("Rate/hr", 4),
+    AdaptiveColumn::optional("Total Cost", 1),
+    AdaptiveColumn::required("Age"),
+];
+
+struct AdaptiveTable {
+    columns: Vec<AdaptiveColumn>,
+    rows: Vec<Vec<String>>,
+    flexible_column: Option<usize>,
+}
+
+impl AdaptiveTable {
+    fn new(
+        columns: Vec<AdaptiveColumn>,
+        rows: Vec<Vec<String>>,
+        flexible_column: Option<usize>,
+    ) -> Self {
+        Self {
+            columns,
+            rows,
+            flexible_column,
+        }
+    }
+
+    fn all_columns(&self) -> Vec<usize> {
+        (0..self.columns.len()).collect()
+    }
+
+    fn required_columns(&self) -> Vec<usize> {
+        self.columns
+            .iter()
+            .enumerate()
+            .filter_map(|(index, column)| column.drop_order.is_none().then_some(index))
+            .collect()
+    }
+
+    fn remove_lowest_priority(&self, active_columns: &mut Vec<usize>) -> bool {
+        let candidate = active_columns
+            .iter()
+            .filter_map(|&index| {
+                self.columns
+                    .get(index)?
+                    .drop_order
+                    .map(|drop_order| (drop_order, index))
+            })
+            .min_by_key(|&(drop_order, _)| drop_order);
+
+        let Some((_, index)) = candidate else {
+            return false;
+        };
+        active_columns.retain(|&active| active != index);
+        true
+    }
+
+    fn build(&self, active_columns: &[usize]) -> Table {
+        let mut builder = Builder::default();
+        builder.push_record(
+            active_columns
+                .iter()
+                .map(|&index| self.columns.get(index).map_or("", |column| column.header)),
+        );
+        for row in &self.rows {
+            builder.push_record(
+                active_columns
+                    .iter()
+                    .map(|&index| row.get(index).map(String::as_str).unwrap_or_default()),
+            );
+        }
+
+        let mut table = builder.build();
+        table.with(Style::modern());
+        table
+    }
+
+    fn flexible_width(&self) -> Option<usize> {
+        let index = self.flexible_column?;
+        self.rows
+            .iter()
+            .filter_map(|row| row.get(index))
+            .map(|value| get_text_width(value))
+            .max()
+    }
+}
+
+fn fit_required_table(
+    mut table: Table,
+    adaptive: &AdaptiveTable,
+    active_columns: &[usize],
+    width: usize,
+) -> String {
+    let overflow = table.total_width().saturating_sub(width);
+    if overflow == 0 {
+        return table.to_string();
+    }
+
+    if let (Some(source_index), Some(natural_width)) =
+        (adaptive.flexible_column, adaptive.flexible_width())
+    {
+        if let Some(position) = active_columns
+            .iter()
+            .position(|&index| index == source_index)
+        {
+            let target = natural_width.saturating_sub(overflow).max(MIN_NAME_WIDTH);
+            if target < natural_width {
+                table.with(
+                    Modify::new(Columns::new(position..position + 1))
+                        .with(Width::truncate(target).suffix("…")),
+                );
+            }
+        }
+    }
+
+    table.to_string()
+}
+
+fn render_adaptive_table_with_context(
+    mut wide: Table,
+    adaptive: AdaptiveTable,
+    output: ResolvedOutput,
+    context: RenderContext,
+) -> String {
+    wide.with(Style::modern());
+
+    match output {
+        ResolvedOutput::Wide | ResolvedOutput::Json => return wide.to_string(),
+        ResolvedOutput::Auto if !context.is_tty || context.width.is_none() => {
+            return wide.to_string();
+        }
+        ResolvedOutput::Auto
+            if context
+                .width
+                .is_some_and(|width| wide.total_width() <= width) =>
+        {
+            return wide.to_string();
+        }
+        ResolvedOutput::Auto | ResolvedOutput::Compact => {}
+    }
+
+    let mut active_columns = if matches!(output, ResolvedOutput::Compact) {
+        adaptive.required_columns()
+    } else {
+        adaptive.all_columns()
+    };
+    let width = context.width;
+
+    loop {
+        let table = adaptive.build(&active_columns);
+        let Some(width) = width else {
+            return table.to_string();
+        };
+        if table.total_width() <= width {
+            return table.to_string();
+        }
+        if matches!(output, ResolvedOutput::Auto)
+            && adaptive.remove_lowest_priority(&mut active_columns)
+        {
+            continue;
+        }
+        return fit_required_table(table, &adaptive, &active_columns, width);
+    }
+}
+
 fn print_standard_table(table: Table) {
     let rendered = render_table_with_context(
         table,
@@ -143,21 +387,6 @@ fn compact_image_name(image: &str) -> String {
     }
 }
 
-fn middle_ellipsis(value: &str, max_chars: usize) -> String {
-    let chars: Vec<char> = value.chars().collect();
-    if chars.len() <= max_chars {
-        return value.to_string();
-    }
-    let available = max_chars.saturating_sub(1);
-    let prefix_len = available / 2;
-    let suffix_len = available - prefix_len;
-    format!(
-        "{}…{}",
-        chars[..prefix_len].iter().collect::<String>(),
-        chars[chars.len() - suffix_len..].iter().collect::<String>()
-    )
-}
-
 /// Format RFC3339 timestamp to YY-MM-DD HH:MM:SS format
 pub fn format_timestamp(timestamp: &str) -> String {
     DateTime::parse_from_rfc3339(timestamp)
@@ -206,7 +435,7 @@ pub fn display_rental_items(
         (rate, cost)
     };
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct WideRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -272,42 +501,32 @@ pub fn display_rental_items(
         })
         .collect();
 
-    #[derive(Tabled)]
-    struct CompactRow {
-        #[tabled(rename = "Name")]
-        name: String,
-        #[tabled(rename = "GPU")]
-        gpu: String,
-        #[tabled(rename = "IP")]
-        ip: String,
-        #[tabled(rename = "Age")]
-        age: String,
-    }
-
     let context = RenderContext::stdout();
-    let compact_rows: Vec<CompactRow> = rentals
-        .iter()
-        .map(|rental| CompactRow {
-            name: rental.name.clone(),
-            gpu: format_gpu_info(&rental.gpu_specs),
-            ip: access_hosts
-                .get(&rental.rental_id)
-                .map(|host| middle_ellipsis(host, 22))
-                .unwrap_or_else(|| "—".to_string()),
-            age: format_age_str(&rental.created_at, context.now),
-        })
-        .collect();
-    let name_width = rentals
-        .iter()
-        .map(|rental| console::measure_text_width(&rental.name))
-        .max();
-    let rendered = render_table_with_context(
-        Table::new(wide_rows),
-        Some(Table::new(compact_rows)),
-        output,
-        context,
-        name_width,
+    let adaptive = AdaptiveTable::new(
+        PS_BOURSE_COLUMNS.to_vec(),
+        wide_rows
+            .iter()
+            .zip(rentals)
+            .map(|(row, rental)| {
+                vec![
+                    row.name.clone(),
+                    row.gpu.clone(),
+                    row.state.clone(),
+                    row.ip.clone(),
+                    row.ports.clone(),
+                    row.image.clone(),
+                    row.cpu_ram.clone(),
+                    row.location.clone(),
+                    row.rate_per_hour.clone(),
+                    row.total_cost.clone(),
+                    format_age_str(&rental.created_at, context.now),
+                ]
+            })
+            .collect(),
+        Some(0),
     );
+    let rendered =
+        render_adaptive_table_with_context(Table::new(wide_rows), adaptive, output, context);
     println!("{rendered}");
 
     Ok(())
@@ -513,13 +732,14 @@ pub fn display_available_nodes_detailed(
 /// Display community cloud GPU categories in aggregated format
 pub fn display_community_cloud_categories(
     aggregations: &[crate::cli::handlers::gpu_rental_helpers::GpuCategoryAggregation],
+    output: ResolvedOutput,
 ) -> Result<()> {
     if aggregations.is_empty() {
         println!("No available GPUs found matching the specified criteria.");
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct CategoryRow {
         #[tabled(rename = "GPU")]
         gpu: String,
@@ -561,7 +781,20 @@ pub fn display_community_cloud_categories(
         })
         .collect();
 
-    print_standard_table(Table::new(rows));
+    let adaptive = AdaptiveTable::new(
+        LS_BOURSE_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| vec![row.gpu.clone(), row.available.clone(), row.price.clone()])
+            .collect(),
+        None,
+    );
+    let rendered = render_adaptive_table_with_context(
+        Table::new(rows),
+        adaptive,
+        output,
+        RenderContext::stdout(),
+    );
+    println!("{rendered}");
 
     let total_nodes: usize = aggregations.iter().map(|a| a.node_count).sum();
     println!("\nTotal available nodes: {}", total_nodes);
@@ -579,7 +812,7 @@ pub fn display_secure_cloud_offerings_detailed(
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct OfferingRow {
         #[tabled(rename = "PROVIDER")]
         provider: String,
@@ -641,51 +874,29 @@ pub fn display_secure_cloud_offerings_detailed(
         })
         .collect();
 
-    #[derive(Tabled)]
-    struct CompactOfferingRow {
-        #[tabled(rename = "PROVIDER")]
-        provider: String,
-        #[tabled(rename = "GPU")]
-        gpu: String,
-        #[tabled(rename = "VRAM")]
-        vram: String,
-        #[tabled(rename = "REGION")]
-        region: String,
-        #[tabled(rename = "RATE")]
-        rate: String,
-    }
-
-    let compact_rows = offerings.iter().map(|offering| {
-        let gpu = if offering.gpu_count == 1 {
-            offering.gpu_type.to_string()
-        } else {
-            format!("{}x {}", offering.gpu_count, offering.gpu_type)
-        };
-        CompactOfferingRow {
-            provider: offering.provider.to_string(),
-            gpu: if offering.is_spot {
-                format!("{gpu} (Spot)")
-            } else {
-                gpu
-            },
-            vram: offering
-                .gpu_memory_gb_per_gpu
-                .map(|memory| format!("{} GB", memory * offering.gpu_count))
-                .unwrap_or_else(|| "—".to_string()),
-            region: offering.region.clone(),
-            rate: format!(
-                "${:.2}/h",
-                offering.hourly_rate_per_gpu * Decimal::from(offering.gpu_count)
-            ),
-        }
-    });
-    let context = RenderContext::stdout();
-    let rendered = render_table_with_context(
-        Table::new(rows),
-        Some(Table::new(compact_rows)),
-        output,
-        context,
+    let adaptive = AdaptiveTable::new(
+        LS_CITADEL_GPU_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.provider.clone(),
+                    row.gpu_info.clone(),
+                    row.vram.clone(),
+                    row.cpu_ram.clone(),
+                    row.storage.clone(),
+                    row.interconnect.clone(),
+                    row.region.clone(),
+                    row.price.clone(),
+                ]
+            })
+            .collect(),
         None,
+    );
+    let rendered = render_adaptive_table_with_context(
+        Table::new(rows),
+        adaptive,
+        output,
+        RenderContext::stdout(),
     );
     println!("{rendered}");
 
@@ -1214,7 +1425,7 @@ pub fn display_secure_cloud_rentals(
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct SecureCloudRentalRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -1284,46 +1495,29 @@ pub fn display_secure_cloud_rentals(
         })
         .collect();
 
-    #[derive(Tabled)]
-    struct CompactRow {
-        #[tabled(rename = "Name")]
-        name: String,
-        #[tabled(rename = "GPU")]
-        gpu: String,
-        #[tabled(rename = "IP")]
-        ip: String,
-        #[tabled(rename = "Age")]
-        age: String,
-    }
     let context = RenderContext::stdout();
-    let compact_rows = rentals.iter().map(|rental| {
-        let gpu = if rental.gpu_count > 1 {
-            format!("{}x {}", rental.gpu_count, rental.gpu_type.to_uppercase())
-        } else {
-            rental.gpu_type.to_uppercase()
-        };
-        CompactRow {
-            name: rental.name.clone(),
-            gpu: if rental.is_spot {
-                format!("{gpu} (Spot)")
-            } else {
-                gpu
-            },
-            ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
-            age: format_age(rental.created_at, context.now),
-        }
-    });
-    let name_width = rentals
-        .iter()
-        .map(|rental| console::measure_text_width(&rental.name))
-        .max();
-    let rendered = render_table_with_context(
-        Table::new(&rows),
-        Some(Table::new(compact_rows)),
-        output,
-        context,
-        name_width,
+    let adaptive = AdaptiveTable::new(
+        PS_CITADEL_GPU_COLUMNS.to_vec(),
+        rows.iter()
+            .zip(rentals)
+            .map(|(row, rental)| {
+                vec![
+                    row.name.clone(),
+                    row.provider.clone(),
+                    row.gpu.clone(),
+                    row.status.clone(),
+                    row.ip.clone(),
+                    row.cpu_ram.clone(),
+                    row.region.clone(),
+                    row.hourly_cost.clone(),
+                    row.total_cost.clone(),
+                    format_age(rental.created_at, context.now),
+                ]
+            })
+            .collect(),
+        Some(0),
     );
+    let rendered = render_adaptive_table_with_context(Table::new(rows), adaptive, output, context);
     println!("{rendered}");
 
     Ok(())
@@ -1339,7 +1533,7 @@ pub fn display_cpu_offerings_detailed(
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct CpuOfferingRow {
         #[tabled(rename = "PROVIDER")]
         provider: String,
@@ -1374,35 +1568,26 @@ pub fn display_cpu_offerings_detailed(
         })
         .collect();
 
-    #[derive(Tabled)]
-    struct CompactCpuOfferingRow {
-        #[tabled(rename = "PROVIDER")]
-        provider: String,
-        #[tabled(rename = "SIZE")]
-        size: String,
-        #[tabled(rename = "REGION")]
-        region: String,
-        #[tabled(rename = "RATE")]
-        rate: String,
-    }
-    let compact_rows = offerings.iter().map(|offering| CompactCpuOfferingRow {
-        provider: offering.provider.clone(),
-        size: format!(
-            "{} cores / {}GB",
-            offering.vcpu_count, offering.system_memory_gb
-        ),
-        region: offering.region.clone(),
-        rate: format!(
-            "${:.2}/h",
-            offering.hourly_rate.parse::<f64>().unwrap_or(0.0)
-        ),
-    });
-    let rendered = render_table_with_context(
-        Table::new(&rows),
-        Some(Table::new(compact_rows)),
+    let adaptive = AdaptiveTable::new(
+        LS_CITADEL_CPU_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.provider.clone(),
+                    row.size.clone(),
+                    row.storage.clone(),
+                    row.region.clone(),
+                    row.price.clone(),
+                ]
+            })
+            .collect(),
+        None,
+    );
+    let rendered = render_adaptive_table_with_context(
+        Table::new(rows),
+        adaptive,
         output,
         RenderContext::stdout(),
-        None,
     );
     println!("{rendered}");
 
@@ -1421,7 +1606,7 @@ pub fn display_cpu_rentals(
         return Ok(());
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct CpuRentalRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -1475,38 +1660,28 @@ pub fn display_cpu_rentals(
         })
         .collect();
 
-    #[derive(Tabled)]
-    struct CompactRow {
-        #[tabled(rename = "Name")]
-        name: String,
-        #[tabled(rename = "Size")]
-        size: String,
-        #[tabled(rename = "IP")]
-        ip: String,
-        #[tabled(rename = "Age")]
-        age: String,
-    }
     let context = RenderContext::stdout();
-    let compact_rows = rentals.iter().map(|rental| CompactRow {
-        name: rental.name.clone(),
-        size: match (rental.vcpu_count, rental.system_memory_gb) {
-            (Some(cores), Some(memory_gb)) => format!("{cores} cores / {memory_gb}GB"),
-            _ => "—".to_string(),
-        },
-        ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
-        age: format_age(rental.created_at, context.now),
-    });
-    let name_width = rentals
-        .iter()
-        .map(|rental| console::measure_text_width(&rental.name))
-        .max();
-    let rendered = render_table_with_context(
-        Table::new(&rows),
-        Some(Table::new(compact_rows)),
-        output,
-        context,
-        name_width,
+    let adaptive = AdaptiveTable::new(
+        PS_CITADEL_CPU_COLUMNS.to_vec(),
+        rows.iter()
+            .zip(rentals)
+            .map(|(row, rental)| {
+                vec![
+                    row.name.clone(),
+                    row.provider.clone(),
+                    row.size.clone(),
+                    row.status.clone(),
+                    row.ip.clone(),
+                    row.region.clone(),
+                    row.hourly_cost.clone(),
+                    row.total_cost.clone(),
+                    format_age(rental.created_at, context.now),
+                ]
+            })
+            .collect(),
+        Some(0),
     );
+    let rendered = render_adaptive_table_with_context(Table::new(rows), adaptive, output, context);
     println!("{rendered}");
 
     Ok(())
@@ -1605,6 +1780,63 @@ mod tests {
         state: String,
     }
 
+    #[derive(Tabled)]
+    struct AdaptiveWideTestRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Low")]
+        low: String,
+        #[tabled(rename = "High")]
+        high: String,
+        #[tabled(rename = "Created")]
+        created: String,
+    }
+
+    fn adaptive_fixture() -> (Table, AdaptiveTable) {
+        let name = "training-rental-with-a-very-long-name".to_string();
+        let wide = Table::new([AdaptiveWideTestRow {
+            name: name.clone(),
+            low: "low-value".to_string(),
+            high: "high-value".to_string(),
+            created: "2026-07-13 12:00:00 UTC".to_string(),
+        }]);
+        let adaptive = AdaptiveTable::new(
+            vec![
+                AdaptiveColumn::required("Name"),
+                AdaptiveColumn::optional("Low", 1),
+                AdaptiveColumn::optional("High", 2),
+                AdaptiveColumn::required("Age"),
+            ],
+            vec![vec![
+                name,
+                "low-value".to_string(),
+                "high-value".to_string(),
+                "2h".to_string(),
+            ]],
+            Some(0),
+        );
+        (wide, adaptive)
+    }
+
+    fn adaptive_render(output: ResolvedOutput, is_tty: bool, width: usize) -> String {
+        let (wide, adaptive) = adaptive_fixture();
+        render_adaptive_table_with_context(
+            wide,
+            adaptive,
+            output,
+            RenderContext {
+                is_tty,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+        )
+    }
+
+    fn adaptive_width(active_columns: &[usize]) -> usize {
+        let (_, adaptive) = adaptive_fixture();
+        adaptive.build(active_columns).total_width()
+    }
+
     fn render_test_table(output: ResolvedOutput, is_tty: bool, width: usize) -> String {
         let name = "training-rental-with-a-very-long-name".to_string();
         render_table_with_context(
@@ -1684,6 +1916,200 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_auto_keeps_wide_table_when_it_fits() {
+        let (mut wide, _) = adaptive_fixture();
+        wide.with(Style::modern());
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, wide.total_width());
+        assert!(rendered.contains("Created"));
+        assert!(!rendered.contains("Age"));
+    }
+
+    #[test]
+    fn adaptive_auto_uses_all_adaptive_columns_before_dropping_any() {
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, adaptive_width(&[0, 1, 2, 3]));
+        assert!(rendered.contains("Low"));
+        assert!(rendered.contains("High"));
+        assert!(rendered.contains("Age"));
+        assert!(!rendered.contains("Created"));
+    }
+
+    #[test]
+    fn adaptive_auto_drops_optional_columns_in_priority_order() {
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, adaptive_width(&[0, 2, 3]));
+        assert!(!rendered.contains("Low"));
+        assert!(rendered.contains("High"));
+        assert!(rendered.contains("Age"));
+    }
+
+    #[test]
+    fn adaptive_auto_reaches_required_columns_only() {
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, adaptive_width(&[0, 3]));
+        assert!(!rendered.contains("Low"));
+        assert!(!rendered.contains("High"));
+        assert!(rendered.contains("Name"));
+        assert!(rendered.contains("Age"));
+    }
+
+    #[test]
+    fn adaptive_compact_always_uses_required_columns_only() {
+        let rendered = adaptive_render(ResolvedOutput::Compact, true, usize::MAX);
+        assert!(!rendered.contains("Low"));
+        assert!(!rendered.contains("High"));
+        assert!(rendered.contains("Name"));
+        assert!(rendered.contains("Age"));
+    }
+
+    #[test]
+    fn adaptive_non_tty_auto_remains_wide() {
+        let rendered = adaptive_render(ResolvedOutput::Auto, false, 1);
+        assert!(rendered.contains("Created"));
+        assert!(rendered.contains("Low"));
+        assert!(rendered.contains("High"));
+    }
+
+    #[test]
+    fn adaptive_required_table_truncates_name_to_eight_character_floor() {
+        let name_width = get_text_width("training-rental-with-a-very-long-name");
+        let required_width = adaptive_width(&[0, 3]);
+        let minimum_width = required_width.saturating_sub(name_width - MIN_NAME_WIDTH);
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, minimum_width);
+        assert!(rendered.contains("trainin…"));
+        assert!(rendered
+            .lines()
+            .all(|line| console::measure_text_width(line) <= minimum_width));
+    }
+
+    #[test]
+    fn adaptive_name_truncation_uses_tabled_width_for_osc8_links() {
+        let label = "training-rental-with-a-very-long-name";
+        let linked_name = format!("\x1b]8;;https://example.com\x1b\\{label}\x1b]8;;\x1b\\");
+        let adaptive = AdaptiveTable::new(
+            vec![
+                AdaptiveColumn::required("Name"),
+                AdaptiveColumn::required("Age"),
+            ],
+            vec![vec![linked_name, "2h".to_string()]],
+            Some(0),
+        );
+        let required_width = adaptive.build(&[0, 1]).total_width();
+        let width = required_width - (get_text_width(label) - MIN_NAME_WIDTH);
+        let rendered = render_adaptive_table_with_context(
+            Table::new([AdaptiveWideTestRow {
+                name: label.to_string(),
+                low: "low-value".to_string(),
+                high: "high-value".to_string(),
+                created: "2026-07-13 12:00:00 UTC".to_string(),
+            }]),
+            adaptive,
+            ResolvedOutput::Compact,
+            RenderContext {
+                is_tty: true,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        assert!(rendered.contains('…'));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= width));
+    }
+
+    #[test]
+    fn adaptive_columns_keep_their_declared_order() {
+        let rendered = adaptive_render(ResolvedOutput::Auto, true, adaptive_width(&[0, 1, 2, 3]));
+        let header = rendered.lines().nth(1).expect("header row");
+        assert!(header.find("Name") < header.find("Low"));
+        assert!(header.find("Low") < header.find("High"));
+        assert!(header.find("High") < header.find("Age"));
+    }
+
+    fn schema(columns: &[AdaptiveColumn]) -> Vec<(&'static str, Option<usize>)> {
+        columns
+            .iter()
+            .map(|column| (column.header, column.drop_order))
+            .collect()
+    }
+
+    #[test]
+    fn ls_adaptive_column_priorities_match_the_cli_contract() {
+        assert_eq!(
+            schema(LS_BOURSE_COLUMNS),
+            vec![("GPU", None), ("Available", None), ("Price/hr", None)]
+        );
+        assert_eq!(
+            schema(LS_CITADEL_GPU_COLUMNS),
+            vec![
+                ("PROVIDER", Some(4)),
+                ("GPU", None),
+                ("VRAM", None),
+                ("CPU/RAM", Some(1)),
+                ("STORAGE", Some(2)),
+                ("INTERCONNECT", Some(3)),
+                ("REGION", None),
+                ("PRICE/HR", None),
+            ]
+        );
+        assert_eq!(
+            schema(LS_CITADEL_CPU_COLUMNS),
+            vec![
+                ("PROVIDER", None),
+                ("SIZE", None),
+                ("STORAGE", Some(1)),
+                ("REGION", None),
+                ("PRICE/HR", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn ps_adaptive_column_priorities_match_the_cli_contract() {
+        assert_eq!(
+            schema(PS_BOURSE_COLUMNS),
+            vec![
+                ("Name", None),
+                ("GPU", None),
+                ("State", Some(7)),
+                ("IP", None),
+                ("Ports (Host → Container)", Some(5)),
+                ("Image", Some(3)),
+                ("CPU/RAM", Some(2)),
+                ("Location", Some(4)),
+                ("Rate/hr", Some(6)),
+                ("Total Cost", Some(1)),
+                ("Age", None),
+            ]
+        );
+        assert_eq!(
+            schema(PS_CITADEL_GPU_COLUMNS),
+            vec![
+                ("Name", None),
+                ("Provider", Some(4)),
+                ("GPU", None),
+                ("State", Some(6)),
+                ("IP", None),
+                ("CPU/RAM", Some(2)),
+                ("Region", Some(3)),
+                ("Rate/hr", Some(5)),
+                ("Total Cost", Some(1)),
+                ("Age", None),
+            ]
+        );
+        assert_eq!(
+            schema(PS_CITADEL_CPU_COLUMNS),
+            vec![
+                ("Name", None),
+                ("Provider", Some(3)),
+                ("Size", None),
+                ("State", Some(5)),
+                ("IP", None),
+                ("Region", Some(2)),
+                ("Rate/hr", Some(4)),
+                ("Total Cost", Some(1)),
+                ("Age", None),
+            ]
+        );
+    }
+
+    #[test]
     fn relative_age_uses_injected_clock() {
         let now = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
             .unwrap()
@@ -1702,15 +2128,6 @@ mod tests {
         );
         assert_eq!(compact_image_name("nvidia/cuda:12.4"), "nvidia/cuda");
         assert_eq!(compact_image_name("ubuntu@sha256:abc"), "ubuntu");
-    }
-
-    #[test]
-    fn access_hosts_use_middle_ellipsis() {
-        assert_eq!(middle_ellipsis("short.example", 22), "short.example");
-        let shortened = middle_ellipsis("ssh-a8f31234567890.basilica.ai", 22);
-        assert_eq!(shortened.chars().count(), 22);
-        assert!(shortened.starts_with("ssh-a8f312"));
-        assert!(shortened.ends_with("basilica.ai"));
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -191,6 +191,12 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("Age"),
 ];
 
+const TOKEN_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+    AdaptiveColumn::required("Created"),
+    AdaptiveColumn::required("Last Used"),
+];
+
 const VOLUME_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
     AdaptiveColumn::required("Size"),
@@ -685,8 +691,8 @@ pub fn display_config(config: &HashMap<String, String>) -> Result<()> {
 }
 
 /// Display API keys in table format
-pub fn display_api_keys(keys: &[ApiKeyInfo]) -> Result<()> {
-    #[derive(Tabled)]
+pub fn display_api_keys(keys: &[ApiKeyInfo], output: ResolvedOutput) -> Result<()> {
+    #[derive(Clone, Tabled)]
     struct ApiKeyRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -708,7 +714,19 @@ pub fn display_api_keys(keys: &[ApiKeyInfo]) -> Result<()> {
         })
         .collect();
 
-    print_standard_table(Table::new(rows));
+    let adaptive = AdaptiveTable::new(
+        TOKEN_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| vec![row.name.clone(), row.created.clone(), row.last_used.clone()])
+            .collect(),
+    );
+    let rendered = render_adaptive_table_with_context(
+        Table::new(rows),
+        adaptive,
+        output,
+        RenderContext::stdout(),
+    );
+    println!("{rendered}");
 
     Ok(())
 }
@@ -2266,6 +2284,51 @@ mod tests {
                 ("Created", Some(1)),
             ]
         );
+    }
+
+    #[test]
+    fn token_columns_keep_dates_and_truncate_only_name() {
+        assert_eq!(
+            schema(TOKEN_COLUMNS),
+            vec![("Name", None), ("Created", None), ("Last Used", None)]
+        );
+        assert_eq!(
+            truncation_schema(TOKEN_COLUMNS),
+            vec![("Name", 1, MIN_NAME_WIDTH)]
+        );
+    }
+
+    #[test]
+    fn token_auto_truncates_long_names_to_fit_sixty_columns() {
+        #[derive(Tabled)]
+        struct TokenTestRow {
+            name: String,
+            created: String,
+            last_used: String,
+        }
+
+        let values = vec![
+            "automation-token-with-a-very-long-name".to_string(),
+            "26-07-13 12:00:00".to_string(),
+            "26-07-13 13:00:00".to_string(),
+        ];
+        let rendered = render_adaptive_table_with_context(
+            Table::new([TokenTestRow {
+                name: values[0].clone(),
+                created: values[1].clone(),
+                last_used: values[2].clone(),
+            }]),
+            AdaptiveTable::new(TOKEN_COLUMNS.to_vec(), vec![values]),
+            ResolvedOutput::Auto,
+            RenderContext {
+                is_tty: true,
+                width: Some(60),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        assert!(rendered.contains('…'));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 60));
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -191,6 +191,29 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("Age"),
 ];
 
+const PS_GPU_HISTORY_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+    AdaptiveColumn::optional("GPUs", 4),
+    AdaptiveColumn::optional("Status", 1),
+    AdaptiveColumn::required("Total Cost"),
+    AdaptiveColumn::optional("Started", 3),
+    AdaptiveColumn::optional("Stopped", 2),
+    AdaptiveColumn::optional("Duration", 5),
+];
+
+const PS_CPU_HISTORY_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+    AdaptiveColumn::optional("Provider", 6),
+    AdaptiveColumn::optional("vCPU", 7),
+    AdaptiveColumn::optional("RAM", 8),
+    AdaptiveColumn::optional("Status", 1),
+    AdaptiveColumn::optional("Price/Hr", 5),
+    AdaptiveColumn::required("Total Cost"),
+    AdaptiveColumn::optional("Started", 3),
+    AdaptiveColumn::optional("Stopped", 2),
+    AdaptiveColumn::optional("Duration", 4),
+];
+
 const FUND_DEPOSIT_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::required("Date"),
     AdaptiveColumn::required("TAO"),
@@ -198,6 +221,13 @@ const FUND_DEPOSIT_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("Conf", 2),
     AdaptiveColumn::optional("Block", 1),
     AdaptiveColumn::required("Status"),
+];
+
+const FUND_CARD_PAYMENT_COLUMNS: &[AdaptiveColumn] = &[
+    AdaptiveColumn::required("Date"),
+    AdaptiveColumn::required("Amount"),
+    AdaptiveColumn::required("Status"),
+    AdaptiveColumn::required_truncatable("Invoice/Receipt", 1, 15),
 ];
 
 const TOKEN_COLUMNS: &[AdaptiveColumn] = &[
@@ -1118,68 +1148,72 @@ pub fn display_deposits(response: &ListDepositsResponse, output: ResolvedOutput)
 }
 
 /// Display card payment history in table format.
-pub fn display_card_purchases(response: &ListCardPurchasesResponse) -> Result<()> {
+pub fn display_card_purchases(
+    response: &ListCardPurchasesResponse,
+    output: ResolvedOutput,
+) -> Result<()> {
     println!();
     println!("{}", style("Card Payment History").bold());
     println!();
 
-    let mut builder = Builder::default();
-    builder.push_record(["Date", "Amount", "Status", "Invoice/Receipt"]);
-
     let mut total_paid_cents: u64 = 0;
+    let rows: Vec<Vec<String>> = response
+        .purchases
+        .iter()
+        .map(|purchase| {
+            let date = purchase
+                .created_at
+                .map(|dt| format_utc_date(&dt))
+                .unwrap_or_else(|| "-".to_string());
+            let amount = format_cents(purchase.requested_amount_cents);
+            let status = match purchase.status {
+                CardPurchaseStatus::Completed => "Completed",
+                CardPurchaseStatus::Pending => "Pending",
+                CardPurchaseStatus::Expired => "Expired",
+                CardPurchaseStatus::Unspecified => "Unspecified",
+            };
 
-    for purchase in &response.purchases {
-        let date = purchase
-            .created_at
-            .map(|dt| format_utc_date(&dt))
-            .unwrap_or_else(|| "-".to_string());
+            // Invoice/Receipt doubles as the per-session link. Prefer the
+            // hosted invoice because it already includes receipt-style
+            // payment detail and a PDF download.
+            let invoice_cell = match purchase_primary_link(purchase) {
+                Some((PrimaryLinkKind::Invoice, url)) => {
+                    let label = purchase.invoice_number.as_deref().unwrap_or("Invoice");
+                    link_cell(label, url)
+                }
+                Some((PrimaryLinkKind::Receipt, url)) => link_cell("Receipt", url),
+                Some((PrimaryLinkKind::Resume, url)) => link_cell("Resume", url),
+                None => "-".to_string(),
+            };
 
-        let amount = format_cents(purchase.requested_amount_cents);
-
-        let status = match purchase.status {
-            CardPurchaseStatus::Completed => "Completed",
-            CardPurchaseStatus::Pending => "Pending",
-            CardPurchaseStatus::Expired => "Expired",
-            CardPurchaseStatus::Unspecified => "Unspecified",
-        };
-
-        // Invoice/Receipt cell doubles as the per-session link. Modern
-        // terminals (iTerm2, Terminal.app, wezterm, Ghostty, VSCode,
-        // kitty, GNOME Terminal) render the OSC 8 escape as clickable;
-        // unsupported terminals show only the styled label and users can
-        // drop to --json for the raw URL. Styling the label blue +
-        // underlined (web-browser link convention) signals clickability
-        // visually even before hovering. Prefer the hosted invoice page
-        // when present — it bundles receipt-style payment detail already,
-        // so a separate receipt link would be redundant. `invoice_pdf`
-        // stays on the SDK type but isn't surfaced here because the
-        // hosted invoice page has a "Download PDF" button.
-        let invoice_cell = match purchase_primary_link(purchase) {
-            Some((PrimaryLinkKind::Invoice, url)) => {
-                let label = purchase.invoice_number.as_deref().unwrap_or("Invoice");
-                link_cell(label, url)
+            if matches!(purchase.status, CardPurchaseStatus::Completed) {
+                total_paid_cents += purchase
+                    .paid_amount_cents
+                    .unwrap_or(purchase.requested_amount_cents);
             }
-            Some((PrimaryLinkKind::Receipt, url)) => link_cell("Receipt", url),
-            Some((PrimaryLinkKind::Resume, url)) => link_cell("Resume", url),
-            None => "-".to_string(),
-        };
 
-        builder.push_record([date.as_str(), amount.as_str(), status, &invoice_cell]);
+            vec![date, amount, status.to_string(), invoice_cell]
+        })
+        .collect();
 
-        if matches!(purchase.status, CardPurchaseStatus::Completed) {
-            total_paid_cents += purchase
-                .paid_amount_cents
-                .unwrap_or(purchase.requested_amount_cents);
-        }
-    }
-
-    print_standard_table(builder.build());
+    let rendered = render_card_purchase_rows(rows, output, RenderContext::stdout());
+    println!("{rendered}");
 
     println!();
     println!("{}:", style("Total Card Payments").bold());
     println!("  {}", style(format_cents(total_paid_cents)).green());
 
     Ok(())
+}
+
+fn render_card_purchase_rows(
+    rows: Vec<Vec<String>>,
+    output: ResolvedOutput,
+    context: RenderContext,
+) -> String {
+    let adaptive = AdaptiveTable::new(FUND_CARD_PAYMENT_COLUMNS.to_vec(), rows);
+    let wide = adaptive.build(&adaptive.all_columns());
+    render_adaptive_table_with_context(wide, adaptive, output, context)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1418,14 +1452,25 @@ pub fn display_usage_history(history: &UsageHistoryResponse) -> Result<()> {
     Ok(())
 }
 
-/// Display historical rental data from billing service
-pub fn display_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<()> {
+fn historical_rental_name(rental: &HistoricalRentalItem) -> String {
+    rental.name.clone().unwrap_or_else(|| {
+        format!(
+            "id:{}",
+            rental.rental_id.chars().take(8).collect::<String>()
+        )
+    })
+}
+
+fn render_rental_history_with_context(
+    rentals: &[&HistoricalRentalItem],
+    output: ResolvedOutput,
+    context: RenderContext,
+) -> String {
     if rentals.is_empty() {
-        println!("{}", style("No rental history found").yellow());
-        return Ok(());
+        return style("No rental history found").yellow().to_string();
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct HistoryRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -1449,9 +1494,7 @@ pub fn display_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<()> {
             let total_cost = format_usd(&rental.total_cost);
 
             HistoryRow {
-                name: rental.name.clone().unwrap_or_else(|| {
-                    format!("id:{}", &rental.rental_id[..8.min(rental.rental_id.len())])
-                }),
+                name: historical_rental_name(rental),
                 gpu_count: format!("{}x GPU", rental.gpu_count),
                 status: rental.status.clone(),
                 total_cost,
@@ -1472,19 +1515,48 @@ pub fn display_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<()> {
 
     rows.sort_by_key(|r| std::cmp::Reverse(r.started.clone()));
 
-    print_standard_table(Table::new(&rows));
+    let adaptive = AdaptiveTable::new(
+        PS_GPU_HISTORY_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.name.clone(),
+                    row.gpu_count.clone(),
+                    row.status.clone(),
+                    row.total_cost.clone(),
+                    row.started.clone(),
+                    row.stopped.clone(),
+                    row.duration.clone(),
+                ]
+            })
+            .collect(),
+    );
+    render_adaptive_table_with_context(Table::new(rows), adaptive, output, context)
+}
+
+/// Display historical rental data from billing service
+pub fn display_rental_history(
+    rentals: &[&HistoricalRentalItem],
+    output: ResolvedOutput,
+) -> Result<()> {
+    println!(
+        "{}",
+        render_rental_history_with_context(rentals, output, RenderContext::stdout())
+    );
 
     Ok(())
 }
 
-/// Display historical CPU rental data from billing service
-pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<()> {
+fn render_cpu_rental_history_with_context(
+    rentals: &[&HistoricalRentalItem],
+    output: ResolvedOutput,
+    context: RenderContext,
+) -> String {
     if rentals.is_empty() {
-        println!("{}", style("No CPU rental history found").yellow());
-        return Ok(());
+        return style("No CPU rental history found").yellow().to_string();
     }
 
-    #[derive(Tabled)]
+    #[derive(Clone, Tabled)]
     struct CpuHistoryRow {
         #[tabled(rename = "Name")]
         name: String,
@@ -1496,7 +1568,7 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
         ram: String,
         #[tabled(rename = "Status")]
         status: String,
-        #[tabled(rename = "Rate/hr")]
+        #[tabled(rename = "Price/Hr")]
         rate: String,
         #[tabled(rename = "Total Cost")]
         total_cost: String,
@@ -1515,7 +1587,7 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
 
             let rate = rental
                 .hourly_rate
-                .map(|r| format!("${:.2}/hr", r))
+                .map(format_hourly_price)
                 .unwrap_or_else(|| "-".to_string());
 
             let vcpu = rental
@@ -1529,9 +1601,7 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
                 .unwrap_or_else(|| "-".to_string());
 
             CpuHistoryRow {
-                name: rental.name.clone().unwrap_or_else(|| {
-                    format!("id:{}", &rental.rental_id[..8.min(rental.rental_id.len())])
-                }),
+                name: historical_rental_name(rental),
                 provider: rental.provider.clone().unwrap_or_else(|| "-".to_string()),
                 vcpu,
                 ram,
@@ -1555,7 +1625,37 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
 
     rows.sort_by_key(|r| std::cmp::Reverse(r.started.clone()));
 
-    print_standard_table(Table::new(&rows));
+    let adaptive = AdaptiveTable::new(
+        PS_CPU_HISTORY_COLUMNS.to_vec(),
+        rows.iter()
+            .map(|row| {
+                vec![
+                    row.name.clone(),
+                    row.provider.clone(),
+                    row.vcpu.clone(),
+                    row.ram.clone(),
+                    row.status.clone(),
+                    row.rate.clone(),
+                    row.total_cost.clone(),
+                    row.started.clone(),
+                    row.stopped.clone(),
+                    row.duration.clone(),
+                ]
+            })
+            .collect(),
+    );
+    render_adaptive_table_with_context(Table::new(rows), adaptive, output, context)
+}
+
+/// Display historical CPU rental data from billing service
+pub fn display_cpu_rental_history(
+    rentals: &[&HistoricalRentalItem],
+    output: ResolvedOutput,
+) -> Result<()> {
+    println!(
+        "{}",
+        render_cpu_rental_history_with_context(rentals, output, RenderContext::stdout())
+    );
 
     Ok(())
 }
@@ -1981,6 +2081,30 @@ mod tests {
         (wide, adaptive)
     }
 
+    fn historical_rental_fixture() -> HistoricalRentalItem {
+        HistoricalRentalItem {
+            name: Some("training-1".to_string()),
+            rental_id: "rental-c1234567890".to_string(),
+            node_id: Some("node-1".to_string()),
+            status: "Stopped".to_string(),
+            total_cost: "27.66".to_string(),
+            hourly_rate: Some(0.55),
+            started_at: DateTime::parse_from_rfc3339("2026-04-07T00:53:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            stopped_at: DateTime::parse_from_rfc3339("2026-04-08T02:13:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            duration_seconds: 91_140,
+            gpu_count: 1,
+            cloud_type: "community".to_string(),
+            compute_type: "gpu".to_string(),
+            vcpu_count: Some(192),
+            system_memory_gb: Some(1536),
+            provider: Some("hyperstack".to_string()),
+        }
+    }
+
     fn adaptive_render(output: ResolvedOutput, is_tty: bool, width: usize) -> String {
         let (wide, adaptive) = adaptive_fixture();
         render_adaptive_table_with_context(
@@ -1998,6 +2122,37 @@ mod tests {
     fn adaptive_width(active_columns: &[usize]) -> usize {
         let (_, adaptive) = adaptive_fixture();
         adaptive.build(active_columns).total_width()
+    }
+
+    fn render_adaptive_schema_at_width(
+        columns: &[AdaptiveColumn],
+        values: &[&str],
+        width: usize,
+    ) -> String {
+        let adaptive = AdaptiveTable::new(
+            columns.to_vec(),
+            vec![values.iter().map(|value| (*value).to_string()).collect()],
+        );
+        let all_columns = adaptive.all_columns();
+        let wide = adaptive.build(&all_columns);
+
+        render_adaptive_table_with_context(
+            wide,
+            adaptive,
+            ResolvedOutput::Auto,
+            RenderContext {
+                is_tty: true,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+        )
+    }
+
+    fn assert_rendered_width(rendered: &str, width: usize) {
+        assert!(
+            rendered.lines().all(|line| get_text_width(line) <= width),
+            "table exceeded {width} columns:\n{rendered}"
+        );
     }
 
     fn render_test_table(output: ResolvedOutput, is_tty: bool, width: usize) -> String {
@@ -2323,6 +2478,259 @@ mod tests {
     }
 
     #[test]
+    fn ps_history_priorities_require_only_name_and_total_cost() {
+        assert_eq!(
+            schema(PS_GPU_HISTORY_COLUMNS),
+            vec![
+                ("Name", None),
+                ("GPUs", Some(4)),
+                ("Status", Some(1)),
+                ("Total Cost", None),
+                ("Started", Some(3)),
+                ("Stopped", Some(2)),
+                ("Duration", Some(5)),
+            ]
+        );
+        assert_eq!(
+            schema(PS_CPU_HISTORY_COLUMNS),
+            vec![
+                ("Name", None),
+                ("Provider", Some(6)),
+                ("vCPU", Some(7)),
+                ("RAM", Some(8)),
+                ("Status", Some(1)),
+                ("Price/Hr", Some(5)),
+                ("Total Cost", None),
+                ("Started", Some(3)),
+                ("Stopped", Some(2)),
+                ("Duration", Some(4)),
+            ]
+        );
+    }
+
+    #[test]
+    fn gpu_history_auto_fits_within_seventy_columns() {
+        let rental = historical_rental_fixture();
+        let rendered = render_rental_history_with_context(
+            &[&rental],
+            ResolvedOutput::Auto,
+            RenderContext {
+                is_tty: true,
+                width: Some(70),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        let header = rendered.lines().nth(1).expect("header row");
+        assert!(header.contains("Name"));
+        assert!(header.contains("GPUs"));
+        assert!(header.contains("Total Cost"));
+        assert!(header.contains("Started"));
+        assert!(header.contains("Duration"));
+        assert!(!header.contains("Status"));
+        assert!(!header.contains("Stopped"));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 70));
+    }
+
+    #[test]
+    fn cpu_history_auto_fits_within_seventy_columns() {
+        let rental = historical_rental_fixture();
+        let rendered = render_cpu_rental_history_with_context(
+            &[&rental],
+            ResolvedOutput::Auto,
+            RenderContext {
+                is_tty: true,
+                width: Some(70),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        let header = rendered.lines().nth(1).expect("header row");
+        assert!(header.contains("Name"));
+        assert!(header.contains("Provider"));
+        assert!(header.contains("vCPU"));
+        assert!(header.contains("RAM"));
+        assert!(header.contains("Total Cost"));
+        assert!(!header.contains("Status"));
+        assert!(!header.contains("Price/Hr"));
+        assert!(!header.contains("Started"));
+        assert!(!header.contains("Stopped"));
+        assert!(!header.contains("Duration"));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 70));
+    }
+
+    #[test]
+    fn history_compact_contains_only_name_and_total_cost() {
+        let rental = historical_rental_fixture();
+        let context = RenderContext {
+            is_tty: true,
+            width: Some(70),
+            now: DateTime::UNIX_EPOCH,
+        };
+        let gpu = render_rental_history_with_context(&[&rental], ResolvedOutput::Compact, context);
+        let cpu =
+            render_cpu_rental_history_with_context(&[&rental], ResolvedOutput::Compact, context);
+
+        for rendered in [gpu, cpu] {
+            let header = rendered.lines().nth(1).expect("header row");
+            assert!(header.contains("Name"));
+            assert!(header.contains("Total Cost"));
+            assert_eq!(header.matches('│').count(), 3);
+            assert!(rendered.lines().all(|line| get_text_width(line) <= 70));
+        }
+    }
+
+    #[test]
+    fn cpu_history_price_does_not_repeat_the_header_unit() {
+        let rental = historical_rental_fixture();
+        let rendered = render_cpu_rental_history_with_context(
+            &[&rental],
+            ResolvedOutput::Wide,
+            RenderContext {
+                is_tty: true,
+                width: Some(70),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        assert!(rendered.contains("$0.55"));
+        assert!(!rendered.contains("$0.55/hr"));
+    }
+
+    #[test]
+    fn history_name_falls_back_to_locally_shortened_api_rental_id() {
+        let mut rental = historical_rental_fixture();
+        rental.name = None;
+
+        assert_eq!(historical_rental_name(&rental), "id:rental-c");
+    }
+
+    #[test]
+    fn ls_tables_fit_representative_rows_within_seventy_columns() {
+        let bourse = render_adaptive_schema_at_width(
+            LS_BOURSE_COLUMNS,
+            &["RTX PRO 6000", "128 nodes", "$0.55 - $0.71"],
+            70,
+        );
+        assert_rendered_width(&bourse, 70);
+
+        let citadel_gpu = render_adaptive_schema_at_width(
+            LS_CITADEL_GPU_COLUMNS,
+            &[
+                "hyperstack",
+                "RTX PRO 6000",
+                "96 GB",
+                "32 cores / 256GB",
+                "2048 GB",
+                "InfiniBand",
+                "us-silicon-valley-1",
+                "$12.34",
+            ],
+            70,
+        );
+        let gpu_header = citadel_gpu.lines().nth(1).expect("GPU ls header");
+        assert!(gpu_header.contains("Provider"));
+        assert!(!gpu_header.contains("CPU/RAM"));
+        assert!(!gpu_header.contains("Storage"));
+        assert!(!gpu_header.contains("Interconnect"));
+        assert_rendered_width(&citadel_gpu, 70);
+
+        let citadel_cpu = render_adaptive_schema_at_width(
+            LS_CITADEL_CPU_COLUMNS,
+            &[
+                "hyperstack",
+                "192 cores / 1536GB",
+                "2048 GB",
+                "us-silicon-valley-1",
+                "$12.34",
+            ],
+            70,
+        );
+        let cpu_header = citadel_cpu.lines().nth(1).expect("CPU ls header");
+        assert!(cpu_header.contains("Provider"));
+        assert!(cpu_header.contains("Size"));
+        assert!(cpu_header.contains("Region"));
+        assert!(cpu_header.contains("Price/Hr"));
+        assert!(!cpu_header.contains("Storage"));
+        assert_rendered_width(&citadel_cpu, 70);
+    }
+
+    #[test]
+    fn ps_tables_fit_representative_ipv4_rows_within_seventy_columns() {
+        let bourse = render_adaptive_schema_at_width(
+            PS_BOURSE_COLUMNS,
+            &[
+                "training-rental-with-a-very-long-name",
+                "8x RTX PRO 6000",
+                "running",
+                "255.255.255.255",
+                "32000→22, 32001→8000",
+                "one-covenant/trainer",
+                "32 cores / 256GB",
+                "us-silicon-valley-1",
+                "$12.34",
+                "$123.45",
+                "25h 19m",
+            ],
+            70,
+        );
+        let bourse_header = bourse.lines().nth(1).expect("Bourse ps header");
+        assert!(bourse_header.contains("Name"));
+        assert!(bourse_header.contains("GPU"));
+        assert!(bourse_header.contains("IP"));
+        assert!(bourse_header.contains("Age"));
+        assert!(bourse.contains('…'));
+        assert_rendered_width(&bourse, 70);
+
+        let citadel_gpu = render_adaptive_schema_at_width(
+            PS_CITADEL_GPU_COLUMNS,
+            &[
+                "training-rental-with-a-very-long-name",
+                "hyperstack",
+                "8x RTX PRO 6000",
+                "running",
+                "255.255.255.255",
+                "32 cores / 256GB",
+                "us-silicon-valley-1",
+                "$12.34",
+                "$123.45",
+                "25h 19m",
+            ],
+            70,
+        );
+        let gpu_header = citadel_gpu.lines().nth(1).expect("Citadel GPU ps header");
+        assert!(gpu_header.contains("Name"));
+        assert!(gpu_header.contains("GPU"));
+        assert!(gpu_header.contains("IP"));
+        assert!(gpu_header.contains("Age"));
+        assert!(citadel_gpu.contains('…'));
+        assert_rendered_width(&citadel_gpu, 70);
+
+        let citadel_cpu = render_adaptive_schema_at_width(
+            PS_CITADEL_CPU_COLUMNS,
+            &[
+                "training-rental-with-a-very-long-name",
+                "hyperstack",
+                "192 cores / 1536GB",
+                "running",
+                "255.255.255.255",
+                "us-silicon-valley-1",
+                "$12.34",
+                "$123.45",
+                "25h 19m",
+            ],
+            70,
+        );
+        let cpu_header = citadel_cpu.lines().nth(1).expect("Citadel CPU ps header");
+        assert!(cpu_header.contains("Name"));
+        assert!(cpu_header.contains("Size"));
+        assert!(cpu_header.contains("IP"));
+        assert!(cpu_header.contains("Age"));
+        assert!(citadel_cpu.contains('…'));
+        assert_rendered_width(&citadel_cpu, 70);
+    }
+
+    #[test]
     fn volume_adaptive_column_priorities_match_the_cli_contract() {
         assert_eq!(
             schema(VOLUME_COLUMNS),
@@ -2612,6 +3020,64 @@ mod tests {
             .to_string()
             .lines()
             .all(|line| tabled::grid::util::string::get_line_width(line) == 9));
+    }
+
+    fn card_payment_rows_with_long_invoice() -> Vec<Vec<String>> {
+        vec![vec![
+            "2026-07-13".to_string(),
+            "$1,234.56".to_string(),
+            "Completed".to_string(),
+            link_cell(
+                "INV-2026-EXTREMELY-LONG-INVOICE-NUMBER-00000001",
+                "https://invoice.stripe.test/i/in_123",
+            ),
+        ]]
+    }
+
+    fn render_card_payment_fixture(output: ResolvedOutput, width: usize) -> String {
+        render_card_purchase_rows(
+            card_payment_rows_with_long_invoice(),
+            output,
+            RenderContext {
+                is_tty: true,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+        )
+    }
+
+    #[test]
+    fn card_payment_auto_fits_long_invoice_link_at_seventy_columns() {
+        let rendered = render_card_payment_fixture(ResolvedOutput::Auto, 70);
+
+        assert!(rendered.contains("Date"));
+        assert!(rendered.contains("Amount"));
+        assert!(rendered.contains("Status"));
+        assert!(rendered.contains("Invoice/Receipt"));
+        assert!(rendered.contains("\x1b]8;;https://invoice.stripe.test/i/in_123\x1b\\"));
+        assert!(rendered.contains("\x1b]8;;\x1b\\"));
+        assert!(rendered.contains('…'));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 70));
+    }
+
+    #[test]
+    fn card_payment_compact_fits_long_invoice_link_at_seventy_columns() {
+        let rendered = render_card_payment_fixture(ResolvedOutput::Compact, 70);
+
+        assert!(rendered.contains("Date"));
+        assert!(rendered.contains("Amount"));
+        assert!(rendered.contains("Status"));
+        assert!(rendered.contains("Invoice/Receipt"));
+        assert!(rendered.contains('…'));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= 70));
+    }
+
+    #[test]
+    fn card_payment_wide_preserves_the_full_invoice_label() {
+        let rendered = render_card_payment_fixture(ResolvedOutput::Wide, 70);
+
+        assert!(rendered.contains("INV-2026-EXTREMELY-LONG-INVOICE-NUMBER-00000001"));
+        assert!(rendered.lines().any(|line| get_text_width(line) > 70));
     }
 
     fn purchase(

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -143,6 +143,21 @@ fn compact_image_name(image: &str) -> String {
     }
 }
 
+fn middle_ellipsis(value: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() <= max_chars {
+        return value.to_string();
+    }
+    let available = max_chars.saturating_sub(1);
+    let prefix_len = available / 2;
+    let suffix_len = available - prefix_len;
+    format!(
+        "{}…{}",
+        chars[..prefix_len].iter().collect::<String>(),
+        chars[chars.len() - suffix_len..].iter().collect::<String>()
+    )
+}
+
 /// Format RFC3339 timestamp to YY-MM-DD HH:MM:SS format
 pub fn format_timestamp(timestamp: &str) -> String {
     DateTime::parse_from_rfc3339(timestamp)
@@ -165,7 +180,11 @@ fn format_duration(seconds: i64) -> String {
 }
 
 /// Display rental items in table format
-pub fn display_rental_items(rentals: &[ApiRentalListItem], output: ResolvedOutput) -> Result<()> {
+pub fn display_rental_items(
+    rentals: &[ApiRentalListItem],
+    access_hosts: &HashMap<String, String>,
+    output: ResolvedOutput,
+) -> Result<()> {
     if rentals.is_empty() {
         println!("{}", style("No Bourse rentals found").yellow());
         return Ok(());
@@ -238,7 +257,10 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], output: ResolvedOutpu
                 name: rental.name.clone(),
                 gpu,
                 state: rental.state.to_string(),
-                ip: "—".to_string(),
+                ip: access_hosts
+                    .get(&rental.rental_id)
+                    .cloned()
+                    .unwrap_or_else(|| "—".to_string()),
                 ports,
                 image: compact_image_name(&rental.container_image),
                 cpu_ram,
@@ -273,8 +295,10 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem], output: ResolvedOutpu
             name: rental.name.clone(),
             gpu: format_gpu_info(&rental.gpu_specs),
             state: rental.state.to_string(),
-            // The Bourse list response currently exposes only `has_ssh`, not the host.
-            ip: "—".to_string(),
+            ip: access_hosts
+                .get(&rental.rental_id)
+                .map(|host| middle_ellipsis(host, 22))
+                .unwrap_or_else(|| "—".to_string()),
             rate: rental
                 .hourly_cost
                 .map(|rate| format!("${rate:.2}/h"))
@@ -1699,6 +1723,15 @@ mod tests {
         );
         assert_eq!(compact_image_name("nvidia/cuda:12.4"), "nvidia/cuda");
         assert_eq!(compact_image_name("ubuntu@sha256:abc"), "ubuntu");
+    }
+
+    #[test]
+    fn access_hosts_use_middle_ellipsis() {
+        assert_eq!(middle_ellipsis("short.example", 22), "short.example");
+        let shortened = middle_ellipsis("ssh-a8f31234567890.basilica.ai", 22);
+        assert_eq!(shortened.chars().count(), 22);
+        assert!(shortened.starts_with("ssh-a8f312"));
+        assert!(shortened.ends_with("basilica.ai"));
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -1,6 +1,7 @@
 //! Table formatting for CLI output
 
 use super::{format_cents, format_usd};
+use crate::cli::commands::ResolvedOutput;
 use crate::error::Result;
 use basilica_common::types::GpuOffering;
 use basilica_common::{types::GpuCategory, LocationProfile};
@@ -13,10 +14,134 @@ use basilica_sdk::{
     AvailableNode,
 };
 use chrono::{DateTime, Local, Utc};
-use console::style;
+use console::{style, Term};
 use rust_decimal::Decimal;
-use std::{collections::HashMap, str::FromStr};
-use tabled::{builder::Builder, settings::Style, Table, Tabled};
+use std::{collections::HashMap, io::IsTerminal, str::FromStr};
+use tabled::{
+    builder::Builder,
+    settings::{object::Columns, Modify, Style, Width},
+    Table, Tabled,
+};
+
+const MIN_NAME_WIDTH: usize = 12;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RenderContext {
+    pub is_tty: bool,
+    pub width: Option<usize>,
+    pub now: DateTime<Utc>,
+}
+
+impl RenderContext {
+    pub(crate) fn stdout() -> Self {
+        let is_tty = std::io::stdout().is_terminal();
+        let width = is_tty
+            .then(|| {
+                Term::stdout()
+                    .size_checked()
+                    .map(|(_, columns)| columns as usize)
+            })
+            .flatten();
+        Self {
+            is_tty,
+            width,
+            now: Utc::now(),
+        }
+    }
+}
+
+pub(crate) fn render_table_with_context(
+    mut wide: Table,
+    compact: Option<Table>,
+    output: ResolvedOutput,
+    context: RenderContext,
+    natural_name_width: Option<usize>,
+) -> String {
+    wide.with(Style::modern());
+
+    let use_compact = match output {
+        ResolvedOutput::Compact => true,
+        ResolvedOutput::Wide | ResolvedOutput::Json => false,
+        ResolvedOutput::Auto => {
+            context.is_tty
+                && context
+                    .width
+                    .is_some_and(|width| wide.total_width() > width)
+        }
+    };
+
+    let Some(mut table) = use_compact.then_some(compact).flatten() else {
+        return wide.to_string();
+    };
+    table.with(Style::modern());
+
+    if let (Some(width), Some(name_width)) = (context.width, natural_name_width) {
+        let overflow = table.total_width().saturating_sub(width);
+        if overflow > 0 && name_width > MIN_NAME_WIDTH {
+            let target = name_width.saturating_sub(overflow).max(MIN_NAME_WIDTH);
+            table.with(Modify::new(Columns::new(0..1)).with(Width::truncate(target).suffix("…")));
+        }
+    }
+
+    table.to_string()
+}
+
+fn print_standard_table(table: Table) {
+    let rendered = render_table_with_context(
+        table,
+        None,
+        ResolvedOutput::Auto,
+        RenderContext::stdout(),
+        None,
+    );
+    println!("{rendered}");
+}
+
+fn format_created(timestamp: DateTime<Utc>) -> String {
+    timestamp
+        .with_timezone(&Local)
+        .format("%y-%m-%d %H:%M")
+        .to_string()
+}
+
+pub(crate) fn format_created_str(timestamp: &str) -> String {
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|timestamp| format_created(timestamp.with_timezone(&Utc)))
+        .unwrap_or_else(|_| timestamp.to_string())
+}
+
+fn format_age(created: DateTime<Utc>, now: DateTime<Utc>) -> String {
+    let elapsed = now.signed_duration_since(created).num_minutes().max(0);
+    if elapsed >= 24 * 60 {
+        format!("{}d", elapsed / (24 * 60))
+    } else if elapsed >= 60 {
+        format!("{}h", elapsed / 60)
+    } else {
+        format!("{}m", elapsed)
+    }
+}
+
+pub(crate) fn format_age_str(created: &str, now: DateTime<Utc>) -> String {
+    DateTime::parse_from_rfc3339(created)
+        .map(|created| format_age(created.with_timezone(&Utc), now))
+        .unwrap_or_else(|_| "—".to_string())
+}
+
+fn compact_image_name(image: &str) -> String {
+    let without_digest = image.split('@').next().unwrap_or(image);
+    let last_slash = without_digest.rfind('/');
+    let without_tag = match without_digest.rfind(':') {
+        Some(colon) if last_slash.is_none_or(|slash| colon > slash) => &without_digest[..colon],
+        _ => without_digest,
+    };
+    let mut parts = without_tag.split('/');
+    let first = parts.next().unwrap_or(without_tag);
+    if first.contains('.') || first.contains(':') || first == "localhost" {
+        parts.collect::<Vec<_>>().join("/")
+    } else {
+        without_tag.to_string()
+    }
+}
 
 /// Format RFC3339 timestamp to YY-MM-DD HH:MM:SS format
 pub fn format_timestamp(timestamp: &str) -> String {
@@ -40,7 +165,7 @@ fn format_duration(seconds: i64) -> String {
 }
 
 /// Display rental items in table format
-pub fn display_rental_items(rentals: &[ApiRentalListItem]) -> Result<()> {
+pub fn display_rental_items(rentals: &[ApiRentalListItem], output: ResolvedOutput) -> Result<()> {
     if rentals.is_empty() {
         println!("{}", style("No Bourse rentals found").yellow());
         return Ok(());
@@ -63,23 +188,21 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem]) -> Result<()> {
     };
 
     #[derive(Tabled)]
-    struct RentalRow {
+    struct WideRow {
         #[tabled(rename = "Name")]
         name: String,
         #[tabled(rename = "GPU")]
         gpu: String,
         #[tabled(rename = "State")]
         state: String,
-        #[tabled(rename = "SSH")]
-        ssh: String,
+        #[tabled(rename = "IP")]
+        ip: String,
         #[tabled(rename = "Ports (Host → Container)")]
         ports: String,
         #[tabled(rename = "Image")]
         image: String,
-        #[tabled(rename = "CPU")]
-        cpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
+        #[tabled(rename = "CPU/RAM")]
+        cpu_ram: String,
         #[tabled(rename = "Location")]
         location: String,
         #[tabled(rename = "Rate/hr")]
@@ -90,31 +213,20 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem]) -> Result<()> {
         created: String,
     }
 
-    let rows: Vec<RentalRow> = rentals
+    let wide_rows: Vec<WideRow> = rentals
         .iter()
         .map(|rental| {
             // Format GPU info from specs
             let gpu = format_gpu_info(&rental.gpu_specs);
 
-            // Format CPU info
-            let cpu = rental
+            let cpu_ram = rental
                 .cpu_specs
                 .as_ref()
-                .map(|cpu| format!("{} ({} cores)", cpu.model, cpu.cores))
-                .unwrap_or_else(|| "Unknown".to_string());
-
-            // Format RAM info
-            let ram = rental
-                .cpu_specs
-                .as_ref()
-                .map(|cpu| format!("{} GB", cpu.memory_gb))
-                .unwrap_or_else(|| "Unknown".to_string());
+                .map(|cpu| format!("{} cores / {}GB", cpu.cores, cpu.memory_gb))
+                .unwrap_or_else(|| "—".to_string());
 
             // Format location
             let location = format_node_location(&rental.location);
-
-            // Format SSH availability
-            let ssh = if rental.has_ssh { "✓" } else { "✗" };
 
             // Format port mappings (show up to 2-3 ports)
             let ports = format_port_mappings(&rental.port_mappings, Some(2));
@@ -122,26 +234,66 @@ pub fn display_rental_items(rentals: &[ApiRentalListItem]) -> Result<()> {
             // Get pricing data for this rental
             let (rate_per_hour, total_cost) = get_rental_pricing(rental);
 
-            RentalRow {
+            WideRow {
                 name: rental.name.clone(),
                 gpu,
                 state: rental.state.to_string(),
-                ssh: ssh.to_string(),
+                ip: "—".to_string(),
                 ports,
-                image: rental.container_image.clone(),
-                cpu,
-                ram,
+                image: compact_image_name(&rental.container_image),
+                cpu_ram,
                 location,
                 rate_per_hour,
                 total_cost,
-                created: format_timestamp(&rental.created_at),
+                created: format_created_str(&rental.created_at),
             }
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{table}");
+    #[derive(Tabled)]
+    struct CompactRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "GPU")]
+        gpu: String,
+        #[tabled(rename = "State")]
+        state: String,
+        #[tabled(rename = "IP")]
+        ip: String,
+        #[tabled(rename = "Rate")]
+        rate: String,
+        #[tabled(rename = "Age")]
+        age: String,
+    }
+
+    let context = RenderContext::stdout();
+    let compact_rows: Vec<CompactRow> = rentals
+        .iter()
+        .map(|rental| CompactRow {
+            name: rental.name.clone(),
+            gpu: format_gpu_info(&rental.gpu_specs),
+            state: rental.state.to_string(),
+            // The Bourse list response currently exposes only `has_ssh`, not the host.
+            ip: "—".to_string(),
+            rate: rental
+                .hourly_cost
+                .map(|rate| format!("${rate:.2}/h"))
+                .unwrap_or_else(|| "—".to_string()),
+            age: format_age_str(&rental.created_at, context.now),
+        })
+        .collect();
+    let name_width = rentals
+        .iter()
+        .map(|rental| console::measure_text_width(&rental.name))
+        .max();
+    let rendered = render_table_with_context(
+        Table::new(wide_rows),
+        Some(Table::new(compact_rows)),
+        output,
+        context,
+        name_width,
+    );
+    println!("{rendered}");
 
     Ok(())
 }
@@ -220,9 +372,7 @@ pub fn display_config(config: &HashMap<String, String>) -> Result<()> {
 
     rows.sort_by_key(|r| r.key.clone());
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{table}");
+    print_standard_table(Table::new(rows));
 
     Ok(())
 }
@@ -251,9 +401,7 @@ pub fn display_api_keys(keys: &[ApiKeyInfo]) -> Result<()> {
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{table}");
+    print_standard_table(Table::new(rows));
 
     Ok(())
 }
@@ -340,9 +488,7 @@ pub fn display_available_nodes_detailed(
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(Table::new(rows));
 
     println!("\nTotal available nodes: {}", nodes.len());
 
@@ -400,9 +546,7 @@ pub fn display_community_cloud_categories(
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(Table::new(rows));
 
     let total_nodes: usize = aggregations.iter().map(|a| a.node_count).sum();
     println!("\nTotal available nodes: {}", total_nodes);
@@ -411,7 +555,10 @@ pub fn display_community_cloud_categories(
 }
 
 /// Display secure cloud GPU offerings in detailed format (individual offerings)
-pub fn display_secure_cloud_offerings_detailed(offerings: &[GpuOffering]) -> Result<()> {
+pub fn display_secure_cloud_offerings_detailed(
+    offerings: &[GpuOffering],
+    output: ResolvedOutput,
+) -> Result<()> {
     if offerings.is_empty() {
         println!("No GPUs available matching your criteria.");
         return Ok(());
@@ -425,10 +572,8 @@ pub fn display_secure_cloud_offerings_detailed(offerings: &[GpuOffering]) -> Res
         gpu_info: String,
         #[tabled(rename = "VRAM")]
         vram: String,
-        #[tabled(rename = "vCPU")]
-        vcpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
+        #[tabled(rename = "CPU/RAM")]
+        cpu_ram: String,
         #[tabled(rename = "STORAGE")]
         storage: String,
         #[tabled(rename = "INTERCONNECT")]
@@ -466,8 +611,10 @@ pub fn display_secure_cloud_offerings_detailed(offerings: &[GpuOffering]) -> Res
                 provider: offering.provider.to_string(),
                 gpu_info,
                 vram,
-                vcpu: offering.vcpu_count.to_string(),
-                ram: format!("{} GB", offering.system_memory_gb),
+                cpu_ram: format!(
+                    "{} cores / {}GB",
+                    offering.vcpu_count, offering.system_memory_gb
+                ),
                 storage: offering.storage.clone().unwrap_or_else(|| "-".to_string()),
                 interconnect: offering
                     .interconnect
@@ -479,9 +626,53 @@ pub fn display_secure_cloud_offerings_detailed(offerings: &[GpuOffering]) -> Res
         })
         .collect();
 
-    let mut table = Table::new(rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    #[derive(Tabled)]
+    struct CompactOfferingRow {
+        #[tabled(rename = "PROVIDER")]
+        provider: String,
+        #[tabled(rename = "GPU")]
+        gpu: String,
+        #[tabled(rename = "VRAM")]
+        vram: String,
+        #[tabled(rename = "REGION")]
+        region: String,
+        #[tabled(rename = "RATE")]
+        rate: String,
+    }
+
+    let compact_rows = offerings.iter().map(|offering| {
+        let gpu = if offering.gpu_count == 1 {
+            offering.gpu_type.to_string()
+        } else {
+            format!("{}x {}", offering.gpu_count, offering.gpu_type)
+        };
+        CompactOfferingRow {
+            provider: offering.provider.to_string(),
+            gpu: if offering.is_spot {
+                format!("{gpu} (Spot)")
+            } else {
+                gpu
+            },
+            vram: offering
+                .gpu_memory_gb_per_gpu
+                .map(|memory| format!("{} GB", memory * offering.gpu_count))
+                .unwrap_or_else(|| "—".to_string()),
+            region: offering.region.clone(),
+            rate: format!(
+                "${:.2}/h",
+                offering.hourly_rate_per_gpu * Decimal::from(offering.gpu_count)
+            ),
+        }
+    });
+    let context = RenderContext::stdout();
+    let rendered = render_table_with_context(
+        Table::new(rows),
+        Some(Table::new(compact_rows)),
+        output,
+        context,
+        None,
+    );
+    println!("{rendered}");
 
     println!("\nTotal offerings: {}", offerings.len());
 
@@ -545,9 +736,7 @@ pub fn display_deposits(response: &ListDepositsResponse) -> Result<()> {
         ]);
     }
 
-    let mut table = builder.build();
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(builder.build());
 
     // Display totals
     println!();
@@ -613,9 +802,7 @@ pub fn display_card_purchases(response: &ListCardPurchasesResponse) -> Result<()
         }
     }
 
-    let mut table = builder.build();
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(builder.build());
 
     println!();
     println!("{}:", style("Total Card Payments").bold());
@@ -750,9 +937,7 @@ pub fn display_rental_usage_detail(usage: &RentalUsageResponse) -> Result<()> {
 
         println!("{}", style("Usage Data Points").bold());
         println!();
-        let mut table = Table::new(&rows);
-        table.with(Style::modern());
-        println!("{}", table);
+        print_standard_table(Table::new(&rows));
         if total_points > MAX_POINTS {
             println!(
                 "{}",
@@ -837,9 +1022,7 @@ pub fn display_usage_history(history: &UsageHistoryResponse) -> Result<()> {
         style(history.total_count).cyan()
     );
     println!();
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(Table::new(&rows));
     println!();
 
     let total_cost: Decimal = history
@@ -918,9 +1101,7 @@ pub fn display_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<()> {
 
     rows.sort_by_key(|r| std::cmp::Reverse(r.started.clone()));
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{table}");
+    print_standard_table(Table::new(&rows));
 
     Ok(())
 }
@@ -1003,9 +1184,7 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
 
     rows.sort_by_key(|r| std::cmp::Reverse(r.started.clone()));
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{table}");
+    print_standard_table(Table::new(&rows));
 
     Ok(())
 }
@@ -1013,6 +1192,7 @@ pub fn display_cpu_rental_history(rentals: &[&HistoricalRentalItem]) -> Result<(
 /// Display secure cloud rentals in table format
 pub fn display_secure_cloud_rentals(
     rentals: &[&basilica_sdk::types::SecureCloudRentalListItem],
+    output: ResolvedOutput,
 ) -> Result<()> {
     if rentals.is_empty() {
         println!("{}", style("No Citadel rentals found").yellow());
@@ -1031,12 +1211,8 @@ pub fn display_secure_cloud_rentals(
         status: String,
         #[tabled(rename = "IP")]
         ip: String,
-        #[tabled(rename = "SSH")]
-        ssh: String,
-        #[tabled(rename = "CPU")]
-        cpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
+        #[tabled(rename = "CPU/RAM")]
+        cpu_ram: String,
         #[tabled(rename = "Region")]
         region: String,
         #[tabled(rename = "Rate/hr")]
@@ -1063,23 +1239,10 @@ pub fn display_secure_cloud_rentals(
                 }
             };
 
-            let ssh = if rental.ssh_command.is_some() {
-                "✓"
-            } else {
-                "✗"
+            let cpu_ram = match (rental.vcpu_count, rental.system_memory_gb) {
+                (Some(cores), Some(memory_gb)) => format!("{cores} cores / {memory_gb}GB"),
+                _ => "—".to_string(),
             };
-
-            // Format CPU
-            let cpu = rental
-                .vcpu_count
-                .map(|cores| format!("{} cores", cores))
-                .unwrap_or_else(|| "-".to_string());
-
-            // Format RAM
-            let ram = rental
-                .system_memory_gb
-                .map(|gb| format!("{} GB", gb))
-                .unwrap_or_else(|| "-".to_string());
 
             // Use accumulated cost from billing service - no fallback
             let total_cost = rental
@@ -1094,23 +1257,65 @@ pub fn display_secure_cloud_rentals(
                 gpu: gpu_str,
                 status: rental.status.clone(),
                 ip: rental.ip_address.clone().unwrap_or_else(|| "-".to_string()),
-                ssh: ssh.to_string(),
-                cpu,
-                ram,
+                cpu_ram,
                 region: rental
                     .location_code
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
                 hourly_cost: format!("${:.2}/hr", rental.hourly_cost),
                 total_cost,
-                created: format_timestamp(&rental.created_at.to_rfc3339()),
+                created: format_created(rental.created_at),
             }
         })
         .collect();
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    #[derive(Tabled)]
+    struct CompactRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "GPU")]
+        gpu: String,
+        #[tabled(rename = "State")]
+        state: String,
+        #[tabled(rename = "IP")]
+        ip: String,
+        #[tabled(rename = "Rate")]
+        rate: String,
+        #[tabled(rename = "Age")]
+        age: String,
+    }
+    let context = RenderContext::stdout();
+    let compact_rows = rentals.iter().map(|rental| {
+        let gpu = if rental.gpu_count > 1 {
+            format!("{}x {}", rental.gpu_count, rental.gpu_type.to_uppercase())
+        } else {
+            rental.gpu_type.to_uppercase()
+        };
+        CompactRow {
+            name: rental.name.clone(),
+            gpu: if rental.is_spot {
+                format!("{gpu} (Spot)")
+            } else {
+                gpu
+            },
+            state: rental.status.clone(),
+            ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
+            rate: format!("${:.2}/h", rental.hourly_cost),
+            age: format_age(rental.created_at, context.now),
+        }
+    });
+    let name_width = rentals
+        .iter()
+        .map(|rental| console::measure_text_width(&rental.name))
+        .max();
+    let rendered = render_table_with_context(
+        Table::new(&rows),
+        Some(Table::new(compact_rows)),
+        output,
+        context,
+        name_width,
+    );
+    println!("{rendered}");
 
     Ok(())
 }
@@ -1118,6 +1323,7 @@ pub fn display_secure_cloud_rentals(
 /// Display CPU-only offerings in detailed table format
 pub fn display_cpu_offerings_detailed(
     offerings: &[basilica_sdk::types::CpuOffering],
+    output: ResolvedOutput,
 ) -> Result<()> {
     if offerings.is_empty() {
         println!("{}", style("No CPU instances available").yellow());
@@ -1128,10 +1334,8 @@ pub fn display_cpu_offerings_detailed(
     struct CpuOfferingRow {
         #[tabled(rename = "PROVIDER")]
         provider: String,
-        #[tabled(rename = "vCPU")]
-        vcpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
+        #[tabled(rename = "SIZE")]
+        size: String,
         #[tabled(rename = "STORAGE")]
         storage: String,
         #[tabled(rename = "REGION")]
@@ -1144,8 +1348,10 @@ pub fn display_cpu_offerings_detailed(
         .iter()
         .map(|offering| CpuOfferingRow {
             provider: offering.provider.clone(),
-            vcpu: format!("{} cores", offering.vcpu_count),
-            ram: format!("{} GB", offering.system_memory_gb),
+            size: format!(
+                "{} cores / {}GB",
+                offering.vcpu_count, offering.system_memory_gb
+            ),
             storage: if offering.storage_gb > 0 {
                 format!("{} GB", offering.storage_gb)
             } else {
@@ -1159,9 +1365,37 @@ pub fn display_cpu_offerings_detailed(
         })
         .collect();
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    #[derive(Tabled)]
+    struct CompactCpuOfferingRow {
+        #[tabled(rename = "PROVIDER")]
+        provider: String,
+        #[tabled(rename = "SIZE")]
+        size: String,
+        #[tabled(rename = "REGION")]
+        region: String,
+        #[tabled(rename = "RATE")]
+        rate: String,
+    }
+    let compact_rows = offerings.iter().map(|offering| CompactCpuOfferingRow {
+        provider: offering.provider.clone(),
+        size: format!(
+            "{} cores / {}GB",
+            offering.vcpu_count, offering.system_memory_gb
+        ),
+        region: offering.region.clone(),
+        rate: format!(
+            "${:.2}/h",
+            offering.hourly_rate.parse::<f64>().unwrap_or(0.0)
+        ),
+    });
+    let rendered = render_table_with_context(
+        Table::new(&rows),
+        Some(Table::new(compact_rows)),
+        output,
+        RenderContext::stdout(),
+        None,
+    );
+    println!("{rendered}");
 
     println!("\nTotal Citadel (CPU) offerings: {}", offerings.len());
 
@@ -1171,6 +1405,7 @@ pub fn display_cpu_offerings_detailed(
 /// Display CPU-only rentals in table format (no GPU column)
 pub fn display_cpu_rentals(
     rentals: &[&basilica_sdk::types::SecureCloudRentalListItem],
+    output: ResolvedOutput,
 ) -> Result<()> {
     if rentals.is_empty() {
         println!("{}", style("No CPU-only rentals found").yellow());
@@ -1183,16 +1418,12 @@ pub fn display_cpu_rentals(
         name: String,
         #[tabled(rename = "Provider")]
         provider: String,
-        #[tabled(rename = "vCPU")]
-        vcpu: String,
-        #[tabled(rename = "RAM")]
-        ram: String,
+        #[tabled(rename = "Size")]
+        size: String,
         #[tabled(rename = "State")]
         status: String,
         #[tabled(rename = "IP")]
         ip: String,
-        #[tabled(rename = "SSH")]
-        ssh: String,
         #[tabled(rename = "Region")]
         region: String,
         #[tabled(rename = "Rate/hr")]
@@ -1206,23 +1437,10 @@ pub fn display_cpu_rentals(
     let rows: Vec<CpuRentalRow> = rentals
         .iter()
         .map(|rental| {
-            let ssh = if rental.ssh_command.is_some() {
-                "✓"
-            } else {
-                "✗"
+            let size = match (rental.vcpu_count, rental.system_memory_gb) {
+                (Some(cores), Some(memory_gb)) => format!("{cores} cores / {memory_gb}GB"),
+                _ => "—".to_string(),
             };
-
-            // Format vCPU
-            let vcpu = rental
-                .vcpu_count
-                .map(|cores| format!("{} cores", cores))
-                .unwrap_or_else(|| "-".to_string());
-
-            // Format RAM
-            let ram = rental
-                .system_memory_gb
-                .map(|gb| format!("{} GB", gb))
-                .unwrap_or_else(|| "-".to_string());
 
             // Use accumulated cost from billing service
             let total_cost = rental
@@ -1234,25 +1452,59 @@ pub fn display_cpu_rentals(
             CpuRentalRow {
                 name: rental.name.clone(),
                 provider: rental.provider.clone(),
-                vcpu,
-                ram,
+                size,
                 status: rental.status.clone(),
                 ip: rental.ip_address.clone().unwrap_or_else(|| "-".to_string()),
-                ssh: ssh.to_string(),
                 region: rental
                     .location_code
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
                 hourly_cost: format!("${:.2}/hr", rental.hourly_cost),
                 total_cost,
-                created: format_timestamp(&rental.created_at.to_rfc3339()),
+                created: format_created(rental.created_at),
             }
         })
         .collect();
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    #[derive(Tabled)]
+    struct CompactRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Size")]
+        size: String,
+        #[tabled(rename = "State")]
+        state: String,
+        #[tabled(rename = "IP")]
+        ip: String,
+        #[tabled(rename = "Rate")]
+        rate: String,
+        #[tabled(rename = "Age")]
+        age: String,
+    }
+    let context = RenderContext::stdout();
+    let compact_rows = rentals.iter().map(|rental| CompactRow {
+        name: rental.name.clone(),
+        size: match (rental.vcpu_count, rental.system_memory_gb) {
+            (Some(cores), Some(memory_gb)) => format!("{cores} cores / {memory_gb}GB"),
+            _ => "—".to_string(),
+        },
+        state: rental.status.clone(),
+        ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
+        rate: format!("${:.2}/h", rental.hourly_cost),
+        age: format_age(rental.created_at, context.now),
+    });
+    let name_width = rentals
+        .iter()
+        .map(|rental| console::measure_text_width(&rental.name))
+        .max();
+    let rendered = render_table_with_context(
+        Table::new(&rows),
+        Some(Table::new(compact_rows)),
+        output,
+        context,
+        name_width,
+    );
+    println!("{rendered}");
 
     Ok(())
 }
@@ -1322,9 +1574,7 @@ pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
         })
         .collect();
 
-    let mut table = Table::new(&rows);
-    table.with(Style::modern());
-    println!("{}", table);
+    print_standard_table(Table::new(&rows));
 
     Ok(())
 }
@@ -1333,6 +1583,142 @@ pub fn display_volumes(volumes: &[VolumeResponse]) -> Result<()> {
 mod tests {
     use super::*;
     use basilica_sdk::types::{CardPurchaseStatus, CardPurchaseSummary};
+
+    #[derive(Tabled)]
+    struct WideTestRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Provider")]
+        provider: String,
+        #[tabled(rename = "State")]
+        state: String,
+    }
+
+    #[derive(Tabled)]
+    struct CompactTestRow {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "State")]
+        state: String,
+    }
+
+    fn render_test_table(output: ResolvedOutput, is_tty: bool, width: usize) -> String {
+        let name = "training-rental-with-a-very-long-name".to_string();
+        render_table_with_context(
+            Table::new([WideTestRow {
+                name: name.clone(),
+                provider: "hyperstack".to_string(),
+                state: "provisioning".to_string(),
+            }]),
+            Some(Table::new([CompactTestRow {
+                name: name.clone(),
+                state: "provisioning".to_string(),
+            }])),
+            output,
+            RenderContext {
+                is_tty,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+            Some(console::measure_text_width(&name)),
+        )
+    }
+
+    #[test]
+    fn wide_layout_golden() {
+        let rendered = render_test_table(ResolvedOutput::Wide, true, 40);
+        assert_eq!(
+            rendered,
+            "┌───────────────────────────────────────┬────────────┬──────────────┐\n\
+             │ Name                                  │ Provider   │ State        │\n\
+             ├───────────────────────────────────────┼────────────┼──────────────┤\n\
+             │ training-rental-with-a-very-long-name │ hyperstack │ provisioning │\n\
+             └───────────────────────────────────────┴────────────┴──────────────┘"
+        );
+    }
+
+    #[test]
+    fn compact_layout_golden() {
+        let rendered = render_test_table(ResolvedOutput::Compact, true, 100);
+        assert_eq!(
+            rendered,
+            "┌───────────────────────────────────────┬──────────────┐\n\
+             │ Name                                  │ State        │\n\
+             ├───────────────────────────────────────┼──────────────┤\n\
+             │ training-rental-with-a-very-long-name │ provisioning │\n\
+             └───────────────────────────────────────┴──────────────┘"
+        );
+    }
+
+    #[test]
+    fn auto_layout_selects_compact_at_injected_width() {
+        let rendered = render_test_table(ResolvedOutput::Auto, true, 55);
+        assert!(!rendered.contains("Provider"));
+        assert!(rendered.contains("State"));
+        assert!(rendered
+            .lines()
+            .all(|line| console::measure_text_width(line) <= 55));
+    }
+
+    #[test]
+    fn compact_layout_truncates_only_name_to_floor() {
+        let rendered = render_test_table(ResolvedOutput::Compact, true, 20);
+        assert_eq!(
+            rendered,
+            "┌──────────────┬──────────────┐\n\
+             │ Name         │ State        │\n\
+             ├──────────────┼──────────────┤\n\
+             │ training-re… │ provisioning │\n\
+             └──────────────┴──────────────┘"
+        );
+    }
+
+    #[test]
+    fn non_tty_auto_output_is_always_wide() {
+        let rendered = render_test_table(ResolvedOutput::Auto, false, 20);
+        assert!(rendered.contains("Provider"));
+        assert!(rendered.contains("training-rental-with-a-very-long-name"));
+    }
+
+    #[test]
+    fn relative_age_uses_injected_clock() {
+        let now = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(format_age_str("2026-07-13T11:13:00Z", now), "47m");
+        assert_eq!(format_age_str("2026-07-13T10:00:00Z", now), "2h");
+        assert_eq!(format_age_str("2026-07-10T12:00:00Z", now), "3d");
+        assert_eq!(format_age_str("2026-07-14T12:00:00Z", now), "0m");
+    }
+
+    #[test]
+    fn image_names_drop_registry_tag_and_digest() {
+        assert_eq!(
+            compact_image_name("ghcr.io/one-covenant/trainer:latest"),
+            "one-covenant/trainer"
+        );
+        assert_eq!(compact_image_name("nvidia/cuda:12.4"), "nvidia/cuda");
+        assert_eq!(compact_image_name("ubuntu@sha256:abc"), "ubuntu");
+    }
+
+    #[test]
+    fn ansi_and_osc8_cells_use_visible_width() {
+        #[derive(Tabled)]
+        struct Row {
+            label: String,
+        }
+        let label =
+            "\x1b]8;;https://example.test/invoice\x1b\\\x1b[34;4mINV-1\x1b[0m\x1b]8;;\x1b\\";
+        let mut table = Table::new([Row {
+            label: label.to_string(),
+        }]);
+        table.with(Style::modern());
+        assert_eq!(table.total_width(), 9);
+        assert!(table
+            .to_string()
+            .lines()
+            .all(|line| tabled::grid::util::string::get_line_width(line) == 9));
+    }
 
     fn purchase(
         hosted_invoice_url: Option<&str>,

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -25,6 +25,7 @@ use tabled::{
 };
 
 pub(crate) const MIN_NAME_WIDTH: usize = 8;
+const MIN_GPU_WIDTH: usize = 8;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RenderContext {
@@ -91,6 +92,13 @@ pub(crate) fn render_table_with_context(
 struct AdaptiveColumn {
     header: &'static str,
     drop_order: Option<usize>,
+    truncation: Option<ColumnTruncation>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ColumnTruncation {
+    order: usize,
+    min_width: usize,
 }
 
 impl AdaptiveColumn {
@@ -98,6 +106,15 @@ impl AdaptiveColumn {
         Self {
             header,
             drop_order: None,
+            truncation: None,
+        }
+    }
+
+    const fn required_truncatable(header: &'static str, order: usize, min_width: usize) -> Self {
+        Self {
+            header,
+            drop_order: None,
+            truncation: Some(ColumnTruncation { order, min_width }),
         }
     }
 
@@ -105,19 +122,20 @@ impl AdaptiveColumn {
         Self {
             header,
             drop_order: Some(drop_order),
+            truncation: None,
         }
     }
 }
 
 const LS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required_truncatable("GPU", 1, MIN_GPU_WIDTH),
     AdaptiveColumn::required("Available"),
     AdaptiveColumn::required("Price/hr"),
 ];
 
 const LS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
     AdaptiveColumn::optional("PROVIDER", 4),
-    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required_truncatable("GPU", 1, MIN_GPU_WIDTH),
     AdaptiveColumn::required("VRAM"),
     AdaptiveColumn::optional("CPU/RAM", 1),
     AdaptiveColumn::optional("STORAGE", 2),
@@ -135,8 +153,8 @@ const LS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
 ];
 
 const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::required("Name"),
-    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+    AdaptiveColumn::required_truncatable("GPU", 2, MIN_GPU_WIDTH),
     AdaptiveColumn::optional("State", 7),
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("Ports (Host → Container)", 5),
@@ -149,9 +167,9 @@ const PS_BOURSE_COLUMNS: &[AdaptiveColumn] = &[
 ];
 
 const PS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::required("Name"),
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
     AdaptiveColumn::optional("Provider", 4),
-    AdaptiveColumn::required("GPU"),
+    AdaptiveColumn::required_truncatable("GPU", 2, MIN_GPU_WIDTH),
     AdaptiveColumn::optional("State", 6),
     AdaptiveColumn::required("IP"),
     AdaptiveColumn::optional("CPU/RAM", 2),
@@ -162,7 +180,7 @@ const PS_CITADEL_GPU_COLUMNS: &[AdaptiveColumn] = &[
 ];
 
 const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
-    AdaptiveColumn::required("Name"),
+    AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
     AdaptiveColumn::optional("Provider", 3),
     AdaptiveColumn::required("Size"),
     AdaptiveColumn::optional("State", 5),
@@ -176,20 +194,11 @@ const PS_CITADEL_CPU_COLUMNS: &[AdaptiveColumn] = &[
 struct AdaptiveTable {
     columns: Vec<AdaptiveColumn>,
     rows: Vec<Vec<String>>,
-    flexible_column: Option<usize>,
 }
 
 impl AdaptiveTable {
-    fn new(
-        columns: Vec<AdaptiveColumn>,
-        rows: Vec<Vec<String>>,
-        flexible_column: Option<usize>,
-    ) -> Self {
-        Self {
-            columns,
-            rows,
-            flexible_column,
-        }
+    fn new(columns: Vec<AdaptiveColumn>, rows: Vec<Vec<String>>) -> Self {
+        Self { columns, rows }
     }
 
     fn all_columns(&self) -> Vec<usize> {
@@ -242,13 +251,38 @@ impl AdaptiveTable {
         table
     }
 
-    fn flexible_width(&self) -> Option<usize> {
-        let index = self.flexible_column?;
-        self.rows
+    fn column_width(&self, index: usize) -> Option<usize> {
+        let header_width = self
+            .columns
+            .get(index)
+            .map(|column| get_text_width(column.header))?;
+        Some(
+            self.rows
+                .iter()
+                .filter_map(|row| row.get(index))
+                .map(|value| get_text_width(value))
+                .max()
+                .unwrap_or_default()
+                .max(header_width),
+        )
+    }
+
+    fn truncatable_columns(
+        &self,
+        active_columns: &[usize],
+    ) -> Vec<(usize, usize, ColumnTruncation)> {
+        let mut columns: Vec<_> = active_columns
             .iter()
-            .filter_map(|row| row.get(index))
-            .map(|value| get_text_width(value))
-            .max()
+            .enumerate()
+            .filter_map(|(position, &source_index)| {
+                self.columns
+                    .get(source_index)?
+                    .truncation
+                    .map(|truncation| (position, source_index, truncation))
+            })
+            .collect();
+        columns.sort_by_key(|(_, _, truncation)| truncation.order);
+        columns
     }
 }
 
@@ -258,25 +292,26 @@ fn fit_required_table(
     active_columns: &[usize],
     width: usize,
 ) -> String {
-    let overflow = table.total_width().saturating_sub(width);
-    if overflow == 0 {
-        return table.to_string();
-    }
-
-    if let (Some(source_index), Some(natural_width)) =
-        (adaptive.flexible_column, adaptive.flexible_width())
-    {
-        if let Some(position) = active_columns
-            .iter()
-            .position(|&index| index == source_index)
-        {
-            let target = natural_width.saturating_sub(overflow).max(MIN_NAME_WIDTH);
-            if target < natural_width {
-                table.with(
-                    Modify::new(Columns::new(position..position + 1))
-                        .with(Width::truncate(target).suffix("…")),
-                );
-            }
+    for (position, source_index, truncation) in adaptive.truncatable_columns(active_columns) {
+        let overflow = table.total_width().saturating_sub(width);
+        if overflow == 0 {
+            break;
+        }
+        let Some(natural_width) = adaptive.column_width(source_index) else {
+            continue;
+        };
+        let header_width = adaptive
+            .columns
+            .get(source_index)
+            .map(|column| get_text_width(column.header))
+            .unwrap_or_default();
+        let floor = truncation.min_width.max(header_width);
+        let target = natural_width.saturating_sub(overflow).max(floor);
+        if target < natural_width {
+            table.with(
+                Modify::new(Columns::new(position..position + 1))
+                    .with(Width::truncate(target).suffix("…")),
+            );
         }
     }
 
@@ -387,6 +422,24 @@ fn compact_image_name(image: &str) -> String {
     }
 }
 
+fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = value.get(..prefix.len())?;
+    candidate
+        .eq_ignore_ascii_case(prefix)
+        .then(|| value.get(prefix.len()..))
+        .flatten()
+}
+
+fn compact_gpu_model_name(model: &str) -> String {
+    let without_vendor = strip_ascii_prefix(model.trim(), "NVIDIA ")
+        .unwrap_or(model.trim())
+        .trim_start();
+    strip_ascii_prefix(without_vendor, "BLACKWELL ")
+        .unwrap_or(without_vendor)
+        .trim_start()
+        .to_string()
+}
+
 /// Format RFC3339 timestamp to YY-MM-DD HH:MM:SS format
 pub fn format_timestamp(timestamp: &str) -> String {
     DateTime::parse_from_rfc3339(timestamp)
@@ -408,6 +461,10 @@ fn format_duration(seconds: i64) -> String {
     }
 }
 
+fn format_hourly_price(rate: impl std::fmt::Display) -> String {
+    format!("${rate:.2}")
+}
+
 /// Display rental items in table format
 pub fn display_rental_items(
     rentals: &[ApiRentalListItem],
@@ -423,7 +480,7 @@ pub fn display_rental_items(
     let get_rental_pricing = |rental: &ApiRentalListItem| -> (String, String) {
         let rate = rental
             .hourly_cost
-            .map(|r| format!("${:.2}/hr", r))
+            .map(format_hourly_price)
             .unwrap_or_else(|| "-".to_string());
 
         let cost = rental
@@ -523,7 +580,6 @@ pub fn display_rental_items(
                 ]
             })
             .collect(),
-        Some(0),
     );
     let rendered =
         render_adaptive_table_with_context(Table::new(wide_rows), adaptive, output, context);
@@ -566,21 +622,22 @@ fn format_gpu_info(gpu_specs: &[GpuSpec]) -> String {
 
     // Check if all GPUs are the same
     let first_gpu = &gpu_specs[0];
+    let first_gpu_name = compact_gpu_model_name(&first_gpu.name);
     let all_same = gpu_specs
         .iter()
         .all(|g| g.name == first_gpu.name && g.memory_gb == first_gpu.memory_gb);
 
     if all_same {
         if gpu_specs.len() > 1 {
-            format!("{}x {}", gpu_specs.len(), first_gpu.name)
+            format!("{}x {}", gpu_specs.len(), first_gpu_name)
         } else {
-            format!("1x {}", first_gpu.name)
+            format!("1x {first_gpu_name}")
         }
     } else {
         // List each GPU
         gpu_specs
             .iter()
-            .map(|g| g.name.clone())
+            .map(|g| compact_gpu_model_name(&g.name))
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -752,10 +809,11 @@ pub fn display_community_cloud_categories(
     let rows: Vec<CategoryRow> = aggregations
         .iter()
         .map(|agg| {
+            let gpu_category = compact_gpu_model_name(&agg.gpu_category);
             let gpu = if agg.gpu_count > 1 {
-                format!("{}x {}", agg.gpu_count, agg.gpu_category)
+                format!("{}x {gpu_category}", agg.gpu_count)
             } else {
-                agg.gpu_category.clone()
+                gpu_category
             };
 
             let multiplier = agg.gpu_count as f64;
@@ -786,7 +844,6 @@ pub fn display_community_cloud_categories(
         rows.iter()
             .map(|row| vec![row.gpu.clone(), row.available.clone(), row.price.clone()])
             .collect(),
-        None,
     );
     let rendered = render_adaptive_table_with_context(
         Table::new(rows),
@@ -836,10 +893,11 @@ pub fn display_secure_cloud_offerings_detailed(
         .iter()
         .map(|offering| {
             let gpu_info = {
+                let gpu_type = compact_gpu_model_name(&offering.gpu_type.to_string());
                 let base = if offering.gpu_count == 1 {
-                    offering.gpu_type.to_string()
+                    gpu_type
                 } else {
-                    format!("{}x {}", offering.gpu_count, offering.gpu_type)
+                    format!("{}x {gpu_type}", offering.gpu_count)
                 };
                 if offering.is_spot {
                     format!("{} (Spot)", base)
@@ -869,7 +927,7 @@ pub fn display_secure_cloud_offerings_detailed(
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
                 region: offering.region.clone(),
-                price: format!("${:.2}/hr", total_hourly_cost),
+                price: format_hourly_price(total_hourly_cost),
             }
         })
         .collect();
@@ -890,7 +948,6 @@ pub fn display_secure_cloud_offerings_detailed(
                 ]
             })
             .collect(),
-        None,
     );
     let rendered = render_adaptive_table_with_context(
         Table::new(rows),
@@ -1453,10 +1510,11 @@ pub fn display_secure_cloud_rentals(
         .iter()
         .map(|rental| {
             let gpu_str = {
+                let gpu_type = compact_gpu_model_name(&rental.gpu_type.to_uppercase());
                 let base = if rental.gpu_count > 1 {
-                    format!("{}x {}", rental.gpu_count, rental.gpu_type.to_uppercase())
+                    format!("{}x {gpu_type}", rental.gpu_count)
                 } else {
-                    rental.gpu_type.to_uppercase()
+                    gpu_type
                 };
                 if rental.is_spot {
                     format!("{} (Spot)", base)
@@ -1488,7 +1546,7 @@ pub fn display_secure_cloud_rentals(
                     .location_code
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
-                hourly_cost: format!("${:.2}/hr", rental.hourly_cost),
+                hourly_cost: format_hourly_price(rental.hourly_cost),
                 total_cost,
                 created: format_created(rental.created_at),
             }
@@ -1515,7 +1573,6 @@ pub fn display_secure_cloud_rentals(
                 ]
             })
             .collect(),
-        Some(0),
     );
     let rendered = render_adaptive_table_with_context(Table::new(rows), adaptive, output, context);
     println!("{rendered}");
@@ -1561,10 +1618,7 @@ pub fn display_cpu_offerings_detailed(
                 "-".to_string()
             },
             region: offering.region.clone(),
-            price: format!(
-                "${:.2}/hr",
-                offering.hourly_rate.parse::<f64>().unwrap_or(0.0)
-            ),
+            price: format_hourly_price(offering.hourly_rate.parse::<f64>().unwrap_or(0.0)),
         })
         .collect();
 
@@ -1581,7 +1635,6 @@ pub fn display_cpu_offerings_detailed(
                 ]
             })
             .collect(),
-        None,
     );
     let rendered = render_adaptive_table_with_context(
         Table::new(rows),
@@ -1653,7 +1706,7 @@ pub fn display_cpu_rentals(
                     .location_code
                     .clone()
                     .unwrap_or_else(|| "-".to_string()),
-                hourly_cost: format!("${:.2}/hr", rental.hourly_cost),
+                hourly_cost: format_hourly_price(rental.hourly_cost),
                 total_cost,
                 created: format_created(rental.created_at),
             }
@@ -1679,7 +1732,6 @@ pub fn display_cpu_rentals(
                 ]
             })
             .collect(),
-        Some(0),
     );
     let rendered = render_adaptive_table_with_context(Table::new(rows), adaptive, output, context);
     println!("{rendered}");
@@ -1802,7 +1854,7 @@ mod tests {
         }]);
         let adaptive = AdaptiveTable::new(
             vec![
-                AdaptiveColumn::required("Name"),
+                AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
                 AdaptiveColumn::optional("Low", 1),
                 AdaptiveColumn::optional("High", 2),
                 AdaptiveColumn::required("Age"),
@@ -1813,7 +1865,6 @@ mod tests {
                 "high-value".to_string(),
                 "2h".to_string(),
             ]],
-            Some(0),
         );
         (wide, adaptive)
     }
@@ -1980,16 +2031,55 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_required_table_truncates_each_eligible_column_in_order() {
+        let name = "training-rental-with-a-very-long-name";
+        let gpu = "gpu-model-with-a-very-long-name";
+        let adaptive = AdaptiveTable::new(
+            vec![
+                AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
+                AdaptiveColumn::required_truncatable("GPU", 2, MIN_GPU_WIDTH),
+                AdaptiveColumn::required("Region"),
+            ],
+            vec![vec![
+                name.to_string(),
+                gpu.to_string(),
+                "us-silicon-valley-1".to_string(),
+            ]],
+        );
+        let required_width = adaptive.build(&[0, 1, 2]).total_width();
+        let width = required_width - (get_text_width(name) - MIN_NAME_WIDTH) - 5;
+        let rendered = render_adaptive_table_with_context(
+            Table::new([AdaptiveWideTestRow {
+                name: name.to_string(),
+                low: gpu.to_string(),
+                high: "us-silicon-valley-1".to_string(),
+                created: "2026-07-13 12:00:00 UTC".to_string(),
+            }]),
+            adaptive,
+            ResolvedOutput::Compact,
+            RenderContext {
+                is_tty: true,
+                width: Some(width),
+                now: DateTime::UNIX_EPOCH,
+            },
+        );
+
+        assert!(rendered.contains("trainin…"));
+        assert!(!rendered.contains(gpu));
+        assert!(rendered.contains("us-silicon-valley-1"));
+        assert!(rendered.lines().all(|line| get_text_width(line) <= width));
+    }
+
+    #[test]
     fn adaptive_name_truncation_uses_tabled_width_for_osc8_links() {
         let label = "training-rental-with-a-very-long-name";
         let linked_name = format!("\x1b]8;;https://example.com\x1b\\{label}\x1b]8;;\x1b\\");
         let adaptive = AdaptiveTable::new(
             vec![
-                AdaptiveColumn::required("Name"),
+                AdaptiveColumn::required_truncatable("Name", 1, MIN_NAME_WIDTH),
                 AdaptiveColumn::required("Age"),
             ],
             vec![vec![linked_name, "2h".to_string()]],
-            Some(0),
         );
         let required_width = adaptive.build(&[0, 1]).total_width();
         let width = required_width - (get_text_width(label) - MIN_NAME_WIDTH);
@@ -2026,6 +2116,17 @@ mod tests {
         columns
             .iter()
             .map(|column| (column.header, column.drop_order))
+            .collect()
+    }
+
+    fn truncation_schema(columns: &[AdaptiveColumn]) -> Vec<(&'static str, usize, usize)> {
+        columns
+            .iter()
+            .filter_map(|column| {
+                column
+                    .truncation
+                    .map(|rule| (column.header, rule.order, rule.min_width))
+            })
             .collect()
     }
 
@@ -2110,6 +2211,31 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_truncation_rules_preserve_non_truncatable_required_columns() {
+        assert_eq!(
+            truncation_schema(LS_BOURSE_COLUMNS),
+            vec![("GPU", 1, MIN_GPU_WIDTH)]
+        );
+        assert_eq!(
+            truncation_schema(LS_CITADEL_GPU_COLUMNS),
+            vec![("GPU", 1, MIN_GPU_WIDTH)]
+        );
+        assert!(truncation_schema(LS_CITADEL_CPU_COLUMNS).is_empty());
+        assert_eq!(
+            truncation_schema(PS_BOURSE_COLUMNS),
+            vec![("Name", 1, MIN_NAME_WIDTH), ("GPU", 2, MIN_GPU_WIDTH),]
+        );
+        assert_eq!(
+            truncation_schema(PS_CITADEL_GPU_COLUMNS),
+            vec![("Name", 1, MIN_NAME_WIDTH), ("GPU", 2, MIN_GPU_WIDTH),]
+        );
+        assert_eq!(
+            truncation_schema(PS_CITADEL_CPU_COLUMNS),
+            vec![("Name", 1, MIN_NAME_WIDTH)]
+        );
+    }
+
+    #[test]
     fn relative_age_uses_injected_clock() {
         let now = DateTime::parse_from_rfc3339("2026-07-13T12:00:00Z")
             .unwrap()
@@ -2128,6 +2254,22 @@ mod tests {
         );
         assert_eq!(compact_image_name("nvidia/cuda:12.4"), "nvidia/cuda");
         assert_eq!(compact_image_name("ubuntu@sha256:abc"), "ubuntu");
+    }
+
+    #[test]
+    fn gpu_names_drop_redundant_vendor_and_architecture_prefixes() {
+        assert_eq!(
+            compact_gpu_model_name("NVIDIA BLACKWELL RTX PRO 6000"),
+            "RTX PRO 6000"
+        );
+        assert_eq!(compact_gpu_model_name("blackwell b200"), "b200");
+        assert_eq!(compact_gpu_model_name("RTX A6000"), "RTX A6000");
+    }
+
+    #[test]
+    fn hourly_prices_do_not_repeat_the_header_unit() {
+        assert_eq!(format_hourly_price(0.23), "$0.23");
+        assert_eq!(format_hourly_price(Decimal::new(55, 2)), "$0.55");
     }
 
     #[test]

--- a/crates/basilica-cli/src/output/table_output.rs
+++ b/crates/basilica-cli/src/output/table_output.rs
@@ -278,12 +278,8 @@ pub fn display_rental_items(
         name: String,
         #[tabled(rename = "GPU")]
         gpu: String,
-        #[tabled(rename = "State")]
-        state: String,
         #[tabled(rename = "IP")]
         ip: String,
-        #[tabled(rename = "Rate")]
-        rate: String,
         #[tabled(rename = "Age")]
         age: String,
     }
@@ -294,14 +290,9 @@ pub fn display_rental_items(
         .map(|rental| CompactRow {
             name: rental.name.clone(),
             gpu: format_gpu_info(&rental.gpu_specs),
-            state: rental.state.to_string(),
             ip: access_hosts
                 .get(&rental.rental_id)
                 .map(|host| middle_ellipsis(host, 22))
-                .unwrap_or_else(|| "—".to_string()),
-            rate: rental
-                .hourly_cost
-                .map(|rate| format!("${rate:.2}/h"))
                 .unwrap_or_else(|| "—".to_string()),
             age: format_age_str(&rental.created_at, context.now),
         })
@@ -1299,12 +1290,8 @@ pub fn display_secure_cloud_rentals(
         name: String,
         #[tabled(rename = "GPU")]
         gpu: String,
-        #[tabled(rename = "State")]
-        state: String,
         #[tabled(rename = "IP")]
         ip: String,
-        #[tabled(rename = "Rate")]
-        rate: String,
         #[tabled(rename = "Age")]
         age: String,
     }
@@ -1322,9 +1309,7 @@ pub fn display_secure_cloud_rentals(
             } else {
                 gpu
             },
-            state: rental.status.clone(),
             ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
-            rate: format!("${:.2}/h", rental.hourly_cost),
             age: format_age(rental.created_at, context.now),
         }
     });
@@ -1496,12 +1481,8 @@ pub fn display_cpu_rentals(
         name: String,
         #[tabled(rename = "Size")]
         size: String,
-        #[tabled(rename = "State")]
-        state: String,
         #[tabled(rename = "IP")]
         ip: String,
-        #[tabled(rename = "Rate")]
-        rate: String,
         #[tabled(rename = "Age")]
         age: String,
     }
@@ -1512,9 +1493,7 @@ pub fn display_cpu_rentals(
             (Some(cores), Some(memory_gb)) => format!("{cores} cores / {memory_gb}GB"),
             _ => "—".to_string(),
         },
-        state: rental.status.clone(),
         ip: rental.ip_address.clone().unwrap_or_else(|| "—".to_string()),
-        rate: format!("${:.2}/h", rental.hourly_cost),
         age: format_age(rental.created_at, context.now),
     });
     let name_width = rentals


### PR DESCRIPTION
## Summary

Makes CLI list tables responsive to terminal width while preserving stable JSON and terminal-independent non-TTY output.

- Adds `-o auto|compact|wide|json` to `ls`, `ps`, `tokens list`, `fund list`, `volumes list`, and `deploy ls`.
- Selects the widest supported layout that fits, dropping optional columns by priority where available.
- Truncates eligible required columns only when necessary.
- Keeps default `auto` output wide and terminal-independent in non-TTY environments, and preserves existing JSON output.
- Keeps truncated deployment URLs actionable with terminal hyperlinks.
- Makes funding history narrower with date-only timestamps, shortened transaction hashes linked to Taostats, and adaptive card-payment invoice labels.
- Applies adaptive layouts to active and historical rental tables, with representative `ls` and `ps` coverage at 70 columns.
- Shows complete fallback rental IDs when space permits and truncates them only when required by the layout.
- Groups related hardware details, shortens long GPU and container-image labels, uses minute-precision active-resource timestamps, and standardizes headers and hourly prices.
- Adds relative ages and a three-line, TTY-only `ps` rental summary.
- Resolves Bourse SSH hosts for human `ps` output with bounded, best-effort lookups.

## Notable behavior

- `auto` is the default output mode.
- `compact` shows required columns only.
- `ps --history` requires only `Name` and `Total Cost`, dropping `Status` first when space is limited.
- `wide` may exceed narrow terminal widths by design.
- `--json -o json` is accepted.
- `--json` conflicts with non-JSON output modes.
- Global `--json` applies consistently to all `deploy` subcommands.
- Bourse access enrichment has a shared five-second deadline and is skipped for JSON output.

## Validation

- `cargo test -p basilica-cli`
- `cargo clippy -p basilica-cli --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--output/-o` (`auto|compact|wide|json`) for `ls`, `ps`, token/fund/volume list views, and deployment listing, including terminal-aware `auto` and URL-friendly compact tables.
  * Improved `ps` summaries with total rentals, combined hourly pricing, accrued costs, and resolved access addresses.
* **Bug Fixes**
  * Enforced valid combinations between global `--json` and per-command `--output` (including rejection of incompatible options).
  * Standardized output handling across list commands for consistent JSON vs table rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
