### PR TITLE
build(deps): bump bittensor-rs for metadata compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
 [[package]]
 name = "bittensor-rs"
 version = "0.1.1"
+source = "git+https://github.com/one-covenant/bittensor-rs?rev=0f27fd41f67b45bdd806f510dbf70c46dccd773f#0f27fd41f67b45bdd806f510dbf70c46dccd773f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,6 @@ dependencies = [
 [[package]]
 name = "bittensor-rs"
 version = "0.1.1"
-source = "git+https://github.com/one-covenant/bittensor-rs?rev=bd344ba62fbedc686e3814096bbf93cf9d34f7c9#bd344ba62fbedc686e3814096bbf93cf9d34f7c9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,9 @@ crabtensor = { git = "https://github.com/one-covenant/crabtensor", branch = "mai
 # Bittensor SDK
 bittensor = { git = "https://github.com/one-covenant/bittensor-rs", rev = "bd344ba62fbedc686e3814096bbf93cf9d34f7c9", package = "bittensor-rs" }
 
+[patch."https://github.com/one-covenant/bittensor-rs"]
+bittensor-rs = { path = "../bittensor-rs/bittensor-rs" }
+
 [workspace.metadata]
 # Workspace metadata for tooling
 rust-version = "1.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,10 +211,7 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 crabtensor = { git = "https://github.com/one-covenant/crabtensor", branch = "main" }
 
 # Bittensor SDK
-bittensor = { git = "https://github.com/one-covenant/bittensor-rs", rev = "bd344ba62fbedc686e3814096bbf93cf9d34f7c9", package = "bittensor-rs" }
-
-[patch."https://github.com/one-covenant/bittensor-rs"]
-bittensor-rs = { path = "../bittensor-rs/bittensor-rs" }
+bittensor = { git = "https://github.com/one-covenant/bittensor-rs", rev = "0f27fd41f67b45bdd806f510dbf70c46dccd773f", package = "bittensor-rs" }
 
 [workspace.metadata]
 # Workspace metadata for tooling


### PR DESCRIPTION
## Summary

- Pin `bittensor-rs` to merged compatibility fix `0f27fd4` from one-covenant/bittensor-rs#10.
- Refresh the lockfile to support current Bittensor runtime metadata.
- Preserve existing Basilica APIs and behavior.

## Testing

- `cargo tree -i bittensor-rs --workspace --locked --offline --depth 1`
- `just lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Bittensor integration to a newer revision, bringing in the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->