### PR TITLE
chore(release): bump basilica-sdk / basilica-sdk-python / basilica-cli to 0.34.0 (#1435)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basilica-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "assert_cmd",
  "axum 0.7.9",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "base64 0.21.7",
  "basilica-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-cli/CHANGELOG.md
+++ b/crates/basilica-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-27
+
+Version-lockstep release with basilica-sdk 0.34.0 (the RL training beta
+lives in the SDK only). No CLI-surface changes; RL commands are
+deliberately absent while the RL API is in staging beta.
+
 ## [0.33.0] - 2026-07-14
 
 ### Added

--- a/crates/basilica-cli/Cargo.toml
+++ b/crates/basilica-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-cli"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Unified CLI for Basilica GPU rental and network management"

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -600,7 +600,8 @@ ticket SDK-S1.
 - Inline API documentation
 - Example code for common workflows
 
-[Unreleased]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.33.0...HEAD
+[Unreleased]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.34.0...HEAD
+[0.34.0]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.33.0...basilica-sdk-python-v0.34.0
 [0.33.0]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.32.0...basilica-sdk-python-v0.33.0
 [0.32.0]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.31.2...basilica-sdk-python-v0.32.0
 [0.14.0]: https://github.com/one-covenant/basilica/compare/basilica-sdk-python-v0.13.0...basilica-sdk-python-v0.14.0

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-27
+
+### Added
+
+- **RL training namespace `client.rl` (beta, staging-only).** First release
+  carrying the managed GRPO training surface: `create_cluster`, `create_job`,
+  `get_cluster`, `get_job`, `wait_cluster`, `wait_job`, `submit_manifest`,
+  and the delete pair `delete_cluster` / `delete_job` (deleting a running
+  job IS the cancel path; deleting a cluster is refused while a job is
+  active, and the error names the blocking job).
+
+  The RL routes exist only on the staging API in this release. The client
+  defaults to production, so point it at staging explicitly:
+
+  ```python
+  from basilica import BasilicaClient
+  client = BasilicaClient(base_url="https://api-staging.basilica.ai",
+                          api_key="...")
+  ```
+
+  or set `BASILICA_API_URL=https://api-staging.basilica.ai`.
+
+  Minimum backend version: the staging deploy of 2026-08-27 (backend
+  #1525 + #1536). Against an older backend the delete methods return 404.
+
+  The CLI intentionally carries no RL commands in this release — the RL
+  surface is SDK-only while in beta.
+
 ## [0.33.0] - 2026-07-14
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.33.0"
+version = "0.34.0"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/uv.lock
+++ b/crates/basilica-sdk-python/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-27
+
+### Added
+
+- **RL training client surface (beta, staging-only):** typed DTOs and
+  methods for the managed GRPO training API — cluster/job create, status
+  reads, manifest submission, and `delete_rl_cluster` / `delete_rl_job`
+  (`DeleteRlClusterResponse` / `DeleteRlJobResponse`). Deleting a running
+  job is the cancel path; a cluster delete under an active job is refused
+  with the blocking job named. Routes exist on the staging API only in
+  this release; minimum backend: the 2026-08-27 staging deploy
+  (backend #1525 + #1536).
+
 ## [0.33.0] - 2026-07-14
 
 ### Added

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "SDK for interacting with the Basilica GPU rental network"


### PR DESCRIPTION
## Summary

Version bump 0.33.0 → 0.34.0 across `basilica-sdk`, `basilica-sdk-python`, and `basilica-cli` (lockstep), with CHANGELOG entries. This is the release PR for the RL training beta: 0.33.0 (2026-07-14) predates all RL work, so **0.34.0 is the first release carrying the entire `client.rl` namespace** — the create/get/wait/manifest surface (#557) plus the delete pair (#559).

## Related Issues

Closes #1435

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

(Version + changelog only — the feature code itself landed in #557/#559.)

## Changes Made

- `version = "0.34.0"` in `basilica-sdk`, `basilica-sdk-python` (Cargo.toml + pyproject.toml), and `basilica-cli` (lockstep), plus the synced `Cargo.lock`
- **Python SDK CHANGELOG**: `client.rl` (beta, **staging-only**) entry with the explicit staging pointer (`base_url="https://api-staging.basilica.ai"` or `BASILICA_API_URL` — the client default is prod, where RL routes don't exist) and the minimum-backend note (staging deploy carrying backend #1525 + #1536; older backends 404 on the delete routes)
- **Rust SDK CHANGELOG**: typed RL DTOs + methods entry, same beta caveats
- **CLI CHANGELOG**: lockstep note only — RL commands deliberately absent while the API is in beta (RL is SDK-only this release)

## Testing

### How Has This Been Tested?

- [x] Unit tests pass (`cargo test`) — 93 SDK + 7 python-binding tests green on the #559 branch; this PR changes versions/changelogs only
- [x] Integration tests pass — SDK delete-contract e2e **6/6 against the deployed staging backend** (the release-sequencing gate from the #559 Talos review); full verdict in the PR comment below
- [x] Manual testing completed — wheel built via maturin, installed in a fresh venv, `.rl` surface exercised live against staging

### Test Configuration

- OS: macOS (Darwin 25.5.0, arm64)
- Rust version: 1.97.1
- Bittensor version (if applicable): n/a

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` to format my code
- [x] I have run `cargo clippy` and addressed all warnings
- [x] I have added tests that prove my fix is effective or that my feature works (contract e2e; feature tests landed with #557/#559)
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (three CHANGELOGs)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (backend #1525 + #1536 merged AND deployed to staging — the hard precondition for tagging)

## Additional Context

Release sequencing after merge: tag `basilica-sdk-python-v0.34.0` → the `Release Python SDK` workflow publishes to PyPI via trusted publishing → post-publish verification re-runs the contract e2e with the wheel installed fresh **from PyPI**. Per the release plan, no ".rl release" labeling — this is a normal SDK release whose headline feature happens to be the RL beta.


https://claude.ai/code/session_01HaW5tNzXtLu3hQewMGKd1d