### PR TITLE
[Core] feat(sdk): 0.35.0 — BYO relay storage + credential rotation (#1578)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "base64 0.21.7",
  "basilica-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "basilica-sdk-python"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "basilica-sdk",
  "basilica-validator",

--- a/crates/basilica-sdk-python/CHANGELOG.md
+++ b/crates/basilica-sdk-python/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-31
+
+### Added
+
+- **Bring-your-own storage for RL clusters (beta, staging-only).**
+  `client.rl.create_cluster(relay={...})` points a cluster's weight-sync
+  relay at your own S3-compatible bucket (R2/S3; `mode: "byo"` with
+  endpoint/bucket/optional `basePrefix`, and either an inline key pair —
+  write-only, converted to a namespaced secret, never echoed — or a
+  `credentialsSecret` you manage). The create response gains
+  `effectivePrefix`, the uid-scoped key prefix all cluster data lands
+  under — scope your IAM grant to it. The same `relay` dict works inside
+  a manifest's `cluster` block. See `docs/BYO-RELAY-USER-GUIDE.md` in the
+  platform repo for endpoint requirements, the IAM template, and the
+  compatibility matrix.
+- **`client.rl.rotate_credentials(name, access_key_id=…,
+  secret_access_key=…)`** rotates a BYO cluster's credentials (inline-pair
+  clusters only). Create the new key first, rotate, then revoke the old
+  key after the returned `rotatedAt` — the relay daemon restarts onto the
+  new material within seconds.
+
 ## [0.34.0] - 2026-08-27
 
 ### Added

--- a/crates/basilica-sdk-python/Cargo.toml
+++ b/crates/basilica-sdk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk-python"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "Python bindings for the Basilica SDK"

--- a/crates/basilica-sdk-python/pyproject.toml
+++ b/crates/basilica-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "basilica-sdk"
-version = "0.34.0"
+version = "0.35.0"
 description = "Python SDK for deploying containerized applications on the Basilica GPU cloud"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/basilica-sdk-python/python/basilica/rl.py
+++ b/crates/basilica-sdk-python/python/basilica/rl.py
@@ -73,12 +73,30 @@ class RlNamespace:
         name: Optional[str] = None,
         min_memory_gb: Optional[int] = None,
         idle_ttl: Optional[str] = None,
+        relay: Optional[dict] = None,
         body: Optional[dict] = None,
     ) -> dict:
         """POST /rl/clusters — a warm trainer+rollout GPU pool.
 
         Certified shapes: 4+4 (H100 for <16B models, H200-class for >=16B —
         admission rejects bad pairings with an actionable message).
+
+        ``relay`` selects bring-your-own storage (wire-shaped dict; the same
+        dict works inside a manifest's ``cluster`` block)::
+
+            relay={
+                "mode": "byo",
+                "endpoint": "https://<acct>.r2.cloudflarestorage.com",
+                "bucket": "my-weights",
+                "basePrefix": "teams/rl/",          # optional
+                "accessKeyId": "...",               # write-only: becomes a
+                "secretAccessKey": "...",           #   secret, never echoed
+                # or instead of the pair: "credentialsSecret": "my-secret"
+            }
+
+        The response then carries ``effectivePrefix`` — the uid-scoped key
+        prefix all cluster data lands under; tighten your IAM grant to it.
+        Omit ``relay`` for platform-managed storage (today's behavior).
         ``body`` replaces the built request entirely (raw wire dict, escape
         hatch) — no other kwargs are consulted when it is given.
         """
@@ -103,9 +121,28 @@ class RlNamespace:
                     "trainer": fleet(trainer_gpus),
                     "rollout": fleet(rollout_gpus),
                     "idleTtl": idle_ttl,
+                    "relay": relay,
                 }
             )
         return json.loads(self._core.rl_create_cluster(json.dumps(body)))
