### PR TITLE
feat(sdk): add optional OpenAPI schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
+ "utoipa",
  "wiremock",
 ]
 
@@ -1602,6 +1603,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "url",
+ "utoipa",
  "uuid",
  "wiremock",
 ]
@@ -9861,6 +9863,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.4"
+utoipa = { version = "5.5", features = ["chrono"] }
 toml = "0.8"
 hex = "0.4"
 md5 = "0.7"

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -24,6 +24,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 
+# OpenAPI schema support (optional)
+utoipa = { workspace = true, optional = true }
 
 # Auth dependencies (moved from CLI)
 oauth2 = { workspace = true }
@@ -42,3 +44,4 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 [features]
 default = []
 client = []
+openapi = ["dep:utoipa", "basilica-validator/openapi"]

--- a/crates/basilica-sdk/src/types.rs
+++ b/crates/basilica-sdk/src/types.rs
@@ -39,22 +39,23 @@ pub struct RentalResponse {
     pub container_info: basilica_validator::rental::ContainerInfo,
 }
 
-/// Health check response
+// Health check response
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct HealthCheckResponse {
-    /// Service status
+    // Service status
     pub status: String,
 
-    /// Service version
+    // Service version
     pub version: String,
 
-    /// Timestamp
+    // Timestamp
     pub timestamp: chrono::DateTime<chrono::Utc>,
 
-    /// Healthy validators count
+    // Healthy validators count
     pub healthy_validators: usize,
 
-    /// Total validators count
+    // Total validators count
     pub total_validators: usize,
 }
 
@@ -171,49 +172,50 @@ pub struct LogStreamQuery {
     pub since_seconds: Option<u32>,
 }
 
-/// Start rental request with GPU-based node selection
+// Start rental request with GPU-based node selection
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct StartRentalApiRequest {
-    /// Optional user-facing rental name
+    /// Optional user-facing rental name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// GPU category: "H100", "A100", "B200", etc. (required)
+    /// GPU category, such as `H100`, `A100`, or `B200`.
     pub gpu_category: String,
 
-    /// Number of GPUs required (required)
+    /// Number of GPUs required.
     pub gpu_count: u32,
 
-    /// Minimum GPU memory in GB (e.g., 80 for 80GB)
+    /// Minimum GPU memory in GB.
     #[serde(default)]
     pub min_memory_gb: Option<u32>,
 
-    /// Maximum acceptable cents/GPU-hour
+    /// Maximum acceptable cents per GPU-hour.
     pub max_hourly_rate_cents: u32,
 
-    /// Container image to run
+    /// Container image to run.
     pub container_image: String,
 
-    /// SSH public key
+    /// SSH public key installed in the rental.
     pub ssh_public_key: String,
 
-    /// Environment variables
+    /// Environment variables supplied to the container.
     #[serde(default)]
     pub environment: std::collections::HashMap<String, String>,
 
-    /// Port mappings
+    /// Container-to-host port mappings.
     #[serde(default)]
     pub ports: Vec<PortMappingRequest>,
 
-    /// Resource requirements
+    /// Requested compute and storage resources.
     #[serde(default)]
     pub resources: ResourceRequirementsRequest,
 
-    /// Command to run
+    /// Command executed in the container.
     #[serde(default)]
     pub command: Vec<String>,
 
-    /// Volume mounts
+    /// Host paths mounted into the container.
     #[serde(default)]
     pub volumes: Vec<VolumeMountRequest>,
 }
