### PR TITLE
fix(exec)!: make SSH execution reliable and transparent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3272,7 +3272,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -4639,7 +4639,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -8250,18 +8250,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -10060,7 +10060,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "multi-stash",
  "smallvec",
- "spin 0.9.8",
+ "spin 0.9.9",
  "wasmi_collections",
  "wasmi_core",
  "wasmi_ir",

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global `--json` now applies consistently to all `deploy` subcommands.
 
 ### Fixed
+- `--json` now renders subprocess exit codes and optional diagnostics as a
+  structured `command_exit` error object.
 - `basilica exec` and file transfers now detect unresponsive sessions with
   server-alive probes. Timed-out or cancelled exec operations terminate and
   reap the local SSH subprocess.
@@ -45,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be retrieved later.
 
 ### Security
+- SSH usernames are validated as portable account names before being passed to
+  OpenSSH, preventing option-like values from being interpreted as SSH flags.
 - Debug logs for `basilica exec`, shared non-interactive SSH subprocesses, and
   automated SCP transfers no longer expose private-key paths or complete
   command details.

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code, and leaves command duration unbounded by default.
 
 ### Fixed
-- SSH commands and file transfers now use async subprocesses with server-alive
-  probes, and configured execution timeouts kill and reap the subprocess.
+- SSH commands and file transfers now detect unresponsive sessions with
+  server-alive probes, and configured execution timeouts stop and reap the
+  local subprocess.
 - `basilica deploy` with `--private` now prints the one-time share token after
   waiting for the deployment to become ready. The token is only returned by
   the create call, so the ready-wait status response dropped it and the CLI

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `basilica exec` now streams stdout and stderr unchanged, returns the SSH exit
   code, and leaves command duration unbounded by default.
+- `basilica cp` now delegates terminal input, output, exit status, and interrupt
+  handling directly to the system `scp`, including native transfer progress.
 - CLI tables now prioritize useful columns on narrow terminals, keep truncated
   deployment URLs and funding transaction hashes actionable, and use consistent
   headers and hourly pricing.
@@ -30,8 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `basilica exec` and file transfers now detect unresponsive sessions with
-  server-alive probes. Timed-out or cancelled operations terminate and reap
-  the local SSH or SCP subprocess.
+  server-alive probes. Timed-out or cancelled exec operations terminate and
+  reap the local SSH subprocess.
 - `basilica ps` now resolves Bourse SSH hosts for human-readable output, so
   access addresses are available alongside Citadel rental addresses.
 - `basilica deploy` with `--private` now prints the one-time share token after
@@ -43,8 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be retrieved later.
 
 ### Security
-- Debug logs for `basilica exec` and shared non-interactive SSH/SCP subprocesses
-  no longer expose private-key paths or complete command details.
+- Debug logs for `basilica exec`, shared non-interactive SSH subprocesses, and
+  automated SCP transfers no longer expose private-key paths or complete
+  command details.
 - Updated transitive `spin` dependencies to patched, non-yanked releases.
 - `basilica upgrade` now verifies the downloaded release archive against the
   published `.sha256` asset before replacing the running binary.

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `basilica exec --timeout <SECS>` for opt-in command deadlines.
+
+### Changed
+- `basilica exec` now streams stdout and stderr unchanged, returns the SSH exit
+  code, and leaves command duration unbounded by default.
+
 ### Fixed
+- SSH commands and file transfers now use async subprocesses with server-alive
+  probes, and configured execution timeouts kill and reap the subprocess.
 - `basilica deploy` with `--private` now prints the one-time share token after
   waiting for the deployment to become ready. The token is only returned by
   the create call, so the ready-wait status response dropped it and the CLI

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `basilica exec --timeout <SECS>` for opt-in command deadlines.
+- `basilica exec --timeout <SECS>` for opt-in total SSH deadlines, including
+  connection setup. Timeouts exit with status 124 and may leave the remote
+  command running.
 - `ls`, `ps`, `tokens list`, `fund list`, `volumes list`, and `deploy ls` now
   support `--output auto|compact|wide|json`. The default `auto` mode adapts
   columns to interactive terminal width while non-interactive output remains
@@ -27,9 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global `--json` now applies consistently to all `deploy` subcommands.
 
 ### Fixed
-- SSH commands and file transfers now detect unresponsive sessions with
-  server-alive probes, and configured execution timeouts stop and reap the
-  local subprocess.
+- `basilica exec` and file transfers now detect unresponsive sessions with
+  server-alive probes. Timed-out or cancelled operations terminate and reap
+  the local SSH or SCP subprocess.
 - `basilica ps` now resolves Bourse SSH hosts for human-readable output, so
   access addresses are available alongside Citadel rental addresses.
 - `basilica deploy` with `--private` now prints the one-time share token after
@@ -41,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be retrieved later.
 
 ### Security