+
+    def rotate_credentials(
+        self, name: str, *, access_key_id: str, secret_access_key: str
+    ) -> dict:
+        """POST /rl/clusters/{name}/credentials — rotate a BYO cluster's
+        storage credentials (only clusters created with the inline pair;
+        clusters using ``credentialsSecret`` update their own secret).
+
+        Sequencing: create the NEW key at your provider first (both keys
+        valid), call this, then revoke the OLD key after the returned
+        ``rotatedAt`` plus a few seconds — the relay daemon restarts onto
+        the new material in that window; in-flight transfers finish on the
+        old key. Revoking first fails the running job with
+        ``RelayAuthFailed`` (recoverable, but wastes the retry window)."""
+        req = {"accessKeyId": access_key_id, "secretAccessKey": secret_access_key}
+        return json.loads(
+            self._core.rl_rotate_cluster_credentials(name, json.dumps(req))
+        )
 
     def get_cluster(self, name: str) -> dict:
         return json.loads(self._core.rl_get_cluster(name))

--- a/crates/basilica-sdk-python/python/basilica/rl.py
+++ b/crates/basilica-sdk-python/python/basilica/rl.py
@@ -129,9 +129,11 @@ class RlNamespace:
     def rotate_credentials(
         self, name: str, *, access_key_id: str, secret_access_key: str
     ) -> dict:
-        """POST /rl/clusters/{name}/credentials — rotate a BYO cluster's
-        storage credentials (only clusters created with the inline pair;
-        clusters using ``credentialsSecret`` update their own secret).
+        """Rotate the storage credentials of a bring-your-own-storage cluster.
+
+        POST /rl/clusters/{name}/credentials. Applies only to clusters
+        created with the inline key pair (platform-managed secret);
+        clusters using ``credentialsSecret`` update their own secret.
 
         Sequencing: create the NEW key at your provider first (both keys
         valid), call this, then revoke the OLD key after the returned

