### PR TITLE
fix(sdk): scale the token refresh lead to the token lifetime

### DIFF
--- a/crates/basilica-sdk/src/auth/simple_manager.rs
+++ b/crates/basilica-sdk/src/auth/simple_manager.rs
@@ -7,7 +7,6 @@ use super::refresh::refresh_access_token;
 use super::token_store::TokenStore;
 use super::types::{get_sdk_data_dir, AuthError, AuthMethod, AuthResult, TokenSet};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, info};
 
@@ -19,9 +18,6 @@ pub struct TokenManager {
 }
 
 impl TokenManager {
-    /// Pre-emptive refresh threshold (60 minutes before expiry)
-    const REFRESH_THRESHOLD: Duration = Duration::from_secs(3600);
-
     /// Create a new token manager with direct tokens
     pub fn new_direct(access_token: String, refresh_token: String) -> Self {
         let tokens = TokenSet::new(access_token, refresh_token);
@@ -108,12 +104,10 @@ impl TokenManager {
     }
 
     /// Check if token should be refreshed
+    ///
+    /// Defers to `TokenSet`, so this manager and the CLI renew on the same
+    /// schedule instead of each carrying its own threshold.
     fn should_refresh(&self, token_set: &TokenSet) -> bool {
-        if token_set.is_expired() {
-            return true;
-        }
-
-        // Pre-emptive refresh if expiring within threshold
-        token_set.expires_within(Self::REFRESH_THRESHOLD)
+        token_set.is_expired() || token_set.needs_refresh()
     }
 }

--- a/crates/basilica-sdk/src/auth/types.rs
+++ b/crates/basilica-sdk/src/auth/types.rs
@@ -7,7 +7,13 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use etcetera::{choose_base_strategy, BaseStrategy};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Ceiling on how early a token is renewed, however long its lifetime.
+const MAX_REFRESH_LEAD: Duration = Duration::from_secs(60 * 60);
+
+/// Lead used when the token carries no `iat`, so its lifetime is unknown.
+const FALLBACK_REFRESH_LEAD: Duration = Duration::from_secs(5 * 60);
 
 /// Result type for authentication operations
 pub type AuthResult<T> = Result<T, AuthError>;
@@ -51,9 +57,8 @@ impl TokenSet {
         }
     }
 
