### PR TITLE
fix(deps): clear the security audit advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +374,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -401,6 +428,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,7 +469,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
@@ -448,6 +488,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +509,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -483,6 +547,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -856,7 +930,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "lru 0.16.3",
+ "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
  "sha2 0.10.9",
@@ -1059,7 +1133,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1576,7 +1650,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "libc",
- "lru 0.16.3",
+ "lru 0.18.2",
  "metrics",
  "metrics-exporter-prometheus",
  "num_cpus",
@@ -2795,6 +2869,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3678,6 +3762,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3899,7 +3994,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4339,7 +4434,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4347,10 +4442,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "jobserver"
@@ -4770,11 +4914,20 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4782,15 +4935,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "maplit"
@@ -5156,12 +5300,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "malloc_buf",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -6294,12 +6477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6513,7 +6690,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -6639,14 +6816,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -6821,7 +6999,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.36",
@@ -6842,7 +7020,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.36",
@@ -7732,6 +7910,16 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -9944,7 +10132,7 @@ dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "arrayref",
  "digest 0.10.7",
  "rand 0.8.6",
@@ -10148,17 +10336,16 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.15"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.9.4",
- "home",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
- "objc",
- "raw-window-handle",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "url",
  "web-sys",
 ]
@@ -10237,7 +10424,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ tonic-health = "0.10.2"
 governor = "0.6"
 jsonwebtoken = "9.2"
 async-stream = "0.3"
-lru = "0.16"
+lru = "0.18"
 eventsource-stream = "0.2"
 fastrand = "2.0"
 aws-config = { version = "1.0", features = ["behavior-version-latest"] }
@@ -162,7 +162,11 @@ shellexpand = "3.1"
 etcetera = "0.8"
 color-eyre = "0.6"
 oauth2 = "4.4"
-webbrowser = "0.8"
+# `hardened` rejects non-HTTP(S) URLs before they reach the OS handler. Both
+# call sites open an https URL (the Auth0 authorize page and the Stripe
+# checkout page), so the restriction costs nothing and closes the argument-
+# injection class described in GHSA-2ph8-5cr8-hr33.
+webbrowser = { version = "1.2", features = ["hardened"] }
 
 # Python bindings
 # abi3-py310 = stable ABI for Python 3.10+, works with 3.10, 3.11, 3.12, etc.