--- a/crates/basilica-sdk-python/src/lib.rs
+++ b/crates/basilica-sdk-python/src/lib.rs
@@ -124,6 +124,28 @@ impl BasilicaClient {
         serde_json::to_string(&response).map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    /// Rotate a BYO cluster's relay storage credentials (#1577).
+    /// `request_json` must match basilica_sdk::rl::RotateRelayCredentialsRequest.
+    fn rl_rotate_cluster_credentials(
+        &self,
+        py: Python,
+        name: String,
+        request_json: String,
+    ) -> PyResult<String> {
+        let request: basilica_sdk::rl::RotateRelayCredentialsRequest =
+            serde_json::from_str(&request_json)
+                .map_err(|e| PyValueError::new_err(format!("invalid rotation request: {e}")))?;
+        let client = Arc::clone(&self.inner);
+        let response = py
+            .detach(|| {
+                self.runtime.block_on(async move {
+                    client.rotate_rl_cluster_credentials(&name, request).await
+                })
+            })
+            .map_err(|e| self.map_error_to_python(e))?;
+        serde_json::to_string(&response).map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+
     /// Delete an RL cluster (refused with an actionable error while a job
     /// is active — delete the job first; that is the cancel path).
     fn rl_delete_cluster(&self, py: Python, name: String) -> PyResult<String> {

--- a/crates/basilica-sdk-python/tests/test_rl_client.py
+++ b/crates/basilica-sdk-python/tests/test_rl_client.py
@@ -308,3 +308,69 @@ def test_delete_cluster_not_found_maps_per_the_error_table(server):
     ]
     with pytest.raises(KeyError, match=r"not found"):
         rl(base).delete_cluster("absent")
+
+
+def test_create_cluster_relay_wire_shape(server):
+    # #1578: the relay dict passes through verbatim (already wire-shaped),
+    # and the response's effectivePrefix reaches the caller.
+    base, rec = server
+    rec.responses = [(200, {
+        "name": "byo-pool", "uid": "u1", "phase": "Provisioning",
+        "effectivePrefix": "teams/rl/u1/",
+    })]
+    out = rl(base).create_cluster(
+        name="byo-pool",
+        base_model="Qwen/Qwen2.5-7B-Instruct",
+        gpu_model="H100",
+        relay={
+            "mode": "byo",
+            "endpoint": "https://acc.r2.cloudflarestorage.com",
+            "bucket": "my-weights",
+            "basePrefix": "teams/rl/",
+            "accessKeyId": "AK",
+            "secretAccessKey": "SK",
+        },
+    )
+    (r,) = rec.requests
+    assert r["body"]["relay"] == {
+        "mode": "byo",
+        "endpoint": "https://acc.r2.cloudflarestorage.com",
+        "bucket": "my-weights",
+        "basePrefix": "teams/rl/",
+        "accessKeyId": "AK",
+        "secretAccessKey": "SK",
+    }
+    assert out["effectivePrefix"] == "teams/rl/u1/"
+
+
+def test_create_cluster_without_relay_is_wire_identical(server):
+    # Omitting relay must serialize NO relay key at all (deny_unknown_fields
+    # servers predating BYO would 400 on an unexpected null).
+    base, rec = server
+    rec.responses = [(200, {"name": "p", "uid": "u", "phase": "Provisioning"})]
+    rl(base).create_cluster(base_model="m/m", gpu_model="H100")
+    (r,) = rec.requests
+    assert "relay" not in r["body"]
+
+
+def test_rotate_credentials_wire_shape(server):
+    base, rec = server
+    rec.responses = [(200, {"name": "byo-pool",
+                            "rotatedAt": "2026-08-31T12:00:00+00:00"})]
+    out = rl(base).rotate_credentials(
+        "byo-pool", access_key_id="NEWAK", secret_access_key="NEWSK"
+    )
+    (r,) = rec.requests
+    assert (r["method"], r["path"]) == ("POST", "/rl/clusters/byo-pool/credentials")
+    assert r["body"] == {"accessKeyId": "NEWAK", "secretAccessKey": "NEWSK"}
+    assert out["rotatedAt"].startswith("2026-08-31")
+
+
+def test_rotate_credentials_maps_errors(server):
+    # A platform-mode cluster refuses rotation with an actionable 400 ->
+    # ValueError carrying the server message.
+    base, rec = server
+    rec.responses = [(400, _api_error(
+        "RelayModeInvalid: cluster plat uses platform-managed storage"))]
+    with pytest.raises(ValueError, match="RelayModeInvalid"):
+        rl(base).rotate_credentials("plat", access_key_id="A", secret_access_key="B")

--- a/crates/basilica-sdk-python/uv.lock
+++ b/crates/basilica-sdk-python/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/basilica-sdk/CHANGELOG.md
+++ b/crates/basilica-sdk/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-31
+
+### Added
+
+- **BYO relay storage DTOs (server #1574/#1577).** `RlRelayRequest` /
+  `RlRelayMode` typed on `CreateRlClusterRequest.relay` (omitted → the
+  platform relay, byte-identical wire shape); `CreateRlClusterResponse`
+  gains the optional `effectivePrefix` (tolerant of servers that omit
+  it). `rotate_rl_cluster_credentials()` +
+  `RotateRelayCredentialsRequest`/`RotateRlCredentialsResponse` for the
+  credential-rotation endpoint. Credential-bearing request DTOs carry
+  hand-written `Debug` impls that redact key material, so client-side
+  request tracing cannot leak it.
+
 ## [0.34.0] - 2026-08-27
 
 ### Added

--- a/crates/basilica-sdk/Cargo.toml
+++ b/crates/basilica-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilica-sdk"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 authors = ["Basilica Team"]
 description = "SDK for interacting with the Basilica GPU rental network"

--- a/crates/basilica-sdk/src/client.rs
+++ b/crates/basilica-sdk/src/client.rs
@@ -45,7 +45,8 @@ use crate::{
     rl::{
         CreateRlClusterRequest, CreateRlClusterResponse, CreateRlJobRequest, CreateRlJobResponse,
         DeleteRlClusterResponse, DeleteRlJobResponse, RlClusterStatusResponse, RlJobStatusResponse,
-        RlManifestRequest, RlManifestResponse,
+        RlManifestRequest, RlManifestResponse, RotateRelayCredentialsRequest,
+        RotateRlCredentialsResponse,
     },
     types::{
         ApiKeyInfo, ApiKeyResponse, ApiListRentalsResponse, BalanceResponse, CardPurchaseResponse,
@@ -382,6 +383,22 @@ impl BasilicaClient {
     pub async fn get_rl_job(&self, name: &str) -> Result<RlJobStatusResponse> {
         Self::validate_rl_name(name)?;
         self.get(&format!("/rl/jobs/{}", name)).await
+    }
+
+    /// Rotate a BYO cluster's relay storage credentials (#1577). Only for
+    /// clusters created with the INLINE key pair (platform-managed secret);
+    /// clusters using `credentialsSecret` update their own secret instead.
+    /// Sequencing: create the NEW key at your provider first, call this,
+    /// then revoke the OLD key after the returned `rotatedAt` (+ a few
+    /// seconds for the relay daemon to restart on the new material).
+    pub async fn rotate_rl_cluster_credentials(
+        &self,
+        name: &str,
+        request: RotateRelayCredentialsRequest,
+    ) -> Result<RotateRlCredentialsResponse> {
+        Self::validate_rl_name(name)?;
+        self.post(&format!("/rl/clusters/{}/credentials", name), &request)
+            .await
     }
 
     /// Delete a cluster. Refused with an actionable 400 while a job is

--- a/crates/basilica-sdk/src/rl.rs
+++ b/crates/basilica-sdk/src/rl.rs
@@ -58,11 +58,105 @@ pub struct CreateRlClusterRequest {
     /// Optional idle-TTL (e.g. `30m`) after which an idle cluster reaps itself.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub idle_ttl: Option<String>,
+    /// Bring-your-own relay storage (#1578; server #1574). Omit for the
+    /// platform relay — today's behavior, byte-identical on the wire.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relay: Option<RlRelayRequest>,
     /// Forward-compat catch-all: fields this SDK version doesn't know are
     /// preserved verbatim on the wire (the `body=` escape hatch depends on
     /// this — server-side schema additions must never be silently dropped).
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Relay storage mode. Serialized lowercase (`byo` | `platform`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RlRelayMode {
+    /// User-supplied S3-compatible storage.
+    Byo,
+    /// The platform-managed relay (the default when the block is omitted).
+    Platform,
+}
+
+/// BYO relay block (mirrors the server's `RlRelayRequest`, #1574).
+///
+/// Credentials are WRITE-ONLY on the platform: they become a namespaced
+/// secret at create and are never echoed by any response or log. The
+/// hand-written `Debug` below redacts them on the CLIENT side too, so an
+/// application that traces its requests cannot leak them either.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RlRelayRequest {
+    /// Storage mode.
+    pub mode: RlRelayMode,
+    /// S3-compatible endpoint URL — https with a public-CA cert and a DNS
+    /// hostname (IP literals are rejected).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Bucket name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bucket: Option<String>,
+    /// Region (S3 dialects; R2 uses `auto`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Organizational prefix inside the bucket; the platform appends
+    /// `<cluster-uid>/` — see `effectivePrefix` on the create response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_prefix: Option<String>,
+    /// Name of an existing namespaced secret you manage (keys
+    /// `access_key_id` / `secret_access_key`). Mutually exclusive with the
+    /// inline pair.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials_secret: Option<String>,
+    /// Inline access key id (write-only; becomes a platform-managed secret).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_key_id: Option<String>,
+    /// Inline secret access key (write-only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_access_key: Option<String>,
+}
+
+impl std::fmt::Debug for RlRelayRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RlRelayRequest")
+            .field("mode", &self.mode)
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .field("base_prefix", &self.base_prefix)
+            .field("credentials_secret", &self.credentials_secret)
+            .field(
+                "access_key_id",
+                &self.access_key_id.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "secret_access_key",
+                &self.secret_access_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// Rotate a BYO cluster's relay credentials
+/// (`POST /rl/clusters/{name}/credentials`, #1577). Applies only to
+/// clusters created with the inline pair (platform-managed secret).
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateRelayCredentialsRequest {
+    /// Replacement access key id (write-only).
+    pub access_key_id: String,
+    /// Replacement secret access key (write-only).
+    pub secret_access_key: String,
+}
+
+impl std::fmt::Debug for RotateRelayCredentialsRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RotateRelayCredentialsRequest")
+            .field("access_key_id", &"<redacted>")
+            .field("secret_access_key", &"<redacted>")
+            .finish()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +267,24 @@ pub struct CreateRlClusterResponse {
     pub uid: String,
     /// Lifecycle phase at creation (`Provisioning`).
     pub phase: String,
+    /// BYO only: the uid-scoped storage key prefix
+    /// (`<basePrefix><cluster-uid>/`) everything the cluster stores lands
+    /// under — tighten your IAM grant to it. Absent for platform-managed
+    /// storage and on servers predating #1574.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_prefix: Option<String>,
+}
+
+/// Response after rotating a cluster's storage credentials (#1577).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateRlCredentialsResponse {
+    /// The cluster whose credentials were rotated.
+    pub name: String,
+    /// When the rotation was applied (RFC 3339). The relay daemon restarts
+    /// with the new key material within seconds of this instant — keep the
+    /// OLD key valid until then, then revoke it.
+    pub rotated_at: String,
 }
 
 /// Cluster status (`GET /rl/clusters/{name}`).
@@ -345,6 +457,7 @@ mod tests {
                 },
             },
             idle_ttl: Some("30m".into()),
+            relay: None,
             extra: Default::default(),
         };
         let v = serde_json::to_value(&req).unwrap();
@@ -352,6 +465,82 @@ mod tests {
         assert_eq!(v["trainer"]["gpu"]["count"], 4);
         assert_eq!(v["idleTtl"], "30m");
         assert!(v["trainer"]["gpu"].get("minMemoryGb").is_none());
+        // No relay block => byte-identical to the pre-#1578 wire shape.
+        assert!(v.get("relay").is_none());
+    }
+
+    #[test]
+    fn relay_request_wire_shape() {
+        let relay = RlRelayRequest {
+            mode: RlRelayMode::Byo,
+            endpoint: Some("https://acc.r2.cloudflarestorage.com".into()),
+            bucket: Some("my-weights".into()),
+            region: None,
+            base_prefix: Some("teams/rl/".into()),
+            credentials_secret: None,
+            access_key_id: Some("AK".into()),
+            secret_access_key: Some("SK".into()),
+        };
+        let v = serde_json::to_value(&relay).unwrap();
+        // The server's deny_unknown_fields DTO expects exactly these names.
+        assert_eq!(v["mode"], "byo");
+        assert_eq!(v["basePrefix"], "teams/rl/");
+        assert_eq!(v["accessKeyId"], "AK");
+        assert_eq!(v["secretAccessKey"], "SK");
+        assert!(v.get("region").is_none());
+        assert!(v.get("credentialsSecret").is_none());
+    }
+
+    #[test]
+    fn relay_debug_redacts_credentials() {
+        let relay = RlRelayRequest {
+            mode: RlRelayMode::Byo,
+            endpoint: None,
+            bucket: None,
+            region: None,
+            base_prefix: None,
+            credentials_secret: None,
+            access_key_id: Some("SUPERSECRETAK".into()),
+            secret_access_key: Some("SUPERSECRETSK".into()),
+        };
+        let dbg = format!("{relay:?}");
+        assert!(!dbg.contains("SUPERSECRET"), "Debug must redact: {dbg}");
+        assert!(dbg.contains("<redacted>"));
+        let rot = RotateRelayCredentialsRequest {
+            access_key_id: "SUPERSECRETAK".into(),
+            secret_access_key: "SUPERSECRETSK".into(),
+        };
+        let dbg = format!("{rot:?}");
+        assert!(!dbg.contains("SUPERSECRET"), "Debug must redact: {dbg}");
+    }
+
+    #[test]
+    fn cluster_response_effective_prefix_is_optional() {
+        // Old servers (pre-#1574) omit it; BYO creates carry it.
+        let old: CreateRlClusterResponse =
+            serde_json::from_str(r#"{"name":"p","uid":"u","phase":"Provisioning"}"#).unwrap();
+        assert_eq!(old.effective_prefix, None);
+        let byo: CreateRlClusterResponse = serde_json::from_str(
+            r#"{"name":"p","uid":"u","phase":"Provisioning","effectivePrefix":"teams/rl/u/"}"#,
+        )
+        .unwrap();
+        assert_eq!(byo.effective_prefix.as_deref(), Some("teams/rl/u/"));
+    }
+
+    #[test]
+    fn rotation_wire_shapes() {
+        let req = RotateRelayCredentialsRequest {
+            access_key_id: "AK".into(),
+            secret_access_key: "SK".into(),
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["accessKeyId"], "AK");
+        assert_eq!(v["secretAccessKey"], "SK");
+        let resp: RotateRlCredentialsResponse =
+            serde_json::from_str(r#"{"name":"p","rotatedAt":"2026-08-31T12:00:00+00:00"}"#)
+                .unwrap();
+        assert_eq!(resp.name, "p");
+        assert!(resp.rotated_at.starts_with("2026-08-31"));
     }
 
     #[test]

--- a/crates/basilica-sdk/src/rl.rs
+++ b/crates/basilica-sdk/src/rl.rs
@@ -117,6 +117,11 @@ pub struct RlRelayRequest {
     pub secret_access_key: Option<String>,
 }
 
+// Redaction policy (deliberate asymmetry): only the two key-material
+// fields are redacted. The remaining fields — endpoint, bucket, region,
+// basePrefix, and the credentialsSecret NAME — are non-secret storage
+// coordinates (the same values appear in the CR spec and cluster status),
+// and printing them is what makes a traced request debuggable.
 impl std::fmt::Debug for RlRelayRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RlRelayRequest")
@@ -383,6 +388,14 @@ mod tests {
     // The SDK request DTOs must serialize to the exact wire shape the server's
     // deny_unknown_fields DTOs accept. These pin the field renames and casing
     // that the server contract depends on.
+    //
+    // Coverage split (deliberate): these are SERIALIZATION tests only. The
+    // HTTP-level contract — method, path, auth header, body-on-the-wire,
+    // and error mapping for every rl_* call including credential rotation —
+    // is pinned by the Python suite's recorded-HTTP harness
+    // (crates/basilica-sdk-python/tests/test_rl_client.py), which exercises
+    // the COMPILED core transport end to end. A Rust-side HTTP harness
+    // would duplicate that coverage one layer lower.
     #[test]
     fn job_request_wire_shape() {
         let req = CreateRlJobRequest {


### PR DESCRIPTION
B5 of the BYO relay epic (basilica-backend#1515); mirrors the server surface from basilica-backend#1574/#1577.

Core (basilica-sdk):
- RlRelayRequest/RlRelayMode typed onto CreateRlClusterRequest.relay (omitted -> no relay key on the wire, byte-identical to 0.34.0 — deny_unknown_fields servers predating BYO stay compatible).
- CreateRlClusterResponse gains optional effectivePrefix (serde default: tolerant of servers that omit it).
- rotate_rl_cluster_credentials() + RotateRelayCredentialsRequest/ RotateRlCredentialsResponse for POST /rl/clusters/{name}/credentials.
- Credential-bearing request DTOs get hand-written Debug impls that redact key material — client-side request tracing cannot leak it (mirrors the server-side convention).

Python (basilica-sdk-python):
- create_cluster(relay={...}) — wire-shaped dict, documented inline; the same dict works in a manifest's cluster block.
- rotate_credentials(name, access_key_id=, secret_access_key=) with the rotation-sequencing contract in the docstring (new key first; revoke old after rotatedAt).
- New binding pymethod rl_rotate_cluster_credentials (JSON-string boundary per the crate convention).
- Version 0.35.0 across Cargo.toml/pyproject; changelogs for both packages.

Tests:
- 5 new core wire-shape tests: relay serialization (lowercase mode, camelCase field names, absent Nones), no-relay byte-identity, Debug redaction (asserts secrets absent from output), optional effectivePrefix parse both ways, rotation shapes.
- 4 new python contract tests against the real recorded-HTTP harness and the BUILT 0.35.0 extension: relay dict passthrough + effectivePrefix, no-relay wire identity, rotation path/body/response, error mapping (RelayModeInvalid 400 -> ValueError).
- Full workspace: all suites green, clippy (--all-features --all-targets --locked) clean; python RL contract suite 22/22 on the built wheel.

## Summary

Brief description of what this PR does.

## Related Issues

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

List the main changes in this PR:

- 
- 
- 

## Testing

### How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [ ] Manual testing completed

### Test Configuration

- OS: 
- Rust version: 
- Bittensor version (if applicable): 

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format my code
- [ ] I have run `cargo clippy` and addressed all warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Context

Add any other context about the PR here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added beta, staging-only support for bring-your-own storage when creating RL clusters.
  * Added credential rotation for RL cluster storage through the SDK.
  * Cluster creation responses now report the effective storage prefix when available.
  * Added support across the Rust and Python SDKs, including typed request and response data.

* **Security**
  * Credential values are redacted from client-side debugging output.

* **Documentation**
  * Updated changelogs and SDK version to 0.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->