-    /// Extract expiration from JWT token
-    /// Returns the exp claim from the JWT if it can be decoded
-    fn decode_jwt_exp(token: &str) -> Option<u64> {
+    /// Read a numeric claim from the access token's payload.
+    fn decode_jwt_claim(token: &str, claim: &str) -> Option<u64> {
         // JWT has three parts: header.payload.signature
         let parts: Vec<&str> = token.split('.').collect();
         if parts.len() != 3 {
@@ -66,15 +71,41 @@ impl TokenSet {
         // Decode base64url without padding (JWT uses base64url encoding)
         let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
 
-        // Parse JSON and extract exp claim
+        // Parse JSON and extract the requested claim
         let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-        json.get("exp")?.as_u64()
+        json.get(claim)?.as_u64()
     }
 
     /// Get the expiration time by decoding JWT
     fn get_expiration(&self) -> Option<u64> {
         // Always decode from JWT token
-        Self::decode_jwt_exp(&self.access_token)
+        Self::decode_jwt_claim(&self.access_token, "exp")
+    }
+
+    /// Total lifetime the issuer gave this token, from its own claims.
+    fn lifetime(&self) -> Option<Duration> {
+        let exp = Self::decode_jwt_claim(&self.access_token, "exp")?;
+        let iat = Self::decode_jwt_claim(&self.access_token, "iat")?;
+        exp.checked_sub(iat).map(Duration::from_secs)
+    }
+
+    /// How long before expiry a refresh should happen.
+    ///
+    /// Half the token's own lifetime, capped at an hour. A fixed lead is wrong
+    /// for short-lived tokens: with a one-hour token, a fixed one-hour lead is
+    /// satisfied the instant the token is minted, so every single call would
+    /// refresh. Scaling with the lifetime keeps roughly half the token usable
+    /// before the first renewal, whatever the issuer configures.
+    ///
+    /// A 24-hour token still gets the one-hour lead it had before this was
+    /// derived, so long-lived tokens behave exactly as they always did.
+    fn refresh_lead(&self) -> Duration {
+        match self.lifetime() {
+            Some(lifetime) => MAX_REFRESH_LEAD.min(lifetime / 2),
+            // No `iat` to measure against; fall back to the same small buffer
+            // the token stores use rather than assuming a long lifetime.
+            None => FALLBACK_REFRESH_LEAD,
+        }
     }
 
     /// Check if the access token is expired
@@ -91,13 +122,15 @@ impl TokenSet {
         }
     }
 
-    /// Check if the token needs refresh (expires within 60 minutes)
+    /// Check whether the token is close enough to expiry to renew.
+    ///
+    /// The window scales with the token's own lifetime; see [`Self::refresh_lead`].
     pub fn needs_refresh(&self) -> bool {
-        self.expires_within(std::time::Duration::from_secs(60 * 60))
+        self.expires_within(self.refresh_lead())
     }
 
     /// Check if the token expires within the specified duration
-    pub fn expires_within(&self, duration: std::time::Duration) -> bool {
+    pub fn expires_within(&self, duration: Duration) -> bool {
         match self.get_expiration() {
             Some(expires_at) => {
                 let now = SystemTime::now()
@@ -112,7 +145,7 @@ impl TokenSet {
     }
 
     /// Get time until token expiration
-    pub fn time_until_expiry(&self) -> Option<std::time::Duration> {
+    pub fn time_until_expiry(&self) -> Option<Duration> {
         match self.get_expiration() {
             Some(expires_at) => {
                 let now = SystemTime::now()
@@ -120,9 +153,9 @@ impl TokenSet {
                     .unwrap()
                     .as_secs();
                 if expires_at > now {
-                    Some(std::time::Duration::from_secs(expires_at - now))
+                    Some(Duration::from_secs(expires_at - now))
                 } else {
-                    Some(std::time::Duration::from_secs(0)) // Already expired
+                    Some(Duration::from_secs(0)) // Already expired
                 }
             }
             None => None, // No expiration time
@@ -218,4 +251,73 @@ pub fn get_sdk_data_dir() -> AuthResult<PathBuf> {
 
     // Use the same path as the CLI for consistency
     Ok(strategy.data_dir().join("basilica"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an access token whose payload carries the given claims. Only the
+    /// payload is read, so the header and signature can be anything.
+    fn token_with(iat: u64, exp: u64) -> TokenSet {
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"iat":{iat},"exp":{exp}}}"#));
+        TokenSet::new(format!("header.{payload}.signature"), "refresh".to_string())
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn lead_is_half_the_lifetime_for_a_short_token() {
+        // One-hour token: renew in the final half hour, not immediately.
+        let t = token_with(now(), now() + 3600);
+        assert_eq!(t.refresh_lead(), Duration::from_secs(1800));
+    }
+
+    #[test]
+    fn a_freshly_minted_short_token_does_not_need_refresh() {
+        // The bug this replaces: a fixed one-hour lead made every call to a
+        // one-hour token refresh, because it was always "expiring within" it.
+        let t = token_with(now(), now() + 3600);
+        assert!(!t.needs_refresh());
+    }
+
+    #[test]
+    fn a_short_token_past_halfway_needs_refresh() {
+        let t = token_with(now() - 1900, now() + 1700);
+        assert!(t.needs_refresh());
+    }
+
+    #[test]
+    fn long_lived_tokens_keep_the_one_hour_lead() {
+        // A 24-hour token behaves exactly as it did before the lead was derived.
+        let t = token_with(now(), now() + 86_400);
+        assert_eq!(t.refresh_lead(), Duration::from_secs(3600));
+        assert!(!t.needs_refresh());
+    }
+
+    #[test]
+    fn a_long_token_inside_the_last_hour_needs_refresh() {
+        let t = token_with(now() - 84_000, now() + 2_400);
+        assert!(t.needs_refresh());
+    }
+
+    #[test]
+    fn without_iat_the_lead_falls_back_to_the_small_buffer() {
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{}}}"#, now() + 3600));
+        let t = TokenSet::new(format!("header.{payload}.signature"), "refresh".to_string());
+        assert_eq!(t.refresh_lead(), FALLBACK_REFRESH_LEAD);
+        assert!(!t.needs_refresh());
+    }
+
+    #[test]
+    fn an_expired_token_needs_refresh() {
+        let t = token_with(now() - 7200, now() - 3600);
+        assert!(t.is_expired());
+        assert!(t.needs_refresh());
+    }
 }


### PR DESCRIPTION
## The problem

The pre-emptive refresh window was a fixed 60 minutes:

```rust
/// Check if the token needs refresh (expires within 60 minutes)
pub fn needs_refresh(&self) -> bool {
    self.expires_within(Duration::from_secs(60 * 60))
}
```

That works while access tokens live a lot longer than an hour. Staging's Auth0 API token lifetime has just moved from 86,400s to 3,600s, and at that point the rule degenerates: a token minted one second ago already "expires within 60 minutes", so `needs_refresh()` is true for a token's entire life.

`basilica-cli/src/client.rs` calls this on every command, so the CLI hits Auth0's token endpoint on **every single invocation** — `ps`, `ssh`, `exec`, all of them.

Observed on staging after the lifetime change: a token issued at 07:47:19 had already been silently replaced by 07:48:21, about a minute later, with no user action in between.

The same fixed hour appears a second time as `TokenManager::REFRESH_THRESHOLD` in `simple_manager.rs`, so the SDK and the CLI each carried their own copy of the value.

## The fix

Derive the window from the token instead of hardcoding it. The lifetime is available from the token's own claims (`exp - iat`):

```rust
fn refresh_lead(&self) -> Duration {
    match self.lifetime() {
        Some(lifetime) => MAX_REFRESH_LEAD.min(lifetime / 2),
        None => FALLBACK_REFRESH_LEAD,
    }
}
```

Half the lifetime, capped at the previous hour.

| Token lifetime | Lead | Effect |
|---|---|---|
| 1 hour (staging today) | 30 min | first half hour quiet, then renews |
| 24 hours (production today) | 60 min | **unchanged from before** |
| 15 min (if ever adopted) | 7.5 min | scales down correctly |
| no `iat` | 5 min | fallback |

The cap is what makes this safe to land: a 24-hour token still gets exactly the 60-minute lead it had before, so this is not a behaviour change for any lifetime currently in use in production. It only fixes the case the fixed value got wrong.

The fallback matters too. With no `iat` there is no lifetime to measure, and the tempting default is the old 3,600s — which would quietly reintroduce the bug for any short-lived token lacking the claim. Five minutes is the same buffer `token_store.rs` already uses, and it fails toward "refresh a bit late" rather than "refresh constantly".

`TokenManager::should_refresh` now defers to `TokenSet` and its duplicate constant is gone, so both paths renew on one schedule.

## Why this matters beyond the noise

It also unblocks tightening the lifetime further. A 900s access token is currently not viable: under the fixed hour it would refresh on every command forever. With the lead derived, 900s yields a 450s lead and behaves correctly. That decision is out of scope here, but this is the change that makes it possible.

## Tests

This module had **no tests at all**, so `is_expired`, `expires_within` and the JWT decoding were entirely unguarded. Seven added, in pairs — a refresh threshold has two failure directions, and pinning only one of them lets "never refresh" pass as a fix:

- `a_freshly_minted_short_token_does_not_need_refresh` — the actual bug; **fails against the previous code**
- `a_short_token_past_halfway_needs_refresh` — its counterweight, so the fix cannot be "never renew"
- `lead_is_half_the_lifetime_for_a_short_token` — pins the arithmetic directly
- `long_lived_tokens_keep_the_one_hour_lead` + `a_long_token_inside_the_last_hour_needs_refresh` — enforce the backward-compatibility claim above, which is otherwise just an assertion in a PR description
- `without_iat_the_lead_falls_back_to_the_small_buffer`
- `an_expired_token_needs_refresh` — boundary where unsigned arithmetic on a negative remaining time would go wrong

All green, plus the full suites: 212 SDK, 89 CLI. Clippy and fmt clean.

## Scope

Deliberately only the timing. Two related issues found in the same investigation are **not** addressed here:

- `simple_manager::get_access_token` propagates a failed refresh with `?` instead of falling back to the still-valid cached token, unlike `client.rs` which warns and continues.
- A revoked session surfaces as `Internal server error: Failed to get access token: Network error: Token refresh failed` — three inaccuracies in one line, and no hint to run `basilica login`.

Both are error-handling rather than timing, and the second is already improved by the `AuthenticationErrorKind` work in the all-sessions-logout PR.

## Merge order

This should go in before the all-sessions-logout PR. That branch also touches the SDK auth module, and landing the smaller, self-contained change first keeps the two diffs from tangling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token refresh timing based on each token’s actual lifetime.
  * Added safer handling for short-lived, long-lived, expired, and tokens missing issuance information.
  * Prevented unnecessary early refreshes while maintaining timely renewal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->