--- a/crates/basilica-sdk-python/uv.lock
+++ b/crates/basilica-sdk-python/uv.lock
@@ -648,11 +648,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,18 @@ ignore = [
     "RUSTSEC-2026-0099",  # wildcard-CN name constraints accepted
     "RUSTSEC-2026-0104",  # CRL parsing reachable panic; 0.101.x has no upstream patch (added 2026-04-23)
 
+    # h2 0.3.x reaches us only through hyper 0.14, which is pulled by the same
+    # axum 0.6 / tonic 0.10 / kube 0.88 / reqwest 0.11 stack as the entries
+    # above. The fix is >=0.4.16, a different major line, and 0.3 has had no
+    # backport since 0.3.27 (July 2025), so this cannot be resolved by a bump —
+    # it goes when that stack does, in the 0.27.0 subnet cleanup.
+    #
+    # The id form is the only one that applies to vulnerabilities; `crate = ...`
+    # covers yanked crates only. Masking by id is acceptable here because this
+    # advisory is defined as "fixed in >=0.4.16", so it can never match the
+    # 0.4.17 we pin in this same change — only the unfixable 0.3.x path.
+    "RUSTSEC-2026-0258",  # h2 unbounded empty DATA frames (0.3.x only)
+
     # Unmaintained transitives through the subnet stack. Treated as advisories
     # because cargo-deny surfaces them; functional risk is low.
     "RUSTSEC-2024-0436",  # paste unmaintained


### PR DESCRIPTION
`security-audit` and `test-python-sdk` are failing on every open PR, not just one — 519, 553 and 554 all show the same two red jobs on dependencies none of them touch. Four advisories, handled three ways.

## Bumped, with a fix at least 14 days old

| Crate | From → To | Age | Advisory |
|---|---|---|---|
| `webbrowser` | 0.8.15 → 1.2.4 | 19d | RUSTSEC-2026-0257 / GHSA-2ph8-5cr8-hr33 |
| `lru` | 0.16.3 → 0.18.2 | 20d | RUSTSEC-2026-0253 |
| `ruint` | 1.17.2 → 1.20.0 | 24d | RUSTSEC-2026-0220 |
| `pip` | 26.1.2 → 26.2.1 | 19d | PYSEC-2026-3721 |

`webbrowser` also gains the `hardened` feature, which the advisory recommends: it rejects non-HTTP(S) URLs before they reach the OS handler, closing the argument-injection class described there. Both call sites open an https URL — the Auth0 authorize page (`auth/oauth_flow.rs`) and the Stripe `checkout_url` (`handlers/fund/card.rs`). The second is the one that matters, since that URL arrives in an API response rather than being built locally.

The 14-day floor is a deliberate soak period: it avoids adopting a release fresh enough that a compromised or broken publish has not yet been noticed. Every transitive crate pulled in by these bumps was checked against it too — the oldest is `objc2-foundation` at 323 days, the youngest `simd_cesu8` at 41.

## The exception: `h2` at 4 days

`h2 0.4.13` → **`0.4.17`**, which is 4 days old and breaks the rule above.

No version satisfies both constraints. The fix landed in `0.4.16` seven days ago, and every release since is newer still. Waiting until 2026-08-31 would leave CI red for a week.

**`0.4.16` is also the wrong target even though it is the nominal fix.** From the changelog:

```
0.4.19 (Aug 24)  Improve default (auto) small DATA frame budget
0.4.18 (Aug 20)  Add data_frame_budget(n) to client and server builders
0.4.17 (Aug 19)  Fix limiting of excessive small DATA frames to ignore EOS frames
0.4.16 (Aug 17)  Fix limiting excessive amount of small DATA frames   <- the CVE fix
```

`0.4.17` is a fix to the fix: `0.4.16`'s new limiter counted end-of-stream frames it should not have, so it rejects legitimate traffic. Shipping `0.4.16` would trade a DoS vector for a correctness bug in our own HTTP/2 stack.

`0.4.18` and `0.4.19` are budget-heuristic refinements — a new tunable, then a retuned default — and still visibly settling, so `0.4.17` is the conservative pick: the oldest version that is both patched and correct.

Since the rule was bent, provenance was checked rather than assumed:

- repository is `hyperium/h2`, 764M downloads
- owners are Carl Lerche, Sean McArthur and Oliver Gould — no unexpected publishers
- the fix commit (`193833e8`, "limit excessive amount of small DATA frames") is seanmonstar's own, and he cut the release
- the large deletion count in the diff is a regenerated HPACK lookup table, from the 8-bit decoding optimisation in the same release

One thing to watch after this lands: the limiter caps *small DATA frames*, and validator telemetry streams over tonic. If a budget is ever too tight, long-lived streaming is where it would show.

## Ignored: `h2 0.3.27`

RUSTSEC-2026-0258 also matches `h2 0.3.27`, and **no bump can fix that one**. The advisory's fix is on the 0.4 line; 0.3 has had no release since 0.3.27 in July 2025.

It reaches us only through `hyper 0.14.32`, which is pulled by `axum 0.6`, `tonic 0.10`, `kube-client 0.88` and `reqwest 0.11` — the same stack the `rustls-webpki` entries directly above it in `deny.toml` are already ignored for, and scheduled for removal in the 0.27.0 subnet cleanup. Resolving it properly means a hyper 0.14 → 1.x migration across four frameworks.

The ignore is by advisory id because `crate = "..."` entries apply only to yanked crates, not vulnerabilities. That is safe here: the advisory is defined as fixed in `>=0.4.16`, so it can never mask the `0.4.17` pinned in this same change — only the unfixable 0.3.x path.

## One incidental fix

The `lru` bump quietly moved `aws-sdk-s3` from 1.120.0 down to **1.119.0**. That was caught and restored. Worth knowing `cargo update --precise` can shift unrelated crates.

## Verification

```
cargo deny check   advisories ok, bans ok, licenses ok, sources ok
pip-audit --local  No known vulnerabilities found
uv lock --locked   satisfied (exclude-newer-span untouched)
```

- `cargo check --workspace --all-targets` clean
- 670 tests pass — validator 212, cli 82, sdk 376
- `cargo fmt --all --check` clean
- `lru` 0.16 → 0.18 is a major bump and `webbrowser` 0.8 → 1.2 is too; both compile and test clean, and `webbrowser::open`'s signature is unchanged

Only four crates changed version in `Cargo.lock` — `h2`, `lru`, `ruint`, `webbrowser`. The rest of that diff is new transitive entries.

## Merge order

This touches `Cargo.lock` broadly, so it will conflict with anything else that moves the lock. Worth landing before 554 and 519.
