### PR TITLE
test(sdk-python): mock-server coverage for the RL delete error mapping + rl.py error-table docstring fix (#561)

### DIFF
--- a/crates/basilica-sdk-python/python/basilica/rl.py
+++ b/crates/basilica-sdk-python/python/basilica/rl.py
@@ -24,7 +24,7 @@ methods, which serde-validate against the core's typed DTOs
 and send through the core transport. That inherits the full auth chain
 (explicit key, BASILICA_API_TOKEN, and the CLI-login token fallback) and
 the core's error mapping: non-2xx surfaces as ValueError (bad request),
-PermissionError (authz), ConnectionError (transport), FileNotFoundError
+PermissionError (authz), ConnectionError (transport), KeyError
 (not found), or RuntimeError (server error), each carrying the server's
 message verbatim.
 

--- a/crates/basilica-sdk-python/tests/test_rl_client.py
+++ b/crates/basilica-sdk-python/tests/test_rl_client.py
@@ -43,7 +43,7 @@ class _Recorder(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
-    do_GET = do_POST = _handle
+    do_GET = do_POST = do_DELETE = _handle
 
     def log_message(self, *_):
         pass
@@ -270,3 +270,41 @@ def test_invalid_name_rejected_client_side(server):
     with pytest.raises(ValueError, match="DNS-1035"):
         rl(base).get_cluster("-leading-dash")
     assert rec.requests == []
+
+
+# ----- delete surface error mapping (#561, the Talos LOW from #559) --------
+
+
+def test_delete_cluster_refusal_maps_to_valueerror_naming_the_job(server):
+    """The active-job 400 refusal surfaces as ValueError carrying the
+    server's message verbatim — including the blocking job's name, which is
+    the part callers act on (delete that job first)."""
+    base, rec = server
+    rec.responses = [
+        (400, _api_error("cluster my-pool has an active job (my-job); delete the job first"))
+    ]
+    with pytest.raises(ValueError, match=r"my-job"):
+        rl(base).delete_cluster("my-pool")
+    (r,) = rec.requests
+    assert (r["method"], r["path"]) == ("DELETE", "/rl/clusters/my-pool")
+    assert r["auth"] == "Bearer test-key"
+
+
+def test_delete_job_wire_shape(server):
+    base, rec = server
+    rec.responses = [(200, {"name": "my-job"})]
+    assert rl(base).delete_job("my-job") == {"name": "my-job"}
+    (r,) = rec.requests
+    assert (r["method"], r["path"]) == ("DELETE", "/rl/jobs/my-job")
+    assert r["auth"] == "Bearer test-key"
+
+
+def test_delete_cluster_not_found_maps_per_the_error_table(server):
+    """404 maps to the not-found exception class (pinned to the observed
+    live behavior of the published wheel)."""
+    base, rec = server
+    rec.responses = [
+        (404, _api_error("rl cluster not found: absent", code="BASILICA_API_NOT_FOUND"))
+    ]
+    with pytest.raises(KeyError, match=r"not found"):
+        rl(base).delete_cluster("absent")


### PR DESCRIPTION
## Summary

The verification follow-up the #559 Talos review asked for (its one LOW): offline mock-server tests pinning the RL delete surface's error mapping, plus a one-line docstring truth-up the tests exposed. No production behavior changes.

## Related Issues

Closes #561

## Type of Change

- [x] Documentation update
- [x] Code refactoring

(Test-only + doc-only: three new tests and a docstring correction — zero behavior change.)

## Changes Made

- `tests/test_rl_client.py`: recorder harness gains `do_DELETE` (was GET/POST only)
- `test_delete_cluster_refusal_maps_to_valueerror_naming_the_job` — the 400 active-job refusal surfaces as `ValueError` carrying the server's message verbatim, asserted to include the blocking job's name (the part callers act on); wire shape + auth header asserted
- `test_delete_job_wire_shape` — success path, `DELETE /rl/jobs/{id}` + auth header
- `test_delete_cluster_not_found_maps_per_the_error_table` — 404 → `KeyError`, pinned to the binding's actual mapping (`map_error_to_python`: `ApiError::NotFound` → `PyKeyError`, `lib.rs:901`)
- `python/basilica/rl.py`: module-docstring error table corrected — it claimed `FileNotFoundError` for not-found, but the binding has mapped not-found → `KeyError` since before the RL surface existed. Doc-only; changing the *behavior* to match the old docstring would have been a breaking change for zero gain, so the docstring moves to match reality.

## Testing

### How Has This Been Tested?

- [x] Unit tests pass (`cargo test`) — untouched by this PR (Python-side only)
- [x] Integration tests pass — `pytest tests/test_rl_client.py`: **18 passed** (15 existing + 3 new), run against the **published PyPI `basilica-sdk==0.34.0` wheel**, so the pins are proven against exactly what users install
- [x] Manual testing completed — the live counterpart of these assertions is the staging delete-contract e2e (stable 6/6 × 3 consecutive rounds, 2026-08-27, after backend#1552)

### Test Configuration

- OS: macOS (Darwin 25.5.0, arm64)
- Rust version: 1.97.1 (not exercised — Python test + docstring only)
- Bittensor version (if applicable): n/a

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` to format my code (no Rust changes)
- [x] I have run `cargo clippy` and addressed all warnings (no Rust changes)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the rl.py error-table docstring)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (0.34.0 already on PyPI; this pins its behavior)

## Additional Context

Why the 404 test pins `KeyError` and the docstring moved rather than the code: the mapping predates the RL surface entirely (it is the core binding's error table), the published wheel and the live e2e agree on it, and "fixing" the code toward the old docstring claim would break anyone already catching `KeyError`. The test documents reality; the docstring now tells the truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaW5tNzXtLu3hQewMGKd1d