### PR TITLE
Add Talos automatic PR review

### DIFF
--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -1,22 +1,26 @@
-# Posts this PR's signed event to Talos, which reviews and comments.
+# Posts this repo's signed PR events and @talos commands to Talos.
 name: Talos review
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 
 jobs:
   review:
     name: Request Talos review
+    if: github.event_name != 'issue_comment' || contains(github.event.comment.body, '@talos')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Post signed pull_request event to Talos
+      - name: Post signed event to Talos
         env:
           TALOS_URL: ${{ vars.TALOS_URL || 'https://95.133.252.205.sslip.io' }}
           TALOS_WEBHOOK_SECRET: ${{ secrets.TALOS_WEBHOOK_SECRET }}
+          GH_EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if [ -z "${TALOS_WEBHOOK_SECRET}" ]; then
@@ -27,7 +31,7 @@ jobs:
           if ! response="$(curl -sS --fail-with-body --max-time 60 \
             --retry 2 --retry-all-errors --retry-delay 5 -X POST \
             -H 'Content-Type: application/json' \
-            -H 'X-GitHub-Event: pull_request' \
+            -H "X-GitHub-Event: ${GH_EVENT}" \
             -H "X-Hub-Signature-256: ${signature}" \
             --data-binary "@${GITHUB_EVENT_PATH}" \
             "${TALOS_URL%/}/webhooks/github")"; then

--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -24,11 +24,14 @@ jobs:
             exit 0
           fi
           signature="sha256=$(python3 -c 'import hashlib, hmac, os; print(hmac.new(os.environ["TALOS_WEBHOOK_SECRET"].encode(), open(os.environ["GITHUB_EVENT_PATH"], "rb").read(), hashlib.sha256).hexdigest())')"
-          response="$(curl -sS --fail-with-body --max-time 60 \
+          if ! response="$(curl -sS --fail-with-body --max-time 60 \
             --retry 2 --retry-all-errors --retry-delay 5 -X POST \
             -H 'Content-Type: application/json' \
             -H 'X-GitHub-Event: pull_request' \
             -H "X-Hub-Signature-256: ${signature}" \
             --data-binary "@${GITHUB_EVENT_PATH}" \
-            "${TALOS_URL%/}/webhooks/github")"
+            "${TALOS_URL%/}/webhooks/github")"; then
+            echo "Talos request failed: ${response}" >&2
+            exit 1
+          fi
           echo "Talos response: ${response}"

--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -1,0 +1,33 @@
+name: Talos review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  review:
+    name: Request Talos review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post signed pull_request event to Talos
+        env:
+          TALOS_URL: ${{ vars.TALOS_URL || 'https://95.133.252.205.sslip.io' }}
+          TALOS_WEBHOOK_SECRET: ${{ secrets.TALOS_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TALOS_WEBHOOK_SECRET}" ]; then
+            echo "TALOS_WEBHOOK_SECRET unavailable (fork PR?), skipping"
+            exit 0
+          fi
+          signature="sha256=$(python3 -c 'import hashlib, hmac, os; print(hmac.new(os.environ["TALOS_WEBHOOK_SECRET"].encode(), open(os.environ["GITHUB_EVENT_PATH"], "rb").read(), hashlib.sha256).hexdigest())')"
+          response="$(curl -sS --fail-with-body --max-time 60 \
+            --retry 2 --retry-all-errors --retry-delay 5 -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'X-GitHub-Event: pull_request' \
+            -H "X-Hub-Signature-256: ${signature}" \
+            --data-binary "@${GITHUB_EVENT_PATH}" \
+            "${TALOS_URL%/}/webhooks/github")"
+          echo "Talos response: ${response}"

--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -1,4 +1,3 @@
-# Posts this PR's signed event to Talos, which reviews and comments.
 name: Talos review
 
 on:

--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -1,3 +1,4 @@
+# Posts this PR's signed event to Talos, which reviews and comments.
 name: Talos review
 
 on:


### PR DESCRIPTION
Adds the Talos review workflow: on every pull request (opened, reopened, synchronize, ready_for_review) it posts the signed event to the Talos deployment, which reviews the diff and comments on the PR. The stub is self-contained, skips cleanly when the secret is unavailable (fork/Dependabot PRs), retries transient failures, and reads the endpoint from the repo variable TALOS_URL when set. Draft-skipping and head-SHA deduplication happen server-side in Talos.

The repository secret TALOS_WEBHOOK_SECRET has already been set. A review posted below by Talos on this PR is the end-to-end check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated security review workflow that sends signed pull request and comment events to the Talos webhook.
  * Reviews are triggered on key pull request activity (open, reopen, update, ready) and when a qualifying comment is created.
  * Uses HMAC-SHA256 signatures, includes GitHub event metadata, retries on transient failures, and safely skips webhook delivery when configuration is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->