### PR TITLE
feat(sdk): delete_cluster / delete_job in client.rl (issue #558)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/rl.py
+++ b/crates/basilica-sdk-python/python/basilica/rl.py
@@ -110,6 +110,18 @@ class RlNamespace:
     def get_cluster(self, name: str) -> dict:
         return json.loads(self._core.rl_get_cluster(name))
 
+    def delete_cluster(self, name: str) -> dict:
+        """Delete a cluster. Refused (ValueError) while a job is active —
+        the error names the blocking job; delete the job first (that IS the
+        cancel path). Deleting the namespace's last cluster also tears down
+        its RL prerequisites server-side."""
+        return json.loads(self._core.rl_delete_cluster(name))
+
+    def delete_job(self, name: str) -> dict:
+        """Delete a job — valid in any phase. Deleting a running job IS the
+        cancel path (pods are torn down by the operator's stop ladder)."""
+        return json.loads(self._core.rl_delete_job(name))
+
     def wait_cluster(
         self, name: str, timeout_s: float = 1800.0, poll_s: float = 15.0
     ) -> dict:

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -124,6 +124,32 @@ impl BasilicaClient {
         serde_json::to_string(&response).map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    /// Delete an RL cluster (refused with an actionable error while a job
+    /// is active — delete the job first; that is the cancel path).
+    fn rl_delete_cluster(&self, py: Python, name: String) -> PyResult<String> {
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime
+                    .block_on(async move { client.delete_rl_cluster(&name).await })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
+        serde_json::to_string(&response).map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
+    /// Delete an RL job — valid in any phase; deleting a running job IS the
+    /// cancel path.
+    fn rl_delete_job(&self, py: Python, name: String) -> PyResult<String> {
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime
+                    .block_on(async move { client.delete_rl_job(&name).await })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
+        serde_json::to_string(&response).map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
     /// Get an RL cluster's status (phase, modelLoaded, activeJobName).
     fn rl_get_cluster(&self, py: Python, name: String) -> PyResult<String> {
         let client = Arc::clone(&self.inner);

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -44,7 +44,8 @@ use crate::{
     },
     rl::{
         CreateRlClusterRequest, CreateRlClusterResponse, CreateRlJobRequest, CreateRlJobResponse,
-        RlClusterStatusResponse, RlJobStatusResponse, RlManifestRequest, RlManifestResponse,
+        DeleteRlClusterResponse, DeleteRlJobResponse, RlClusterStatusResponse, RlJobStatusResponse,
+        RlManifestRequest, RlManifestResponse,
     },
     types::{
         ApiKeyInfo, ApiKeyResponse, ApiListRentalsResponse, BalanceResponse, CardPurchaseResponse,
@@ -381,6 +382,22 @@ impl BasilicaClient {
     pub async fn get_rl_job(&self, name: &str) -> Result<RlJobStatusResponse> {
         Self::validate_rl_name(name)?;
         self.get(&format!("/rl/jobs/{}", name)).await
+    }
+
+    /// Delete a cluster. Refused with an actionable 400 while a job is
+    /// active (the error names the blocking job) — delete the job first;
+    /// that IS the cancel path. Deleting the namespace's last cluster also
+    /// tears down its RL prerequisites server-side.
+    pub async fn delete_rl_cluster(&self, name: &str) -> Result<DeleteRlClusterResponse> {
+        Self::validate_rl_name(name)?;
+        self.delete(&format!("/rl/clusters/{}", name)).await
+    }
+
+    /// Delete a job — valid in any phase. Deleting a running job IS the
+    /// cancel path: the operator's stop ladder owns pod teardown.
+    pub async fn delete_rl_job(&self, name: &str) -> Result<DeleteRlJobResponse> {
+        Self::validate_rl_name(name)?;
+        self.delete(&format!("/rl/jobs/{}", name)).await
     }
 
     /// Submit a declarative manifest (renders a cluster and/or a job).

--- a/crates/basilica-sdk/src/rl.rs
+++ b/crates/basilica-sdk/src/rl.rs
@@ -248,6 +248,22 @@ pub struct RlManifestResponse {
     pub job: Option<CreateRlJobResponse>,
 }
 
+/// Response after deleting a cluster (`DELETE /rl/clusters/{name}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteRlClusterResponse {
+    /// The deleted cluster's name.
+    pub name: String,
+}
+
+/// Response after deleting a job (`DELETE /rl/jobs/{name}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteRlJobResponse {
+    /// The deleted job's name.
+    pub name: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,6 +310,17 @@ mod tests {
         // but a null in a non-Option server slot would 400)
         assert!(v.get("name").is_none());
         assert!(v.get("lr").is_none());
+    }
+
+    #[test]
+    fn delete_response_wire_shape() {
+        // The server serializes camelCase; both delete responses carry only
+        // `name`. Pin the deserialization so a server-side field rename is
+        // caught here, not by a user.
+        let c: DeleteRlClusterResponse = serde_json::from_str(r#"{"name":"my-pool"}"#).unwrap();
+        assert_eq!(c.name, "my-pool");
+        let j: DeleteRlJobResponse = serde_json::from_str(r#"{"name":"my-pool-job"}"#).unwrap();
+        assert_eq!(j.name, "my-pool-job");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `delete_cluster` / `delete_job` to the SDK's `client.rl` namespace, completing the RL surface for the 0.34.0 release. The merged namespace (#557) predates basilica-backend's DELETE routes (one-covenant/basilica-backend#1525 — reviewed as a pair with this PR): SDK users could create clusters and jobs but not remove them, falling back to kubectl for cleanup.

## Related Issues

Closes #558

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `basilica-sdk`: `DeleteRlClusterResponse` / `DeleteRlJobResponse` DTOs (camelCase wire shape pinned by a serde test) + `delete_rl_cluster` / `delete_rl_job` client methods (name-validated, typed DELETE) — mirroring the existing `get_rl_*` patterns exactly.
- `basilica-sdk-python`: `rl_delete_cluster` / `rl_delete_job` pymethods (JSON-over-the-boundary, same `runtime`/`py.detach` shape as the rest of the binding).
- python `client.rl`: `delete_cluster` / `delete_job` with the semantics documented in the docstrings — `delete_cluster` is refused with an actionable error while a job is active (the server names the blocking job; deleting the job IS the cancel path); `delete_job` is valid in any phase (deleting a running job IS cancel).
- The `.pyi` stub is `pyo3_stub_gen`-generated and picks the new methods up at build time; no hand edits.

## Testing

### How Has This Been Tested?

- [x] Unit tests pass (`cargo test`) — basilica-sdk 93 passed + 7 passed, including the new `delete_response_wire_shape` pin (deserializes the exact server DTO shapes from one-covenant/basilica-backend#1525).
- [ ] Integration tests pass — live verification against staging is queued behind one-covenant/basilica-backend#1525's merge + CD deploy; the first use will be SDK-driven cleanup of the leftover smoke-test clusters (the exact workflow this closes).
- [x] Manual testing completed — `cargo clippy` clean on both crates; python wrapper compiles.

### Test Configuration

- OS: macOS 15 (darwin arm64)
- Rust version: 1.97.1

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` to format my code
- [x] I have run `cargo clippy` and addressed all warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstrings; the CHANGELOG entry ships with the 0.34.0 bump PR)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published — depends on one-covenant/basilica-backend#1525 (the DELETE routes), green and awaiting review as this PR's pair

## Additional Context

Ships in 0.34.0 together with #557 so one release carries the complete beta `.rl` surface (create/get/wait/delete for clusters and jobs). Release plan per Evan's sign-off: version bump 0.33.0 → 0.34.0, CHANGELOG entry marking `client.rl` as beta (staging-only).