@@ -356,16 +358,16 @@ pub struct SshKeyResponse {
 // ============================================================================
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct StartSecureCloudRentalRequest {
-    /// Optional user-facing rental name
+    /// Optional user-facing rental name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// Offering ID from list_gpu_prices endpoint
+    /// Offering ID returned by the GPU or CPU price endpoint.
     pub offering_id: String,
 
-    /// User's registered SSH key ID (NOT the public key string)
-    /// Must be a key owned by the authenticated user
+    /// ID of an SSH key registered by the authenticated user.
     pub ssh_public_key_id: String,
 }
 
@@ -1858,34 +1860,36 @@ pub struct ListVolumesResponse {
     pub total_count: u32,
 }
 
-/// Create volume request
+// Create volume request
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateVolumeRequest {
-    /// Volume name (unique per user, case-insensitive)
+    /// Volume name, unique per user and compared case-insensitively.
     pub name: String,
 
-    /// Optional description
+    /// Optional human-readable description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    /// Size in GB (1-10240)
+    /// Requested size in GB, from 1 through 10240.
     pub size_gb: u32,
 
-    /// Availability-zone root (e.g., "cyan")
+    /// Availability-zone root, such as `cyan`.
     pub provider: String,
 
-    /// Basilica region segment (e.g., "us-texas-1", "ca-quebec-1")
+    /// Basilica region segment, such as `us-texas-1`.
     pub region: String,
 }
 
-/// Attach volume request
+// Attach volume request
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AttachVolumeRequest {
-    /// Rental name to attach the volume to
+    /// User-facing rental name. Supply this or `rental_id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rental_name: Option<String>,
 
-    /// Rental ID to attach the volume to
+    /// Rental ID. Supply this or `rental_name`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rental_id: Option<String>,
 }

--- a/crates/basilica-validator/Cargo.toml
+++ b/crates/basilica-validator/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+utoipa = { workspace = true, optional = true }
 tracing = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
@@ -98,3 +99,5 @@ client = ["futures-util"]
 test-utils = []
 # Enable CLI support with clap derives
 cli = []
+# Enable OpenAPI schema generation support (requires Rust 1.75+)
+openapi = ["dep:utoipa"]

--- a/crates/basilica-validator/src/api/routes/rentals.rs
+++ b/crates/basilica-validator/src/api/routes/rentals.rs
@@ -79,12 +79,15 @@ impl Default for StartRentalRequest {
     }
 }
 
-/// Port mapping request
+// Port mapping request
 #[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct PortMappingRequest {
     pub container_port: u32,
     pub host_port: u32,
+    /// Transport protocol. Defaults to `tcp` when omitted.
     #[serde(default = "default_protocol")]
+    #[cfg_attr(feature = "openapi", schema(default = default_protocol))]
     pub protocol: String,
 }
 
@@ -122,8 +125,9 @@ impl From<PortMappingRequest> for crate::rental::PortMapping {
     }
 }
 
-/// Resource requirements request
+// Resource requirements request
 #[derive(Debug, Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ResourceRequirementsRequest {
     pub cpu_cores: f64,
     pub memory_mb: i64,
@@ -157,8 +161,9 @@ impl From<ResourceRequirementsRequest> for crate::rental::ResourceRequirements {
     }
 }
 
-/// Volume mount request
+// Volume mount request
 #[derive(Debug, Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct VolumeMountRequest {
     pub host_path: String,
     pub container_path: String,


### PR DESCRIPTION
## Summary

Adds non-default `openapi` features to `basilica-sdk` and `basilica-validator`, allowing consumers to generate OpenAPI schemas directly from canonical request types instead of maintaining duplicate schema types.

The SDK feature forwards schema support for validator-owned nested request types. Normal SDK, validator, CLI, and Python SDK builds remain Utoipa-free.

Enabling the feature requires Rust 1.75 or newer through Utoipa 5.5. Existing default builds retain their current dependency and compiler requirements.

## Validation

- `cargo fmt --all -- --check`
- Default SDK and validator checks
- Feature-enabled SDK and validator checks
- Strict all-target/all-feature Clippy
- Verified Utoipa remains absent from default SDK, validator, CLI, and Python dependency graphs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OpenAPI schema generation for SDK and validator API request and response types.
  * Added an `openapi` feature to enable schema support when needed.

* **Documentation**
  * Clarified documentation for rental and volume-related request fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->