### PR TITLE
Talos: review only on PR open, not every commit

### DIFF
--- a/.github/workflows/talos-review.yml
+++ b/.github/workflows/talos-review.yml
@@ -3,7 +3,7 @@ name: Talos review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Drops the synchronize trigger from the Talos review workflow so Talos reviews once when a PR opens (opened/reopened/ready_for_review) instead of on every pushed commit. Re-review on demand with an @talos review comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Talos review automation to run when pull requests are opened, reopened, or marked ready for review.
  * Prevented the review workflow from running automatically on every subsequent pull request update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->