+- Debug logs for `basilica exec` and shared non-interactive SSH/SCP subprocesses
+  no longer expose private-key paths or complete command details.
+- Updated transitive `spin` dependencies to patched, non-yanked releases.
 - `basilica upgrade` now verifies the downloaded release archive against the
   published `.sha256` asset before replacing the running binary.
 

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -200,8 +200,18 @@ impl Args {
             Commands::Restart { target } => {
                 handlers::gpu_rental::handle_restart(target.clone(), config).await?;
             }
-            Commands::Exec { command, target } => {
-                handlers::gpu_rental::handle_exec(target.clone(), command.clone(), config).await?;
+            Commands::Exec {
+                command,
+                target,
+                timeout,
+            } => {
+                handlers::gpu_rental::handle_exec(
+                    target.clone(),
+                    command.clone(),
+                    *timeout,
+                    config,
+                )
+                .await?;
             }
             Commands::Ssh { target, options } => {
                 handlers::gpu_rental::handle_ssh(target.clone(), options.clone(), config).await?;

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -122,6 +122,10 @@ pub enum Commands {
         /// Rental name or ID (optional)
         #[arg(long)]
         target: Option<String>,
+
+        /// Maximum command duration in seconds (unbounded by default)
+        #[arg(long, value_name = "SECS")]
+        timeout: Option<u64>,
     },
 
     /// SSH into instances
@@ -1570,6 +1574,43 @@ mod train_command_tests {
     use clap::error::ErrorKind;
     use clap::Parser;
     use std::str::FromStr;
+
+    #[test]
+    fn exec_parses_optional_timeout_seconds() {
+        let args = Args::try_parse_from([
+            "basilica",
+            "exec",
+            "sleep 10",
+            "--target",
+            "rental-1",
+            "--timeout",
+            "7",
+        ])
+        .unwrap();
+
+        match args.command {
+            Commands::Exec {
+                command,
+                target,
+                timeout,
+            } => {
+                assert_eq!(command, "sleep 10");
+                assert_eq!(target.as_deref(), Some("rental-1"));
+                assert_eq!(timeout, Some(7));
+            }
+            other => panic!("expected exec command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exec_has_no_timeout_by_default() {
+        let args = Args::try_parse_from(["basilica", "exec", "sleep 10"]).unwrap();
+
+        match args.command {
+            Commands::Exec { timeout, .. } => assert_eq!(timeout, None),
+            other => panic!("expected exec command, got {other:?}"),
+        }
+    }
 
     // -----------------------------------------------------------------
     // WorldSizeTriple parser.

--- a/crates/basilica-cli/src/cli/commands.rs
+++ b/crates/basilica-cli/src/cli/commands.rs
@@ -123,7 +123,8 @@ pub enum Commands {
         #[arg(long)]
         target: Option<String>,
 
-        /// Maximum command duration in seconds (unbounded by default)
+        /// Maximum total SSH execution duration in seconds, including connection setup
+        /// (unbounded by default)
         #[arg(long, value_name = "SECS")]
         timeout: Option<u64>,
     },
@@ -1572,7 +1573,7 @@ mod train_command_tests {
     use super::*;
     use crate::cli::args::Args;
     use clap::error::ErrorKind;
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use std::str::FromStr;
 
     #[test]
@@ -1610,6 +1611,15 @@ mod train_command_tests {
             Commands::Exec { timeout, .. } => assert_eq!(timeout, None),
             other => panic!("expected exec command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn exec_timeout_help_includes_connection_setup() {
+        let mut command = Args::command();
+        let exec = command.find_subcommand_mut("exec").unwrap();
+        let help = exec.render_long_help().to_string();
+
+        assert!(help.contains("including connection setup"));
     }
 
     // -----------------------------------------------------------------

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -867,7 +867,7 @@ async fn handle_rental_with_offering(
                 .await
                 .map_err(CliError::Internal)?;
 
-            let ssh_client = SshClient::new(&config.ssh, None)?;
+            let ssh_client = SshClient::new(&config.ssh)?;
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
@@ -1109,7 +1109,7 @@ async fn handle_community_cloud_rental_with_selection(
                 .await
                 .map_err(CliError::Internal)?;
 
-            let ssh_client = SshClient::new(&config.ssh, None)?;
+            let ssh_client = SshClient::new(&config.ssh)?;
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
@@ -2661,7 +2661,12 @@ pub async fn handle_exec(
     };
 
     // Use SSH client to execute command
-    let ssh_client = SshClient::new(&config.ssh, timeout.map(Duration::from_secs))?;
+    let ssh_client = match timeout {
+        Some(timeout_secs) => {
+            SshClient::with_execution_timeout(&config.ssh, Duration::from_secs(timeout_secs))?
+        }
+        None => SshClient::new(&config.ssh)?,
+    };
     let status = ssh_client
         .execute_command(&ssh_access, &command, private_key_path)
         .await?;
@@ -2726,7 +2731,7 @@ pub async fn handle_ssh(
     debug!("Using private key: {}", private_key_path.display());
 
     // Use SSH client to handle connection with options
-    let ssh_client = SshClient::new(&config.ssh, None)?;
+    let ssh_client = SshClient::new(&config.ssh)?;
 
     // Open interactive session with port forwarding options
     ssh_client
@@ -2814,7 +2819,7 @@ pub async fn handle_cp(
     );
 
     // Use SSH client for file transfer
-    let ssh_client = SshClient::new(&config.ssh, None).map_err(|e| eyre!(e))?;
+    let ssh_client = SshClient::new(&config.ssh).map_err(|e| eyre!(e))?;
 
     if is_upload {
         ssh_client

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -2481,13 +2481,7 @@ fn exec_status_result(
 ) -> Result<(), CliError> {
     match status {
         basilica_common::ssh::SshCommandStatus::Exited(status) if status.success() => Ok(()),
-        basilica_common::ssh::SshCommandStatus::Exited(status) => {
-            let code = status.code().unwrap_or(1);
-            let message = (code == 255).then(|| {
-                "SSH transport failed (exit 255); the client cannot determine whether the remote command started or stopped\nCheck if the rental is still active and SSH port is exposed\nRun 'basilica status <rental-id>' to check rental status".to_string()
-            });
-            Err(CliError::CommandExit { code, message })
-        }
+        basilica_common::ssh::SshCommandStatus::Exited(status) => Err(exec_exit_error(status)),
         basilica_common::ssh::SshCommandStatus::TimedOut => {
             let timeout = timeout.ok_or_else(|| {
                 CliError::Internal(eyre!(
@@ -2501,6 +2495,37 @@ fn exec_status_result(
                 )),
             })
         }
+    }
+}
+
+fn exec_exit_error(status: std::process::ExitStatus) -> CliError {
+    if let Some(code) = status.code() {
+        let message = (code == 255).then(|| {
+            "SSH transport failed (exit 255); the client cannot determine whether the remote command started or stopped\nCheck if the rental is still active and SSH port is exposed\nRun 'basilica status <rental-id>' to check rental status".to_string()
+        });
+        return CliError::CommandExit { code, message };
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        if let Some(signal) = status.signal() {
+            return CliError::CommandExit {
+                code: 128 + signal,
+                message: Some(format!(
+                    "SSH process terminated by signal {signal}; the client cannot determine whether the remote command started or stopped"
+                )),
+            };
+        }
+    }
+
+    CliError::CommandExit {
+        code: 1,
+        message: Some(
+            "SSH process terminated without an exit status; the client cannot determine whether the remote command started or stopped"
+                .to_string(),
+        ),
     }
 }
 
@@ -2552,8 +2577,6 @@ pub async fn handle_exec(
 
         crate::ssh::find_private_key_for_public_key(&public_key).map_err(CliError::Internal)?
     };
-
-    debug!("Using private key for exec: {}", private_key_path.display());
 
     // Use SSH client to execute command
     let ssh_client = SshClient::new(&config.ssh, timeout.map(Duration::from_secs))?;
@@ -3246,6 +3269,25 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exec_status_reports_local_ssh_signal() {
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("kill -TERM $$")
+            .status()
+            .unwrap();
+        let error = exec_status_result(SshCommandStatus::Exited(status), None).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CliError::CommandExit {
+                code: 143,
+                message: Some(message)
+            } if message == "SSH process terminated by signal 15; the client cannot determine whether the remote command started or stopped"
+        ));
     }
 
     #[test]

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -815,7 +815,7 @@ async fn handle_rental_with_offering(
                 .await
                 .map_err(CliError::Internal)?;
 
-            let ssh_client = SshClient::new(&config.ssh)?;
+            let ssh_client = SshClient::new(&config.ssh, None)?;
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
@@ -1057,7 +1057,7 @@ async fn handle_community_cloud_rental_with_selection(
                 .await
                 .map_err(CliError::Internal)?;
 
-            let ssh_client = SshClient::new(&config.ssh)?;
+            let ssh_client = SshClient::new(&config.ssh, None)?;
             match retry_ssh_connection(
                 &ssh_client,
                 &ssh_access,
@@ -2475,9 +2475,39 @@ pub async fn handle_restart(target: Option<String>, config: &CliConfig) -> Resul
 }
 
 /// Handle the `exec` command - execute commands via SSH
+fn exec_status_result(
+    status: basilica_common::ssh::SshCommandStatus,
+    timeout: Option<u64>,
+) -> Result<(), CliError> {
+    match status {
+        basilica_common::ssh::SshCommandStatus::Exited(status) if status.success() => Ok(()),
+        basilica_common::ssh::SshCommandStatus::Exited(status) => {
+            let code = status.code().unwrap_or(1);
+            let message = (code == 255).then(|| {
+                "SSH transport failed (exit 255); the client cannot determine whether the remote command started or stopped\nCheck if the rental is still active and SSH port is exposed\nRun 'basilica status <rental-id>' to check rental status".to_string()
+            });
+            Err(CliError::CommandExit { code, message })
+        }
+        basilica_common::ssh::SshCommandStatus::TimedOut => {
+            let timeout = timeout.ok_or_else(|| {
+                CliError::Internal(eyre!(
+                    "SSH command timed out without a configured execution timeout"
+                ))
+            })?;
+            Err(CliError::CommandExit {
+                code: 124,
+                message: Some(format!(
+                    "command timed out after {timeout}s; it may still be running on the remote host"
+                )),
+            })
+        }
+    }
+}
+
 pub async fn handle_exec(
     target: Option<String>,
     command: String,
+    timeout: Option<u64>,
     config: &CliConfig,
 ) -> Result<(), CliError> {
     // Create API client to verify rental status
@@ -2526,11 +2556,12 @@ pub async fn handle_exec(
     debug!("Using private key for exec: {}", private_key_path.display());
 
     // Use SSH client to execute command
-    let ssh_client = SshClient::new(&config.ssh)?;
-    ssh_client
+    let ssh_client = SshClient::new(&config.ssh, timeout.map(Duration::from_secs))?;
+    let status = ssh_client
         .execute_command(&ssh_access, &command, private_key_path)
         .await?;
-    Ok(())
+
+    exec_status_result(status, timeout)
 }
 
 /// Handle the `ssh` command - SSH into instances
@@ -2590,7 +2621,7 @@ pub async fn handle_ssh(
     debug!("Using private key: {}", private_key_path.display());
 
     // Use SSH client to handle connection with options
-    let ssh_client = SshClient::new(&config.ssh)?;
+    let ssh_client = SshClient::new(&config.ssh, None)?;
 
     // Open interactive session with port forwarding options
     ssh_client
@@ -2678,7 +2709,7 @@ pub async fn handle_cp(
     );
 
     // Use SSH client for file transfer
-    let ssh_client = SshClient::new(&config.ssh).map_err(|e| eyre!(e))?;
+    let ssh_client = SshClient::new(&config.ssh, None).map_err(|e| eyre!(e))?;
 
     if is_upload {
         ssh_client
@@ -3174,7 +3205,61 @@ fn display_ps_quick_start_commands() {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_total_hourly_cost, total_hourly_cost};
+    use super::{exec_status_result, format_total_hourly_cost, total_hourly_cost};
+    use crate::CliError;
+    use basilica_common::ssh::SshCommandStatus;
+
+    fn shell_status(code: i32) -> std::process::ExitStatus {
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!("exit {code}"))
+            .status()
+            .unwrap()
+    }
+
+    #[test]
+    fn exec_status_preserves_remote_exit_code_without_message() {
+        let error =
+            exec_status_result(SshCommandStatus::Exited(shell_status(3)), None).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CliError::CommandExit {
+                code: 3,
+                message: None
+            }
+        ));
+    }
+
+    #[test]
+    fn exec_status_adds_rental_guidance_only_for_transport_failure() {
+        let error =
+            exec_status_result(SshCommandStatus::Exited(shell_status(255)), None).unwrap_err();
+
+        match error {
+            CliError::CommandExit {
+                code: 255,
+                message: Some(message),
+            } => {
+                assert!(message.contains("cannot determine whether the remote command started"));
+                assert!(message.contains("basilica status <rental-id>"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exec_timeout_uses_exit_124_and_reports_remote_ambiguity() {
+        let error = exec_status_result(SshCommandStatus::TimedOut, Some(7)).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CliError::CommandExit {
+                code: 124,
+                message: Some(message)
+            } if message == "command timed out after 7s; it may still be running on the remote host"
+        ));
+    }
 
     #[test]
     fn format_total_hourly_cost_uses_two_decimal_places() {

--- a/crates/basilica-cli/src/error.rs
+++ b/crates/basilica-cli/src/error.rs
@@ -102,6 +102,10 @@ pub enum CliError {
     #[error("missing prerequisite: {field}")]
     MissingPrerequisite { field: String, hint: String },
 
+    /// A child command's exit status should become the CLI process exit status.
+    #[error("command exited with status {code}")]
+    CommandExit { code: i32, message: Option<String> },
+
     /// Everything else (using color-eyre's Report for rich errors)
     #[error(transparent)]
     Internal(#[from] Report),
@@ -109,3 +113,13 @@ pub enum CliError {
 
 /// Result type alias for CLI operations
 pub type Result<T> = std::result::Result<T, CliError>;
+
+impl CliError {
+    /// Exit code that the CLI process should return for this error.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::CommandExit { code, .. } => *code,
+            _ => 1,
+        }
+    }
+}

--- a/crates/basilica-cli/src/main.rs
+++ b/crates/basilica-cli/src/main.rs
@@ -76,13 +76,14 @@ async fn run_async(args: Args) -> Result<()> {
 
     // Run and handle errors explicitly to show suggestions
     if let Err(err) = args.run().await {
+        let exit_code = err.exit_code();
         let mode = if json {
             basilica_cli::output::RenderMode::Json
         } else {
             basilica_cli::output::RenderMode::Human
         };
         let _ = basilica_cli::output::render_error(&err, mode, &mut std::io::stderr());
-        std::process::exit(1);
+        std::process::exit(exit_code);
     }
 
     Ok(())

--- a/crates/basilica-cli/src/output/error_render.rs
+++ b/crates/basilica-cli/src/output/error_render.rs
@@ -12,13 +12,6 @@ pub enum RenderMode {
 }
 
 pub fn render_error(err: &CliError, mode: RenderMode, w: &mut dyn Write) -> std::io::Result<()> {
-    if let CliError::CommandExit { message, .. } = err {
-        return match message {
-            Some(message) => writeln!(w, "{}", message),
-            None => Ok(()),
-        };
-    }
-
     match mode {
         RenderMode::Json => render_json(err, w),
         RenderMode::Human => render_human(err, w),
@@ -37,6 +30,11 @@ fn render_json(err: &CliError, w: &mut dyn Write) -> std::io::Result<()> {
             "field": field,
             "hint": hint,
         }),
+        CliError::CommandExit { code, message } => serde_json::json!({
+            "error": "command_exit",
+            "code": code,
+            "message": message,
+        }),
         other => serde_json::json!({
             "error": "cli_error",
             "message": other.to_string(),
@@ -47,6 +45,10 @@ fn render_json(err: &CliError, w: &mut dyn Write) -> std::io::Result<()> {
 
 fn render_human(err: &CliError, w: &mut dyn Write) -> std::io::Result<()> {
     match err {
+        CliError::CommandExit { message, .. } => match message {
+            Some(message) => writeln!(w, "{}", message),
+            None => Ok(()),
+        },
         CliError::MissingInput { field, hint } => {
             writeln!(w, "error: missing input for '{}'", field)?;
             writeln!(w, "hint: {}", hint)
@@ -136,7 +138,21 @@ mod tests {
     }
 
     #[test]
-    fn command_exit_with_message_renders_exact_message() {
+    fn human_command_exit_with_message_renders_exact_message() {
+        let err = CliError::CommandExit {
+            code: 124,
+            message: Some("command timed out after 2s".into()),
+        };
+        let mut buf = Vec::new();
+
+        render_error(&err, RenderMode::Human, &mut buf).unwrap();
+
+        assert_eq!(buf, b"command timed out after 2s\n");
+        assert_eq!(err.exit_code(), 124);
+    }
+
+    #[test]
+    fn json_command_exit_with_message_is_structured() {
         let err = CliError::CommandExit {
             code: 124,
             message: Some("command timed out after 2s".into()),
@@ -145,7 +161,25 @@ mod tests {
 
         render_error(&err, RenderMode::Json, &mut buf).unwrap();
 
-        assert_eq!(buf, b"command timed out after 2s\n");
-        assert_eq!(err.exit_code(), 124);
+        let value: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(value["error"], "command_exit");
+        assert_eq!(value["code"], 124);
+        assert_eq!(value["message"], "command timed out after 2s");
+    }
+
+    #[test]
+    fn json_command_exit_without_message_includes_null_message() {
+        let err = CliError::CommandExit {
+            code: 3,
+            message: None,
+        };
+        let mut buf = Vec::new();
+
+        render_error(&err, RenderMode::Json, &mut buf).unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(value["error"], "command_exit");
+        assert_eq!(value["code"], 3);
+        assert!(value["message"].is_null());
     }
 }

--- a/crates/basilica-cli/src/output/error_render.rs
+++ b/crates/basilica-cli/src/output/error_render.rs
@@ -12,6 +12,13 @@ pub enum RenderMode {
 }
 
 pub fn render_error(err: &CliError, mode: RenderMode, w: &mut dyn Write) -> std::io::Result<()> {
+    if let CliError::CommandExit { message, .. } = err {
+        return match message {
+            Some(message) => writeln!(w, "{}", message),
+            None => Ok(()),
+        };
+    }
+
     match mode {
         RenderMode::Json => render_json(err, w),
         RenderMode::Human => render_human(err, w),
@@ -112,5 +119,33 @@ mod tests {
         assert!(s.contains("SSH command failed"));
         assert!(s.contains("ModuleNotFoundError"));
         assert!(!s.contains("Command execution failed"));
+    }
+
+    #[test]
+    fn command_exit_without_message_renders_nothing() {
+        let err = CliError::CommandExit {
+            code: 3,
+            message: None,
+        };
+        let mut buf = Vec::new();
+
+        render_error(&err, RenderMode::Human, &mut buf).unwrap();
+
+        assert!(buf.is_empty());
+        assert_eq!(err.exit_code(), 3);
+    }
+
+    #[test]
+    fn command_exit_with_message_renders_exact_message() {
+        let err = CliError::CommandExit {
+            code: 124,
+            message: Some("command timed out after 2s".into()),
+        };
+        let mut buf = Vec::new();
+
+        render_error(&err, RenderMode::Json, &mut buf).unwrap();
+
+        assert_eq!(buf, b"command timed out after 2s\n");
+        assert_eq!(err.exit_code(), 124);
     }
 }

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -9,7 +9,8 @@ pub use key_matcher::{
 use crate::config::SshConfig;
 use crate::error::{CliError, Result};
 use basilica_common::ssh::{
-    SshCommandStatus, SshConnectionConfig, SshConnectionDetails, StandardSshClient,
+    validate_ssh_username, SshCommandStatus, SshConnectionConfig, SshConnectionDetails,
+    StandardSshClient,
 };
 use basilica_sdk::types::{RentalStatusResponse, SshAccess};
 use color_eyre::eyre::eyre;
@@ -77,6 +78,8 @@ impl SshClient {
         ssh_access: &SshAccess,
         private_key_path: std::path::PathBuf,
     ) -> Result<SshConnectionDetails> {
+        validate_ssh_username(&ssh_access.username).map_err(|error| eyre!(error))?;
+
         if !private_key_path.exists() {
             return Err(eyre!(
                 "SSH private key not found at: {}",
@@ -485,15 +488,7 @@ impl SshClient {
         {
             return Err(eyre!("Host contains invalid characters").into());
         }
-        if details.username.is_empty() {
-            return Err(eyre!("Username cannot be empty").into());
-        }
-        if details
-            .username
-            .contains(&[';', '&', '|', '$', '`', '\n', '\r', '@'][..])
-        {
-            return Err(eyre!("Username contains invalid characters").into());
-        }
+        validate_ssh_username(&details.username).map_err(|error| eyre!(error))?;
 
         let mut command = TokioCommand::new(program);
         command
@@ -843,6 +838,14 @@ mod tests {
 
         details.host = "example.test".to_string();
         details.username.clear();
+        assert!(SshClient::scp_command(&details, Path::new("scp")).is_err());
+    }
+
+    #[test]
+    fn scp_command_rejects_option_like_username() {
+        let mut details = connection_details("/tmp/test-key".into());
+        details.username = "-oProxyCommand=echo injected".to_string();
+
         assert!(SshClient::scp_command(&details, Path::new("scp")).is_err());
     }
 }

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -9,14 +9,15 @@ pub use key_matcher::{
 use crate::config::SshConfig;
 use crate::error::{CliError, Result};
 use basilica_common::ssh::{
-    SshCommandStatus, SshConnectionConfig, SshConnectionDetails, SshFileTransferManager,
-    StandardSshClient,
+    SshCommandStatus, SshConnectionConfig, SshConnectionDetails, StandardSshClient,
 };
 use basilica_sdk::types::{RentalStatusResponse, SshAccess};
 use color_eyre::eyre::eyre;
 use color_eyre::Section;
 use std::path::Path;
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
+use tokio::process::Command as TokioCommand;
 use tracing::{debug, info};
 
 /// SSH client for rental operations
@@ -474,6 +475,133 @@ impl SshClient {
         Ok(())
     }
 
+    fn scp_command(details: &SshConnectionDetails, program: &Path) -> Result<TokioCommand> {
+        if details.host.is_empty() {
+            return Err(eyre!("Host cannot be empty").into());
+        }
+        if details
+            .host
+            .contains(&[';', '&', '|', '$', '`', '\n', '\r'][..])
+        {
+            return Err(eyre!("Host contains invalid characters").into());
+        }
+        if details.username.is_empty() {
+            return Err(eyre!("Username cannot be empty").into());
+        }
+        if details
+            .username
+            .contains(&[';', '&', '|', '$', '`', '\n', '\r', '@'][..])
+        {
+            return Err(eyre!("Username contains invalid characters").into());
+        }
+
+        let mut command = TokioCommand::new(program);
+        command
+            .arg("-i")
+            .arg(&details.private_key_path)
+            .arg("-P")
+            .arg(details.port.to_string())
+            .arg("-o")
+            .arg("StrictHostKeyChecking=no")
+            .arg("-o")
+            .arg("UserKnownHostsFile=/dev/null")
+            .arg("-o")
+            .arg("LogLevel=ERROR")
+            .arg("-o")
+            .arg("IdentitiesOnly=yes")
+            .arg("-o")
+            .arg(format!("ConnectTimeout={}", details.timeout.as_secs()))
+            .arg("-o")
+            .arg("ServerAliveInterval=15")
+            .arg("-o")
+            .arg("ServerAliveCountMax=3");
+
+        Ok(command)
+    }
+
+    fn scp_upload_command(
+        details: &SshConnectionDetails,
+        local_path: &Path,
+        remote_path: &str,
+        program: &Path,
+    ) -> Result<TokioCommand> {
+        let mut command = Self::scp_command(details, program)?;
+        command.arg("--").arg(local_path).arg(format!(
+            "{}@{}:{}",
+            details.username, details.host, remote_path
+        ));
+        Ok(command)
+    }
+
+    fn scp_download_command(
+        details: &SshConnectionDetails,
+        remote_path: &str,
+        local_path: &Path,
+        program: &Path,
+    ) -> Result<TokioCommand> {
+        let mut command = Self::scp_command(details, program)?;
+        command
+            .arg("--")
+            .arg(format!(
+                "{}@{}:{}",
+                details.username, details.host, remote_path
+            ))
+            .arg(local_path);
+        Ok(command)
+    }
+
+    async fn run_scp_with_stdio(
+        command: &mut TokioCommand,
+        stdin: Stdio,
+        stdout: Stdio,
+        stderr: Stdio,
+    ) -> Result<()> {
+        let status = command
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(stderr)
+            .status()
+            .await
+            .map_err(|error| {
+                CliError::Internal(
+                    eyre!("Failed to start SCP file transfer: {}", error)
+                        .suggestion("Ensure OpenSSH scp is installed and available in PATH"),
+                )
+            })?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(Self::scp_exit_error(status))
+        }
+    }
+
+    fn scp_exit_error(status: ExitStatus) -> CliError {
+        if let Some(code) = status.code() {
+            return CliError::CommandExit {
+                code,
+                message: None,
+            };
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+
+            if let Some(signal) = status.signal() {
+                return CliError::CommandExit {
+                    code: 128 + signal,
+                    message: None,
+                };
+            }
+        }
+
+        CliError::CommandExit {
+            code: 1,
+            message: None,
+        }
+    }
+
     /// Upload file via SSH
     pub async fn upload_file(
         &self,
@@ -487,14 +615,14 @@ impl SshClient {
 
         info!("Uploading {} to {}", local_path, ssh_access.host);
 
-        self.client
-            .upload_file(&details, local, remote_path)
-            .await
-            .map_err(|e| {
-                eyre!("File upload failed: {}", e)
-                    .suggestion("Check file permissions and available disk space on the rental")
-                    .note("Ensure the local file exists and is readable")
-            })?;
+        let mut command = Self::scp_upload_command(&details, local, remote_path, Path::new("scp"))?;
+        Self::run_scp_with_stdio(
+            &mut command,
+            Stdio::inherit(),
+            Stdio::inherit(),
+            Stdio::inherit(),
+        )
+        .await?;
 
         info!("Upload completed successfully");
         Ok(())
@@ -513,14 +641,15 @@ impl SshClient {
 
         info!("Downloading {} from {}", remote_path, ssh_access.host);
 
-        self.client
-            .download_file(&details, remote_path, local)
-            .await
-            .map_err(|e| {
-                eyre!("File download failed: {}", e)
-                    .suggestion("Check that the remote file exists and you have read permissions")
-                    .note("Ensure the destination directory is writable")
-            })?;
+        let mut command =
+            Self::scp_download_command(&details, remote_path, local, Path::new("scp"))?;
+        Self::run_scp_with_stdio(
+            &mut command,
+            Stdio::inherit(),
+            Stdio::inherit(),
+            Stdio::inherit(),
+        )
+        .await?;
 
         info!("Download completed successfully");
         Ok(())
@@ -577,4 +706,142 @@ pub fn parse_ssh_credentials(credentials: &str) -> Result<(String, u16, String)>
     };
 
     Ok((host, 22, user))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::CliError;
+    use crate::ssh::SshClient;
+    use basilica_common::ssh::SshConnectionDetails;
+    use std::ffi::OsStr;
+    use std::fs::File;
+    use std::path::Path;
+    use std::process::Stdio;
+    use std::time::Duration;
+    use tokio::process::Command as TokioCommand;
+
+    fn connection_details(private_key_path: std::path::PathBuf) -> SshConnectionDetails {
+        SshConnectionDetails {
+            host: "example.test".to_string(),
+            username: "testuser".to_string(),
+            port: 2222,
+            private_key_path,
+            timeout: Duration::from_secs(7),
+        }
+    }
+
+    fn command_args(command: &TokioCommand) -> Vec<String> {
+        command
+            .as_std()
+            .get_args()
+            .map(OsStr::to_string_lossy)
+            .map(|argument| argument.into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn scp_commands_preserve_options_and_operand_order() {
+        let details = connection_details("/tmp/test-key".into());
+        let upload = SshClient::scp_upload_command(
+            &details,
+            Path::new("-local file"),
+            "/remote/upload",
+            Path::new("fake-scp"),
+        )
+        .unwrap();
+        let download = SshClient::scp_download_command(
+            &details,
+            "/remote/download",
+            Path::new("local file"),
+            Path::new("fake-scp"),
+        )
+        .unwrap();
+
+        let base_args = vec![
+            "-i",
+            "/tmp/test-key",
+            "-P",
+            "2222",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
+            "-o",
+            "IdentitiesOnly=yes",
+            "-o",
+            "ConnectTimeout=7",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "--",
+        ];
+
+        assert_eq!(
+            command_args(&upload),
+            base_args
+                .iter()
+                .copied()
+                .chain(["-local file", "testuser@example.test:/remote/upload"])
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            command_args(&download),
+            base_args
+                .iter()
+                .copied()
+                .chain(["testuser@example.test:/remote/download", "local file"])
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scp_runner_passes_through_stdio_and_exit_status() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let stdin_path = temp_dir.path().join("stdin");
+        let stdout_path = temp_dir.path().join("stdout");
+        let stderr_path = temp_dir.path().join("stderr");
+        std::fs::write(&stdin_path, "input-bytes\n").unwrap();
+
+        let mut command = TokioCommand::new("sh");
+        command.arg("-c").arg(
+            "IFS= read -r input; printf 'stdout:%s' \"$input\"; printf 'stderr:%s' \"$input\" >&2; exit 7",
+        );
+
+        let error = SshClient::run_scp_with_stdio(
+            &mut command,
+            Stdio::from(File::open(&stdin_path).unwrap()),
+            Stdio::from(File::create(&stdout_path).unwrap()),
+            Stdio::from(File::create(&stderr_path).unwrap()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CliError::CommandExit {
+                code: 7,
+                message: None
+            }
+        ));
+        assert_eq!(std::fs::read(&stdout_path).unwrap(), b"stdout:input-bytes");
+        assert_eq!(std::fs::read(&stderr_path).unwrap(), b"stderr:input-bytes");
+    }
+
+    #[test]
+    fn scp_command_rejects_empty_remote_identity() {
+        let mut details = connection_details("/tmp/test-key".into());
+        details.host.clear();
+
+        assert!(SshClient::scp_command(&details, Path::new("scp")).is_err());
+
+        details.host = "example.test".to_string();
+        details.username.clear();
+        assert!(SshClient::scp_command(&details, Path::new("scp")).is_err());
+    }
 }

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -36,8 +36,17 @@ pub enum SshProbeStatus {
 }
 
 impl SshClient {
-    /// Create new SSH client
-    pub fn new(config: &SshConfig, execution_timeout: Option<Duration>) -> Result<Self> {
+    /// Create a new SSH client without an execution timeout.
+    pub fn new(config: &SshConfig) -> Result<Self> {
+        Self::build(config, None)
+    }
+
+    /// Create a new SSH client with an execution timeout.
+    pub fn with_execution_timeout(config: &SshConfig, execution_timeout: Duration) -> Result<Self> {
+        Self::build(config, Some(execution_timeout))
+    }
+
+    fn build(config: &SshConfig, execution_timeout: Option<Duration>) -> Result<Self> {
         // Create SSH connection config using configured timeout
         let connection_timeout = if config.connection_timeout > 0 {
             Duration::from_secs(config.connection_timeout)

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -98,14 +98,7 @@ impl SshClient {
     ) -> Result<SshCommandStatus> {
         let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
-        debug!(
-            "Executing command via SSH: ssh -i {} -p {} {}@{} '{}'",
-            details.private_key_path.display(),
-            details.port,
-            details.username,
-            details.host,
-            command
-        );
+        debug!("Executing command via SSH");
 
         self.client
             .execute_command_passthrough(&details, command)

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -560,6 +560,7 @@ impl SshClient {
             .stdin(stdin)
             .stdout(stdout)
             .stderr(stderr)
+            .kill_on_drop(true)
             .status()
             .await
             .map_err(|error| {

--- a/crates/basilica-cli/src/ssh/mod.rs
+++ b/crates/basilica-cli/src/ssh/mod.rs
@@ -9,7 +9,7 @@ pub use key_matcher::{
 use crate::config::SshConfig;
 use crate::error::{CliError, Result};
 use basilica_common::ssh::{
-    SshConnectionConfig, SshConnectionDetails, SshConnectionManager, SshFileTransferManager,
+    SshCommandStatus, SshConnectionConfig, SshConnectionDetails, SshFileTransferManager,
     StandardSshClient,
 };
 use basilica_sdk::types::{RentalStatusResponse, SshAccess};
@@ -37,7 +37,7 @@ pub enum SshProbeStatus {
 
 impl SshClient {
     /// Create new SSH client
-    pub fn new(config: &SshConfig) -> Result<Self> {
+    pub fn new(config: &SshConfig, execution_timeout: Option<Duration>) -> Result<Self> {
         // Create SSH connection config using configured timeout
         let connection_timeout = if config.connection_timeout > 0 {
             Duration::from_secs(config.connection_timeout)
@@ -47,7 +47,7 @@ impl SshClient {
 
         let ssh_config = SshConnectionConfig {
             connection_timeout,
-            execution_timeout: Duration::from_secs(3600),
+            execution_timeout,
             retry_attempts: 3,
             max_transfer_size: 1000 * 1024 * 1024, // 1000MB
             cleanup_remote_files: false,
@@ -95,7 +95,7 @@ impl SshClient {
         ssh_access: &SshAccess,
         command: &str,
         private_key_path: std::path::PathBuf,
-    ) -> Result<()> {
+    ) -> Result<SshCommandStatus> {
         let details = self.ssh_access_to_connection_details(ssh_access, private_key_path)?;
 
         debug!(
@@ -107,18 +107,10 @@ impl SshClient {
             command
         );
 
-        let output = self
-            .client
-            .execute_command(&details, command, true)
+        self.client
+            .execute_command_passthrough(&details, command)
             .await
-            .map_err(|e| {
-                eyre!(e)
-                    .suggestion("Check if the rental is still active and SSH port is exposed")
-                    .note("Run 'basilica status <rental-id>' to check rental status")
-            })?;
-
-        println!("{}", output);
-        Ok(())
+            .map_err(|e| eyre!(e).into())
     }
 
     /// Execute a command with rental status (for backward compatibility)

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -587,7 +587,7 @@ impl StandardSshClient {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        debug!("Spawning SSH streaming command: {:?}", cmd);
+        debug!("Spawning SSH streaming command");
 
         cmd.spawn()
             .map_err(|e| anyhow::anyhow!("Failed to spawn SSH streaming command: {}", e))
@@ -605,7 +605,7 @@ impl StandardSshClient {
         match timeout(execution_timeout, child.wait()).await {
             Ok(status) => Ok(SshCommandStatus::Exited(status?)),
             Err(_) => {
-                child.kill().await.map_err(|error| {
+                child.start_kill().map_err(|error| {
                     anyhow::anyhow!("Failed to kill timed-out subprocess: {}", error)
                 })?;
                 child.wait().await.map_err(|error| {
@@ -627,6 +627,7 @@ impl StandardSshClient {
         } else {
             command.stdout(Stdio::null()).stderr(Stdio::null());
         }
+        command.kill_on_drop(true);
 
         let mut child = command.spawn()?;
         let stdout_task = child.stdout.take().map(|mut stdout| {
@@ -713,8 +714,9 @@ impl StandardSshClient {
             .stdout(stdout)
             .stderr(stderr);
 
-        debug!("Executing SSH command with pass-through output: {:?}", cmd);
+        debug!("Executing SSH command with pass-through output");
 
+        cmd.kill_on_drop(true);
         let mut child = cmd
             .spawn()
             .map_err(|e| anyhow::anyhow!("Failed to spawn SSH command: {}", e))?;
@@ -745,7 +747,7 @@ impl StandardSshClient {
             cmd.stdout(Stdio::null()).stderr(Stdio::null());
         }
 
-        debug!("Executing SSH command: {:?}", cmd);
+        debug!("Executing SSH command");
 
         let output = self
             .execute_process(&mut cmd, capture_output)
@@ -1091,13 +1093,13 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn passthrough_uses_ssh_status_and_reaps_timed_out_fake_ssh() {
+    async fn passthrough_preserves_streams_status_timeout_and_cancellation() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp_dir = tempfile::tempdir().unwrap();
         let fake_ssh = temp_dir.path().join("fake-ssh");
         let private_key = temp_dir.path().join("key");
-        let pid_file = temp_dir.path().join("pid");
+        let cancellation_pid_file = temp_dir.path().join("cancel-pid");
         let stdout_file = temp_dir.path().join("stdout");
         let stderr_file = temp_dir.path().join("stderr");
         std::fs::write(
@@ -1107,7 +1109,8 @@ for last_arg do :; done
 case "$last_arg" in
   success) printf 'stdout-bytes'; printf 'stderr-bytes' >&2; exit 0 ;;
   exit-3) exit 3 ;;
-  timeout:*) printf '%s' "$$" > "${last_arg#timeout:}"; exec sleep 30 ;;
+  hang) exec sleep 30 ;;
+  cancel:*) printf '%s' "$$" > "${last_arg#cancel:}"; exec sleep 30 ;;
 esac
 exit 255
 "#,
@@ -1161,17 +1164,51 @@ exit 255
             ..SshConnectionConfig::default()
         });
         let timeout_status = timeout_client
-            .execute_command_passthrough_with_program(
-                &details,
-                &format!("timeout:{}", pid_file.display()),
-                &fake_ssh,
-            )
+            .execute_command_passthrough_with_program(&details, "hang", &fake_ssh)
             .await
             .unwrap();
-        let pid: i32 = std::fs::read_to_string(&pid_file).unwrap().parse().unwrap();
 
         assert!(matches!(timeout_status, SshCommandStatus::TimedOut));
-        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+
+        {
+            let cancellation_command = format!("cancel:{}", cancellation_pid_file.display());
+            let cancellation = client.execute_command_with_program_and_stdio(
+                &details,
+                &cancellation_command,
+                &fake_ssh,
+                Stdio::null(),
+                Stdio::null(),
+            );
+            tokio::pin!(cancellation);
+            let wait_until_started = async {
+                while !cancellation_pid_file.exists() {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            };
+
+            tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::select! {
+                    result = &mut cancellation => {
+                        panic!("fake SSH exited before cancellation: {result:?}")
+                    }
+                    () = wait_until_started => {}
+                }
+            })
+            .await
+            .unwrap();
+        }
+
+        let cancelled_pid: i32 = std::fs::read_to_string(&cancellation_pid_file)
+            .unwrap()
+            .parse()
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while unsafe { libc::kill(cancelled_pid, 0) } == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
     }
 
     #[test]

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -743,10 +743,6 @@ impl StandardSshClient {
         cmd.arg(format!("{}@{}", details.username, details.host))
             .arg(command);
 
-        if !capture_output {
-            cmd.stdout(Stdio::null()).stderr(Stdio::null());
-        }
-
         debug!("Executing SSH command");
 
         let output = self
@@ -902,7 +898,7 @@ impl SshFileTransferManager for StandardSshClient {
             details.username, details.host, remote_path
         ));
 
-        debug!("Executing SCP command: {:?}", cmd);
+        debug!("Executing SCP upload command");
 
         let output = self.execute_process(&mut cmd, true).await?;
 
@@ -955,7 +951,7 @@ impl SshFileTransferManager for StandardSshClient {
         ))
         .arg(local_path);
 
-        debug!("Executing SCP download command: {:?}", cmd);
+        debug!("Executing SCP download command");
 
         let output = self.execute_process(&mut cmd, true).await?;
 

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -6,8 +6,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
@@ -16,8 +18,8 @@ use tracing::{debug, info, warn};
 pub struct SshConnectionConfig {
     /// Connection timeout
     pub connection_timeout: Duration,
-    /// Command execution timeout
-    pub execution_timeout: Duration,
+    /// Optional command and file-transfer execution timeout
+    pub execution_timeout: Option<Duration>,
     /// Maximum file transfer size in bytes
     pub max_transfer_size: u64,
     /// Number of retry attempts
@@ -34,7 +36,7 @@ impl Default for SshConnectionConfig {
     fn default() -> Self {
         Self {
             connection_timeout: Duration::from_secs(30),
-            execution_timeout: Duration::from_secs(300),
+            execution_timeout: None,
             max_transfer_size: 100 * 1024 * 1024, // 100MB
             retry_attempts: 3,
             cleanup_remote_files: true,
@@ -42,6 +44,22 @@ impl Default for SshConnectionConfig {
             known_hosts_file: None,
         }
     }
+}
+
+/// Outcome of an SSH command whose output is passed through to the caller.
+#[derive(Debug)]
+pub enum SshCommandStatus {
+    /// The SSH subprocess exited normally with this status.
+    Exited(ExitStatus),
+    /// The configured execution timeout expired and the SSH subprocess was reaped.
+    TimedOut,
+}
+
+#[derive(Debug)]
+struct CapturedCommandOutput {
+    status: SshCommandStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
 }
 
 /// SSH connection details
@@ -158,6 +176,8 @@ impl StandardSshClient {
             "ConnectTimeout={}",
             self.config.connection_timeout.as_secs()
         ));
+        options.push("ServerAliveInterval=15".to_string());
+        options.push("ServerAliveCountMax=3".to_string());
         Ok(options)
     }
 
@@ -573,6 +593,134 @@ impl StandardSshClient {
             .map_err(|e| anyhow::anyhow!("Failed to spawn SSH streaming command: {}", e))
     }
 
+    async fn wait_for_child(&self, child: &mut Child) -> Result<SshCommandStatus> {
+        let Some(execution_timeout) = self.config.execution_timeout else {
+            return child
+                .wait()
+                .await
+                .map(SshCommandStatus::Exited)
+                .map_err(Into::into);
+        };
+
+        match timeout(execution_timeout, child.wait()).await {
+            Ok(status) => Ok(SshCommandStatus::Exited(status?)),
+            Err(_) => {
+                child.kill().await.map_err(|error| {
+                    anyhow::anyhow!("Failed to kill timed-out subprocess: {}", error)
+                })?;
+                child.wait().await.map_err(|error| {
+                    anyhow::anyhow!("Failed to reap timed-out subprocess: {}", error)
+                })?;
+                Ok(SshCommandStatus::TimedOut)
+            }
+        }
+    }
+
+    async fn execute_process(
+        &self,
+        command: &mut Command,
+        capture_output: bool,
+    ) -> Result<CapturedCommandOutput> {
+        command.stdin(Stdio::null());
+        if capture_output {
+            command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        } else {
+            command.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+
+        let mut child = command.spawn()?;
+        let stdout_task = child.stdout.take().map(|mut stdout| {
+            tokio::spawn(async move {
+                let mut output = Vec::new();
+                stdout.read_to_end(&mut output).await?;
+                Ok::<_, std::io::Error>(output)
+            })
+        });
+        let stderr_task = child.stderr.take().map(|mut stderr| {
+            tokio::spawn(async move {
+                let mut output = Vec::new();
+                stderr.read_to_end(&mut output).await?;
+                Ok::<_, std::io::Error>(output)
+            })
+        });
+
+        let status = self.wait_for_child(&mut child).await?;
+        let stdout = match stdout_task {
+            Some(task) => task.await??,
+            None => Vec::new(),
+        };
+        let stderr = match stderr_task {
+            Some(task) => task.await??,
+            None => Vec::new(),
+        };
+
+        Ok(CapturedCommandOutput {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+
+    /// Execute an SSH command with byte-for-byte stdout and stderr pass-through.
+    pub async fn execute_command_passthrough(
+        &self,
+        details: &SshConnectionDetails,
+        command: &str,
+    ) -> Result<SshCommandStatus> {
+        self.execute_command_passthrough_with_program(details, command, Path::new("ssh"))
+            .await
+    }
+
+    async fn execute_command_passthrough_with_program(
+        &self,
+        details: &SshConnectionDetails,
+        command: &str,
+        program: &Path,
+    ) -> Result<SshCommandStatus> {
+        self.execute_command_with_program_and_stdio(
+            details,
+            command,
+            program,
+            Stdio::inherit(),
+            Stdio::inherit(),
+        )
+        .await
+    }
+
+    async fn execute_command_with_program_and_stdio(
+        &self,
+        details: &SshConnectionDetails,
+        command: &str,
+        program: &Path,
+        stdout: Stdio,
+        stderr: Stdio,
+    ) -> Result<SshCommandStatus> {
+        self.validate_connection_details(details)?;
+
+        let mut cmd = Command::new(program);
+        cmd.arg("-i")
+            .arg(&details.private_key_path)
+            .arg("-p")
+            .arg(details.port.to_string());
+
+        for option in self.connection_options(true)? {
+            cmd.arg("-o").arg(option);
+        }
+
+        cmd.arg(format!("{}@{}", details.username, details.host))
+            .arg(command)
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr);
+
+        debug!("Executing SSH command with pass-through output: {:?}", cmd);
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Failed to spawn SSH command: {}", e))?;
+        self.wait_for_child(&mut child).await
+    }
+
     /// Internal SSH command execution
     async fn execute_ssh_command(
         &self,
@@ -599,18 +747,26 @@ impl StandardSshClient {
 
         debug!("Executing SSH command: {:?}", cmd);
 
-        let output = cmd
-            .output()
+        let output = self
+            .execute_process(&mut cmd, capture_output)
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to execute SSH command: {}", e))?;
 
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            debug!("Command executed successfully");
-            Ok(stdout)
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            debug!("SSH command failed: {}", stderr);
-            Err(anyhow::anyhow!("SSH command failed: {}", stderr))
+        match output.status {
+            SshCommandStatus::Exited(status) if status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                debug!("Command executed successfully");
+                Ok(stdout)
+            }
+            SshCommandStatus::Exited(_) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                debug!("SSH command failed: {}", stderr);
+                Err(anyhow::anyhow!("SSH command failed: {}", stderr))
+            }
+            SshCommandStatus::TimedOut => {
+                debug!("Command execution timed out");
+                Err(anyhow::anyhow!("Command execution timed out"))
+            }
         }
     }
 }
@@ -631,14 +787,11 @@ impl SshConnectionManager for StandardSshClient {
 
         self.validate_connection_details(details)?;
 
-        let result = timeout(
-            self.config.connection_timeout,
-            self.execute_ssh_command(details, "echo 'connection_test'", true),
-        )
-        .await;
-
-        match result {
-            Ok(Ok(output)) => {
+        match self
+            .execute_ssh_command(details, "echo 'connection_test'", true)
+            .await
+        {
+            Ok(output) => {
                 if output.trim() == "connection_test" {
                     info!("SSH connection test successful");
                     Ok(())
@@ -646,13 +799,9 @@ impl SshConnectionManager for StandardSshClient {
                     Err(anyhow::anyhow!("Unexpected response from connection test"))
                 }
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 debug!("SSH connection test failed: {}", e);
                 Err(e)
-            }
-            Err(_) => {
-                debug!("SSH connection test timed out");
-                Err(anyhow::anyhow!("Connection test timed out"))
             }
         }
     }
@@ -667,19 +816,8 @@ impl SshConnectionManager for StandardSshClient {
 
         self.validate_connection_details(details)?;
 
-        let result = timeout(
-            self.config.execution_timeout,
-            self.execute_ssh_command(details, command, capture_output),
-        )
-        .await;
-
-        match result {
-            Ok(result) => result,
-            Err(_) => {
-                debug!("Command execution timed out");
-                Err(anyhow::anyhow!("Command execution timed out"))
-            }
-        }
+        self.execute_ssh_command(details, command, capture_output)
+            .await
     }
 
     async fn execute_command_with_retry(
@@ -764,27 +902,19 @@ impl SshFileTransferManager for StandardSshClient {
 
         debug!("Executing SCP command: {:?}", cmd);
 
-        let result = timeout(self.config.execution_timeout, async {
-            let output = cmd.output()?;
-            if output.status.success() {
-                Ok(())
-            } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                Err(anyhow::anyhow!("SCP upload failed: {}", stderr))
-            }
-        })
-        .await;
+        let output = self.execute_process(&mut cmd, true).await?;
 
-        match result {
-            Ok(Ok(())) => {
+        match output.status {
+            SshCommandStatus::Exited(status) if status.success() => {
                 info!("File upload successful");
                 Ok(())
             }
-            Ok(Err(e)) => {
-                debug!("File upload failed: {}", e);
-                Err(e)
+            SshCommandStatus::Exited(_) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                debug!("File upload failed: {}", stderr);
+                Err(anyhow::anyhow!("SCP upload failed: {}", stderr))
             }
-            Err(_) => {
+            SshCommandStatus::TimedOut => {
                 debug!("File upload timed out");
                 Err(anyhow::anyhow!("File upload timed out"))
             }
@@ -825,27 +955,19 @@ impl SshFileTransferManager for StandardSshClient {
 
         debug!("Executing SCP download command: {:?}", cmd);
 
-        let result = timeout(self.config.execution_timeout, async {
-            let output = cmd.output()?;
-            if output.status.success() {
-                Ok(())
-            } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                Err(anyhow::anyhow!("SCP download failed: {}", stderr))
-            }
-        })
-        .await;
+        let output = self.execute_process(&mut cmd, true).await?;
 
-        match result {
-            Ok(Ok(())) => {
+        match output.status {
+            SshCommandStatus::Exited(status) if status.success() => {
                 info!("File download successful");
                 Ok(())
             }
-            Ok(Err(e)) => {
-                debug!("File download failed: {}", e);
-                Err(e)
+            SshCommandStatus::Exited(_) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                debug!("File download failed: {}", stderr);
+                Err(anyhow::anyhow!("SCP download failed: {}", stderr))
             }
-            Err(_) => {
+            SshCommandStatus::TimedOut => {
                 debug!("File download timed out");
                 Err(anyhow::anyhow!("File download timed out"))
             }
@@ -925,12 +1047,131 @@ mod tests {
     fn test_ssh_connection_config_default() {
         let config = SshConnectionConfig::default();
         assert_eq!(config.connection_timeout, Duration::from_secs(30));
-        assert_eq!(config.execution_timeout, Duration::from_secs(300));
+        assert_eq!(config.execution_timeout, None);
         assert_eq!(config.max_transfer_size, 100 * 1024 * 1024);
         assert_eq!(config.retry_attempts, 3);
         assert!(config.cleanup_remote_files);
         assert!(!config.strict_host_key_checking);
         assert!(config.known_hosts_file.is_none());
+    }
+
+    #[tokio::test]
+    async fn process_execution_captures_streams_and_nonzero_status() {
+        let client = StandardSshClient::new();
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("printf stdout-bytes; printf stderr-bytes >&2; exit 3");
+
+        let output = client.execute_process(&mut command, true).await.unwrap();
+
+        match output.status {
+            SshCommandStatus::Exited(status) => assert_eq!(status.code(), Some(3)),
+            SshCommandStatus::TimedOut => panic!("command unexpectedly timed out"),
+        }
+        assert_eq!(output.stdout, b"stdout-bytes");
+        assert_eq!(output.stderr, b"stderr-bytes");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn execution_timeout_kills_and_reaps_child() {
+        let client = StandardSshClient::with_config(SshConnectionConfig {
+            execution_timeout: Some(Duration::from_millis(50)),
+            ..SshConnectionConfig::default()
+        });
+        let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let status = client.wait_for_child(&mut child).await.unwrap();
+
+        assert!(matches!(status, SshCommandStatus::TimedOut));
+        assert_eq!(unsafe { libc::kill(pid as i32, 0) }, -1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn passthrough_uses_ssh_status_and_reaps_timed_out_fake_ssh() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fake_ssh = temp_dir.path().join("fake-ssh");
+        let private_key = temp_dir.path().join("key");
+        let pid_file = temp_dir.path().join("pid");
+        let stdout_file = temp_dir.path().join("stdout");
+        let stderr_file = temp_dir.path().join("stderr");
+        std::fs::write(
+            &fake_ssh,
+            r#"#!/bin/sh
+for last_arg do :; done
+case "$last_arg" in
+  success) printf 'stdout-bytes'; printf 'stderr-bytes' >&2; exit 0 ;;
+  exit-3) exit 3 ;;
+  timeout:*) printf '%s' "$$" > "${last_arg#timeout:}"; exec sleep 30 ;;
+esac
+exit 255
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(&private_key, "test-key").unwrap();
+        let details = SshConnectionDetails {
+            host: "example.test".to_string(),
+            username: "testuser".to_string(),
+            port: 22,
+            private_key_path: private_key,
+            timeout: Duration::from_secs(30),
+        };
+        let client = StandardSshClient::new();
+
+        let success = client
+            .execute_command_with_program_and_stdio(
+                &details,
+                "success",
+                &fake_ssh,
+                Stdio::from(std::fs::File::create(&stdout_file).unwrap()),
+                Stdio::from(std::fs::File::create(&stderr_file).unwrap()),
+            )
+            .await
+            .unwrap();
+        let failure = client
+            .execute_command_with_program_and_stdio(
+                &details,
+                "exit-3",
+                &fake_ssh,
+                Stdio::null(),
+                Stdio::null(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            success,
+            SshCommandStatus::Exited(status) if status.success()
+        ));
+        assert_eq!(std::fs::read(&stdout_file).unwrap(), b"stdout-bytes");
+        assert_eq!(std::fs::read(&stderr_file).unwrap(), b"stderr-bytes");
+        assert!(matches!(
+            failure,
+            SshCommandStatus::Exited(status) if status.code() == Some(3)
+        ));
+
+        let timeout_client = StandardSshClient::with_config(SshConnectionConfig {
+            execution_timeout: Some(Duration::from_millis(50)),
+            ..SshConnectionConfig::default()
+        });
+        let timeout_status = timeout_client
+            .execute_command_passthrough_with_program(
+                &details,
+                &format!("timeout:{}", pid_file.display()),
+                &fake_ssh,
+            )
+            .await
+            .unwrap();
+        let pid: i32 = std::fs::read_to_string(&pid_file).unwrap().parse().unwrap();
+
+        assert!(matches!(timeout_status, SshCommandStatus::TimedOut));
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
     }
 
     #[test]
@@ -948,6 +1189,8 @@ mod tests {
                 "IdentitiesOnly=yes".to_string(),
                 "BatchMode=yes".to_string(),
                 "ConnectTimeout=30".to_string(),
+                "ServerAliveInterval=15".to_string(),
+                "ServerAliveCountMax=3".to_string(),
             ]
         );
     }
@@ -971,6 +1214,8 @@ mod tests {
                 "LogLevel=ERROR".to_string(),
                 "IdentitiesOnly=yes".to_string(),
                 "ConnectTimeout=7".to_string(),
+                "ServerAliveInterval=15".to_string(),
+                "ServerAliveCountMax=3".to_string(),
             ]
         );
     }
@@ -995,6 +1240,8 @@ mod tests {
                 "LogLevel=ERROR".to_string(),
                 "IdentitiesOnly=yes".to_string(),
                 "ConnectTimeout=7".to_string(),
+                "ServerAliveInterval=15".to_string(),
+                "ServerAliveCountMax=3".to_string(),
             ]
         );
     }

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -589,6 +589,7 @@ impl StandardSshClient {
 
         debug!("Spawning SSH streaming command");
 
+        cmd.kill_on_drop(true);
         cmd.spawn()
             .map_err(|e| anyhow::anyhow!("Failed to spawn SSH streaming command: {}", e))
     }

--- a/crates/basilica-common/src/ssh/connection.rs
+++ b/crates/basilica-common/src/ssh/connection.rs
@@ -55,6 +55,24 @@ pub enum SshCommandStatus {
     TimedOut,
 }
 
+/// Validate a portable SSH account name before passing it to OpenSSH.
+pub fn validate_ssh_username(username: &str) -> Result<()> {
+    let mut characters = username.chars();
+    let Some(first) = characters.next() else {
+        return Err(anyhow::anyhow!("Username cannot be empty"));
+    };
+
+    if !(first.is_ascii_alphanumeric() || first == '_')
+        || !characters.all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+        })
+    {
+        return Err(anyhow::anyhow!("Username contains invalid characters"));
+    }
+
+    Ok(())
+}
+
 #[derive(Debug)]
 struct CapturedCommandOutput {
     status: SshCommandStatus,
@@ -194,16 +212,7 @@ impl StandardSshClient {
             return Err(anyhow::anyhow!("Host contains invalid characters"));
         }
 
-        if details.username.is_empty() {
-            return Err(anyhow::anyhow!("Username cannot be empty"));
-        }
-
-        if details
-            .username
-            .contains(&[';', '&', '|', '$', '`', '\n', '\r', '@'][..])
-        {
-            return Err(anyhow::anyhow!("Username contains invalid characters"));
-        }
+        validate_ssh_username(&details.username)?;
 
         if !details.private_key_path.exists() {
             return Err(anyhow::anyhow!(
@@ -1303,6 +1312,30 @@ exit 255
             .unwrap_err()
             .to_string()
             .contains("Username cannot be empty"));
+    }
+
+    #[test]
+    fn ssh_username_validation_accepts_portable_account_names() {
+        for username in ["root", "ubuntu22", "_service", "azure-user", "user.name"] {
+            validate_ssh_username(username).unwrap();
+        }
+    }
+
+    #[test]
+    fn ssh_username_validation_rejects_option_injection_and_invalid_names() {
+        for username in [
+            "-oProxyCommand=echo injected",
+            "user name",
+            "user@example.com",
+            "user/name",
+            "user\\name",
+            "usér",
+        ] {
+            assert!(
+                validate_ssh_username(username).is_err(),
+                "username should be rejected: {username}"
+            );
+        }
     }
 
     #[test]

--- a/crates/basilica-validator/src/rental/container_client.rs
+++ b/crates/basilica-validator/src/rental/container_client.rs
@@ -83,6 +83,7 @@ impl ContainerClient {
             strict_host_key_checking: false,
             known_hosts_file: None,
             connection_timeout: Duration::from_secs(10),
+            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 
@@ -120,6 +121,7 @@ impl ContainerClient {
             strict_host_key_checking,
             known_hosts_file: known_hosts_file.clone(),
             connection_timeout: Duration::from_secs(10),
+            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 
@@ -720,30 +722,6 @@ impl ContainerClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn container_clients_do_not_enforce_an_execution_timeout() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let key_path = temp_dir.path().join("test_key");
-        std::fs::write(&key_path, "dummy_key").unwrap();
-
-        let default_client =
-            ContainerClient::new("user@example.com".to_string(), Some(key_path.clone())).unwrap();
-        let configured_client = ContainerClient::with_ssh_config(
-            "user@example.com".to_string(),
-            Some(key_path),
-            true,
-            None,
-            Some("ERROR".to_string()),
-        )
-        .unwrap();
-
-        assert_eq!(default_client.ssh_client.config().execution_timeout, None);
-        assert_eq!(
-            configured_client.ssh_client.config().execution_timeout,
-            None
-        );
-    }
 
     #[test]
     fn test_parse_ssh_connection_ipv4_with_port() {

--- a/crates/basilica-validator/src/rental/container_client.rs
+++ b/crates/basilica-validator/src/rental/container_client.rs
@@ -83,7 +83,7 @@ impl ContainerClient {
             strict_host_key_checking: false,
             known_hosts_file: None,
             connection_timeout: Duration::from_secs(10),
-            execution_timeout: Duration::from_secs(300),
+            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 
@@ -121,7 +121,7 @@ impl ContainerClient {
             strict_host_key_checking,
             known_hosts_file: known_hosts_file.clone(),
             connection_timeout: Duration::from_secs(10),
-            execution_timeout: Duration::from_secs(300),
+            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 

--- a/crates/basilica-validator/src/rental/container_client.rs
+++ b/crates/basilica-validator/src/rental/container_client.rs
@@ -83,7 +83,6 @@ impl ContainerClient {
             strict_host_key_checking: false,
             known_hosts_file: None,
             connection_timeout: Duration::from_secs(10),
-            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 
@@ -121,7 +120,6 @@ impl ContainerClient {
             strict_host_key_checking,
             known_hosts_file: known_hosts_file.clone(),
             connection_timeout: Duration::from_secs(10),
-            execution_timeout: Some(Duration::from_secs(300)),
             ..Default::default()
         };
 
@@ -722,6 +720,30 @@ impl ContainerClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn container_clients_do_not_enforce_an_execution_timeout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let key_path = temp_dir.path().join("test_key");
+        std::fs::write(&key_path, "dummy_key").unwrap();
+
+        let default_client =
+            ContainerClient::new("user@example.com".to_string(), Some(key_path.clone())).unwrap();
+        let configured_client = ContainerClient::with_ssh_config(
+            "user@example.com".to_string(),
+            Some(key_path),
+            true,
+            None,
+            Some("ERROR".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(default_client.ssh_client.config().execution_timeout, None);
+        assert_eq!(
+            configured_client.ssh_client.config().execution_timeout,
+            None
+        );
+    }
 
     #[test]
     fn test_parse_ssh_connection_ipv4_with_port() {

--- a/crates/basilica-validator/src/ssh/tests.rs
+++ b/crates/basilica-validator/src/ssh/tests.rs
@@ -75,7 +75,7 @@ mod ssh_tests {
     fn test_validator_ssh_client_with_config() {
         let ssh_config = SshConnectionConfig {
             connection_timeout: Duration::from_secs(60),
-            execution_timeout: Duration::from_secs(300),
+            execution_timeout: Some(Duration::from_secs(300)),
             max_transfer_size: 50 * 1024 * 1024, // 50MB
             retry_attempts: 5,
             cleanup_remote_files: false,


### PR DESCRIPTION
## Summary

Make `basilica exec` a reliable, transparent remote-execution primitive.

The existing SSH path used blocking subprocess calls inside async timeout wrappers, which could pin a Tokio worker and prevent the timeout from firing. This replaces those calls with async subprocess handling and gives `exec` SSH-like stream and exit-status behavior.

## Changes Made

- Run SSH and SCP subprocesses asynchronously, with cleanup on timeout and future cancellation.
- Stream `basilica exec` stdout and stderr live and unchanged, while preserving the SSH exit status.
- Leave command duration unbounded by default and add the opt-in `--timeout <SECS>` flag.
- Return exit `124` for configured timeouts and reserve exit `255` guidance for SSH transport failures.
- Add SSH server-alive probes so unresponsive connections terminate instead of hanging indefinitely.
- Redact command, host, username, and key-path details from SSH debug logging.
- Add regression coverage for output preservation, exit codes, timeouts, child cleanup, and cancellation.

## Additional Context

This intentionally changes the `basilica exec` contract:

- Output is no longer buffered or followed by an added newline.
- The CLI now returns the SSH/remote exit code instead of collapsing every failure to exit `1`.
- Commands have no client-side duration limit unless `--timeout` is supplied.

Timeouts kill and reap the local SSH subprocess, but the client cannot prove whether the remote command has stopped. The timeout message preserves that ambiguity, and `exec` does not retry commands automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `--timeout <SECS>` to `basilica exec` (including connection setup).
  - Added `--output auto|compact|wide|json` to `ls`, `ps`, `tokens list`, `fund list`, `volumes list`, and `deploy ls` (`auto` adapts to interactive terminal width).

- **Bug Fixes**
  - `basilica exec` preserves streamed stdout/stderr and returns the underlying exit code.
  - Timeouts map to exit code **124**; unresponsive sessions are detected and timed-out runs are terminated and cleaned up.
  - Transport failures return exit code **255** with guidance; signal termination maps to the appropriate exit code.
  - The CLI process exit code now reflects the encountered error’s exit status.

- **Security**
  - Reduced debug log details to avoid exposing sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->